### PR TITLE
ENG-3435: Clean up antd v6 deprecated prop warnings

### DIFF
--- a/changelog/7936-eng-3435-antd-deprecated-props.yaml
+++ b/changelog/7936-eng-3435-antd-deprecated-props.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Cleaned up Ant Design v6 deprecated prop warnings in the browser console across the Admin UI
+pr: 7936
+labels: []

--- a/clients/admin-ui/__tests__/features/common/nav/NavSearch.collapsed.test.tsx
+++ b/clients/admin-ui/__tests__/features/common/nav/NavSearch.collapsed.test.tsx
@@ -25,9 +25,9 @@ jest.mock("fidesui", () => {
       const { prefix, suffix, allowClear, autoFocus, ...rest } = props;
       return MockReact.createElement("input", { ...rest, ref });
     }),
-    Modal: ({ open: modalOpen, children, onCancel, destroyOnClose }: any) => {
+    Modal: ({ open: modalOpen, children, onCancel, destroyOnHidden }: any) => {
       if (!modalOpen) {
-        if (destroyOnClose) {
+        if (destroyOnHidden) {
           return null;
         }
         return MockReact.createElement(

--- a/clients/admin-ui/__tests__/features/common/nav/NavSearch.test.tsx
+++ b/clients/admin-ui/__tests__/features/common/nav/NavSearch.test.tsx
@@ -63,9 +63,9 @@ jest.mock("fidesui", () => {
       const { prefix, suffix, allowClear, autoFocus, ...rest } = props;
       return MockReact.createElement("input", { ...rest, ref });
     }),
-    Modal: ({ open: modalOpen, children, onCancel, destroyOnClose }: any) => {
+    Modal: ({ open: modalOpen, children, onCancel, destroyOnHidden }: any) => {
       if (!modalOpen) {
-        if (destroyOnClose) {
+        if (destroyOnHidden) {
           return null;
         }
         return MockReact.createElement(

--- a/clients/admin-ui/src/features/access-control/ViolationRateCard.tsx
+++ b/clients/admin-ui/src/features/access-control/ViolationRateCard.tsx
@@ -58,9 +58,11 @@ export const ViolationRateCard = () => {
               precision={1}
               prefix={getTrendPrefix(trend)}
               suffix="% vs last mo"
-              valueStyle={{
-                color: getTrendColor(trend, token),
-                fontSize: token.fontSizeSM,
+              styles={{
+                content: {
+                  color: getTrendColor(trend, token),
+                  fontSize: token.fontSizeSM,
+                },
               }}
             />
           </Flex>

--- a/clients/admin-ui/src/features/access-control/ViolationsChartCard.tsx
+++ b/clients/admin-ui/src/features/access-control/ViolationsChartCard.tsx
@@ -115,9 +115,11 @@ export const ViolationsChartCard = () => {
           precision={1}
           prefix={getTrendPrefix(trend)}
           suffix="% vs last mo"
-          valueStyle={{
-            color: getTrendColor(trend, token),
-            fontSize: token.fontSizeSM,
+          styles={{
+            content: {
+              color: getTrendColor(trend, token),
+              fontSize: token.fontSizeSM,
+            },
           }}
         />
       </Flex>

--- a/clients/admin-ui/src/features/chat-provider/ChatConfigurations.tsx
+++ b/clients/admin-ui/src/features/chat-provider/ChatConfigurations.tsx
@@ -43,7 +43,7 @@ const EmptyTableNotice = () => {
   return (
     <Empty
       description={
-        <Space direction="vertical" size="small">
+        <Space orientation="vertical" size="small">
           <Text strong>No chat providers found.</Text>
           <Text type="secondary">
             Click &quot;Add a chat provider&quot; to configure Slack or other
@@ -296,7 +296,7 @@ export const ChatConfigurations = () => {
           </Button>,
         ]}
       >
-        <Space direction="vertical">
+        <Space orientation="vertical">
           <Text>
             Are you sure you want to delete the Slack provider for{" "}
             <strong>
@@ -329,7 +329,7 @@ export const ChatConfigurations = () => {
               role="link"
               type="primary"
               icon={<Icons.Add />}
-              iconPosition="end"
+              iconPlacement="end"
               data-testid="add-chat-provider-btn"
             >
               Add a chat provider

--- a/clients/admin-ui/src/features/common/ScrollableList.tsx
+++ b/clients/admin-ui/src/features/common/ScrollableList.tsx
@@ -191,7 +191,7 @@ const ScrollableListAdd = ({
       data-testid={`add-${baseTestId}`}
       block
       icon={<Icons.Add size={16} />}
-      iconPosition="end"
+      iconPlacement="end"
     >
       {label}
     </Button>

--- a/clients/admin-ui/src/features/common/custom-reports/CustomReportTemplates.tsx
+++ b/clients/admin-ui/src/features/common/custom-reports/CustomReportTemplates.tsx
@@ -363,7 +363,7 @@ export const CustomReportTemplates = ({
         <Button
           className="max-w-40"
           icon={<Icons.ChevronDown size={14} />}
-          iconPosition="end"
+          iconPlacement="end"
           data-testid="custom-reports-trigger"
         >
           <Text ellipsis>{buttonLabel}</Text>

--- a/clients/admin-ui/src/features/common/nav/NavSearch.tsx
+++ b/clients/admin-ui/src/features/common/nav/NavSearch.tsx
@@ -130,7 +130,7 @@ const NavSearchExpanded = ({ groups }: { groups: NavGroup[] }) => {
         onOpenChange={handleOpenChange}
         defaultActiveFirstOption
         className={styles.expandedAutoComplete}
-        popupClassName={styles.searchDropdown}
+        classNames={{ popup: { root: styles.searchDropdown } }}
         value={searchValue}
         onSearch={setSearchValue}
       >

--- a/clients/admin-ui/src/features/common/nav/NavSearchModal.tsx
+++ b/clients/admin-ui/src/features/common/nav/NavSearchModal.tsx
@@ -171,7 +171,7 @@ const NavSearchModal = ({ groups }: NavSearchModalProps) => {
         width={480}
         style={{ top: "calc(33vh - 24px)" }}
         className={styles.searchModal}
-        destroyOnClose
+        destroyOnHidden
         afterOpenChange={(isOpen) => {
           if (isOpen) {
             modalInputRef.current?.focus();

--- a/clients/admin-ui/src/features/common/system-data-flow/DataFlowAccordionForm.tsx
+++ b/clients/admin-ui/src/features/common/system-data-flow/DataFlowAccordionForm.tsx
@@ -146,7 +146,7 @@ export const DataFlowAccordionForm = ({
                   type="primary"
                   size="small"
                   icon={<Icons.Settings />}
-                  iconPosition="end"
+                  iconPlacement="end"
                   className="mb-4"
                   data-testid="assign-systems-btn"
                 >

--- a/clients/admin-ui/src/features/configure-consent/AddVendor.tsx
+++ b/clients/admin-ui/src/features/configure-consent/AddVendor.tsx
@@ -203,7 +203,7 @@ const AddVendor = ({
             open={isOpen}
             onCancel={handleCloseModal}
             centered
-            destroyOnClose
+            destroyOnHidden
             title="Add a vendor"
             footer={null}
           >

--- a/clients/admin-ui/src/features/consent-settings/tcf/CreateTCFConfigModal.tsx
+++ b/clients/admin-ui/src/features/consent-settings/tcf/CreateTCFConfigModal.tsx
@@ -43,7 +43,7 @@ export const CreateTCFConfigModal = ({
       open={isOpen}
       onCancel={onClose}
       centered
-      destroyOnClose
+      destroyOnHidden
       footer={null}
     >
       <Formik
@@ -53,7 +53,7 @@ export const CreateTCFConfigModal = ({
       >
         {({ isValid, dirty }) => (
           <Form>
-            <Space direction="vertical" size="small" className="w-full">
+            <Space orientation="vertical" size="small" className="w-full">
               <Text>
                 TCF configurations allow you to define unique sets of publisher
                 restrictions. These configurations can be added to privacy

--- a/clients/admin-ui/src/features/consent-settings/tcf/PublisherRestrictionsConfig.tsx
+++ b/clients/admin-ui/src/features/consent-settings/tcf/PublisherRestrictionsConfig.tsx
@@ -69,7 +69,7 @@ export const PublisherRestrictionsConfig = ({
 
   return (
     <SettingsBox title="Publisher restrictions" fontSize="sm">
-      <Space direction="vertical" size="small" style={{ width: "100%" }}>
+      <Space orientation="vertical" size="small" style={{ width: "100%" }}>
         <TCFOverrideToggle
           defaultChecked={showTcfOverrideConfig}
           onChange={(checked) => setShowTcfOverrideConfig(checked)}

--- a/clients/admin-ui/src/features/consent-settings/tcf/PurposeRestrictionFormModal.tsx
+++ b/clients/admin-ui/src/features/consent-settings/tcf/PurposeRestrictionFormModal.tsx
@@ -237,7 +237,7 @@ export const PurposeRestrictionFormModal = ({
         }}
         getIsDirty={() => formik.dirty}
         centered
-        destroyOnClose
+        destroyOnHidden
         title="Edit restriction"
         footer={null}
       >

--- a/clients/admin-ui/src/features/consent-settings/tcf/TCFConfigurationDropdown.tsx
+++ b/clients/admin-ui/src/features/consent-settings/tcf/TCFConfigurationDropdown.tsx
@@ -53,7 +53,7 @@ interface DropdownContentProps {
 }
 
 const LoadingContent = () => (
-  <Space direction="vertical" size="small">
+  <Space orientation="vertical" size="small">
     <Skeleton width="100%" className="h-4" />
     <Skeleton width="100%" className="h-4" />
     <Skeleton width="100%" className="h-4" />
@@ -323,7 +323,7 @@ export const TCFConfigurationDropdown = ({
       >
         <Button
           icon={<Icons.ChevronDown />}
-          iconPosition="end"
+          iconPlacement="end"
           data-testid="tcf-config-dropdown-trigger"
         >
           {buttonLabel}

--- a/clients/admin-ui/src/features/consent-settings/tcf/TCFOverrideToggle.tsx
+++ b/clients/admin-ui/src/features/consent-settings/tcf/TCFOverrideToggle.tsx
@@ -99,7 +99,7 @@ export const TCFOverrideToggle = ({
 
   return (
     <>
-      <Space direction="vertical" size="small">
+      <Space orientation="vertical" size="small">
         <Text>Configure overrides for TCF related purposes.</Text>
         <Space size="small">
           <Switch

--- a/clients/admin-ui/src/features/data-catalog/systems/EditMinimalDataUseModal.tsx
+++ b/clients/admin-ui/src/features/data-catalog/systems/EditMinimalDataUseModal.tsx
@@ -82,7 +82,7 @@ const EditMinimalDataUseModal = ({
         onClose={onClose}
         getIsDirty={() => formik.dirty}
         centered
-        destroyOnClose
+        destroyOnHidden
         footer={null}
       >
         <Form>

--- a/clients/admin-ui/src/features/data-discovery-and-detection/ActionButton.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/ActionButton.tsx
@@ -12,7 +12,7 @@ const ActionButton = ({ title, icon, type, ...props }: ActionButtonProps) => (
     type={type}
     data-testid={`action-${title}`}
     icon={icon}
-    iconPosition="start"
+    iconPlacement="start"
     {...props}
   >
     {title}

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AddDataUsesModal.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AddDataUsesModal.tsx
@@ -36,7 +36,7 @@ const AddDataUsesModal = ({
       open={isOpen}
       onCancel={handleReset}
       centered
-      destroyOnClose
+      destroyOnHidden
       footer={null}
     >
       <Flex vertical gap={20} className="pb-6 pt-4">

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AssignSystemModal.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/AssignSystemModal.tsx
@@ -42,7 +42,7 @@ export const AssignSystemModal = ({
       open={isOpen}
       onCancel={handleClose}
       centered
-      destroyOnClose
+      destroyOnHidden
       footer={null}
       data-testid="add-modal-content"
     >

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/ConsentBreakdownModal.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/ConsentBreakdownModal.tsx
@@ -65,7 +65,7 @@ export const ConsentBreakdownModal = ({
         {isError ? (
           <Alert
             type="error"
-            message="Error fetching data"
+            title="Error fetching data"
             description="Please try again later."
             showIcon
           />

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/components/InProgressMonitorTaskItem.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/components/InProgressMonitorTaskItem.tsx
@@ -184,7 +184,7 @@ export const InProgressMonitorTaskItem = ({
     <div {...props} className="w-full">
       <Row gutter={12} className="w-full">
         <Col span={14} className="align-middle">
-          <Space direction="vertical" size={4}>
+          <Space orientation="vertical" size={4}>
             <Space align="center" size={8} wrap>
               {logoSource && <ConnectionTypeLogo data={logoSource} size={24} />}
               <Title level={5} className="m-0">

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/components/InProgressMonitorTasksList.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/components/InProgressMonitorTasksList.tsx
@@ -139,7 +139,7 @@ export const InProgressMonitorTasksList = ({
           open={filterPopoverOpen}
           onOpenChange={setFilterPopoverOpen}
         >
-          <Button icon={<Icons.ChevronDown />} iconPosition="end">
+          <Button icon={<Icons.ChevronDown />} iconPlacement="end">
             Filter
           </Button>
         </Popover>

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/page.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/page.tsx
@@ -405,7 +405,7 @@ const ActionCenterFields = ({
                 <Button
                   type="primary"
                   icon={<Icons.ChevronDown />}
-                  iconPosition="end"
+                  iconPlacement="end"
                   loading={isFetchingAllowedActions}
                 >
                   Actions

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/DiscoveredAssetsTable.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/DiscoveredAssetsTable.tsx
@@ -209,7 +209,7 @@ export const DiscoveredAssetsTable = ({
             >
               <Button
                 icon={<Icons.ChevronDown />}
-                iconPosition="end"
+                iconPlacement="end"
                 loading={anyBulkActionIsLoading}
                 data-testid="bulk-actions-menu"
                 disabled={
@@ -234,7 +234,7 @@ export const DiscoveredAssetsTable = ({
                 loading={isAddingAllResults}
                 type="primary"
                 icon={<Icons.Checkmark />}
-                iconPosition="end"
+                iconPlacement="end"
                 data-testid="add-all"
               >
                 Add all

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/DiscoveredInfrastructureSystemsTable.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/DiscoveredInfrastructureSystemsTable.tsx
@@ -148,7 +148,7 @@ export const DiscoveredInfrastructureSystemsTable = ({
     <Flex vertical gap="medium" className="h-full overflow-hidden">
       <Alert
         showIcon
-        message="Fides detected the following systems"
+        title="Fides detected the following systems"
         description="Some may not yet be in your inventory. Review each system's detected data use — approve to add it to your inventory, or ignore if it's not relevant."
         closable
       />
@@ -172,7 +172,7 @@ export const DiscoveredInfrastructureSystemsTable = ({
             <Button
               type="primary"
               icon={<Icons.ChevronDown />}
-              iconPosition="end"
+              iconPlacement="end"
               disabled={!hasSelectedRows || isBulkActionInProgress}
               loading={isBulkActionInProgress}
             >

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/DiscoveredSystemAggregateTable.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/DiscoveredSystemAggregateTable.tsx
@@ -113,7 +113,7 @@ export const DiscoveredSystemAggregateTable = ({
             <Button
               type="primary"
               icon={<Icons.ChevronDown />}
-              iconPosition="end"
+              iconPlacement="end"
               loading={anyBulkActionIsLoading}
               disabled={!hasSelectedRows}
               data-testid="bulk-actions-menu"

--- a/clients/admin-ui/src/features/datamap/modals/ReportExportModal.tsx
+++ b/clients/admin-ui/src/features/datamap/modals/ReportExportModal.tsx
@@ -26,7 +26,7 @@ const ReportExportModal = ({
       open={isOpen}
       onCancel={onClose}
       centered
-      destroyOnClose
+      destroyOnHidden
       data-testid="export-modal"
       footer={
         <Flex gap="small" justify="flex-end">

--- a/clients/admin-ui/src/features/datamap/reporting/DatamapReportFilterModal.tsx
+++ b/clients/admin-ui/src/features/datamap/reporting/DatamapReportFilterModal.tsx
@@ -143,7 +143,7 @@ export const DatamapReportFilterModal = ({
       open={isOpen}
       onCancel={onClose}
       centered
-      destroyOnClose
+      destroyOnHidden
       data-testid="datamap-report-filter-modal"
       footer={
         <Flex gap={3} sx={{ "& button": { width: "100%" } }}>

--- a/clients/admin-ui/src/features/datamap/reporting/DatamapReportTable.tsx
+++ b/clients/admin-ui/src/features/datamap/reporting/DatamapReportTable.tsx
@@ -294,11 +294,11 @@ export const DatamapReportTable = ({
                     },
                   ],
                 }}
-                overlayClassName="group-by-menu-list"
+                classNames={{ root: "group-by-menu-list" }}
               >
                 <Button
                   icon={<Icons.ChevronDown size={14} />}
-                  iconPosition="end"
+                  iconPlacement="end"
                   loading={groupChangeStarted}
                   data-testid="group-by-menu"
                 >
@@ -335,7 +335,7 @@ export const DatamapReportTable = ({
                   ],
                 }}
                 placement="bottomRight"
-                overlayClassName="more-menu-list"
+                classNames={{ root: "more-menu-list" }}
               >
                 <Button
                   icon={<Icons.OverflowMenuVertical />}

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/ConnectionListDropdown.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/ConnectionListDropdown.tsx
@@ -310,7 +310,7 @@ const ConnectionListDropdown = ({
         aria-label={selectedText ?? label}
         disabled={disabled}
         icon={<Icons.ChevronDown />}
-        iconPosition="end"
+        iconPlacement="end"
         data-testid="select-dropdown-btn"
         className="w-[272px]"
       >

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/fields/DatasetConfigField/YamlEditorModal.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/fields/DatasetConfigField/YamlEditorModal.tsx
@@ -29,7 +29,7 @@ const YamlEditorModal = ({
     open={isOpen}
     onCancel={onClose}
     centered
-    destroyOnClose
+    destroyOnHidden
     width={MODAL_SIZE.lg}
     title={title ?? "Edit Dataset"}
     footer={null}

--- a/clients/admin-ui/src/features/digests/components/DigestConfigList.tsx
+++ b/clients/admin-ui/src/features/digests/components/DigestConfigList.tsx
@@ -133,7 +133,7 @@ const DigestConfigList = () => {
             <List.Item.Meta
               title={config.name}
               description={
-                <Space direction="vertical" size={4}>
+                <Space orientation="vertical" size={4}>
                   <Space size={4}>
                     <Tag>{DIGEST_TYPE_LABELS[config.digest_type]}</Tag>
                     {config.messaging_service_type && (

--- a/clients/admin-ui/src/features/digests/components/DigestSchedulePicker.tsx
+++ b/clients/admin-ui/src/features/digests/components/DigestSchedulePicker.tsx
@@ -129,10 +129,10 @@ const DigestSchedulePicker = ({
   };
 
   return (
-    <Space direction="vertical" size="medium" className="w-full">
+    <Space orientation="vertical" size="medium" className="w-full">
       {showCustomCronWarning && (
         <Alert
-          message="Custom Cron Expression"
+          title="Custom Cron Expression"
           description="This digest uses a custom cron expression that cannot be edited with the picker. Changing the schedule will replace the custom expression."
           type="warning"
           closable

--- a/clients/admin-ui/src/features/integrations/ConfigureIntegrationModal.tsx
+++ b/clients/admin-ui/src/features/integrations/ConfigureIntegrationModal.tsx
@@ -75,7 +75,7 @@ const ConfigureIntegrationModal = ({
       onClose={onClose}
       getIsDirty={() => formState?.dirty ?? false}
       centered
-      destroyOnClose
+      destroyOnHidden
       footer={modalFooter}
     >
       <ConfigureIntegrationForm

--- a/clients/admin-ui/src/features/integrations/SharedConfigModal.tsx
+++ b/clients/admin-ui/src/features/integrations/SharedConfigModal.tsx
@@ -46,7 +46,7 @@ const SharedConfigModal = () => {
     <>
       <Button
         icon={<Icons.Settings />}
-        iconPosition="end"
+        iconPlacement="end"
         onClick={() => setModalIsOpen(true)}
         data-testid="configurations-btn"
       >

--- a/clients/admin-ui/src/features/integrations/configure-monitor/ConfigureMonitorModal.tsx
+++ b/clients/admin-ui/src/features/integrations/configure-monitor/ConfigureMonitorModal.tsx
@@ -118,7 +118,7 @@ const ConfigureMonitorModal = ({
         onClose={onClose}
         getIsDirty={() => form.isFieldsTouched()}
         centered
-        destroyOnClose
+        destroyOnHidden
         footer={null}
         data-testid="add-modal-content"
       >
@@ -145,7 +145,7 @@ const ConfigureMonitorModal = ({
       onClose={onClose}
       getIsDirty={() => form.isFieldsTouched()}
       centered
-      destroyOnClose
+      destroyOnHidden
       footer={null}
       data-testid="add-modal-content"
     >

--- a/clients/admin-ui/src/features/integrations/configure-monitor/MonitorConfigTab.tsx
+++ b/clients/admin-ui/src/features/integrations/configure-monitor/MonitorConfigTab.tsx
@@ -121,7 +121,7 @@ const MonitorConfigTab = ({
           <Button
             onClick={modal.onOpen}
             icon={<MonitorIcon />}
-            iconPosition="end"
+            iconPlacement="end"
             data-testid="add-monitor-btn"
             disabled={isAddMonitorButtonDisabled}
           >

--- a/clients/admin-ui/src/features/integrations/configure-tasks/TaskConditionsTab.tsx
+++ b/clients/admin-ui/src/features/integrations/configure-tasks/TaskConditionsTab.tsx
@@ -214,7 +214,7 @@ const TaskConditionsTab = ({ connectionKey }: TaskConditionsTabProps) => {
       {/* Warning banner for mixed consent + access/erasure configurations */}
       {hasConsentTasks && hasAccessOrErasureTasks && (
         <Alert
-          message="Consent task limitations"
+          title="Consent task limitations"
           description="Dataset field conditions and some privacy request fields (like due date) are not evaluated for consent manual tasks. These conditions will only apply to access and erasure tasks."
           type="warning"
           showIcon

--- a/clients/admin-ui/src/features/integrations/configure-tasks/components/PrivacyRequestFieldPicker.tsx
+++ b/clients/admin-ui/src/features/integrations/configure-tasks/components/PrivacyRequestFieldPicker.tsx
@@ -228,7 +228,7 @@ export const PrivacyRequestFieldPicker = ({
       />
       {showManualKeyInput && (
         <Input
-          addonBefore="privacy_request.identity."
+          prefix="privacy_request.identity."
           value={manualKeyValue}
           onChange={handleManualKeyChange}
           placeholder="e.g. customer_id"

--- a/clients/admin-ui/src/features/integrations/setup-steps/IntegrationSetupSteps.tsx
+++ b/clients/admin-ui/src/features/integrations/setup-steps/IntegrationSetupSteps.tsx
@@ -128,7 +128,7 @@ export const IntegrationSetupSteps = ({
   return (
     <Card title="Integration setup" data-testid="integration-setup-card">
       <Steps
-        direction="vertical"
+        orientation="vertical"
         current={getCurrentStep()}
         status={getStepStatus()}
         items={stepsWithIcons}

--- a/clients/admin-ui/src/features/integrations/setup-steps/hooks/types.ts
+++ b/clients/admin-ui/src/features/integrations/setup-steps/hooks/types.ts
@@ -9,7 +9,7 @@ export type StepState = "finish" | "process" | "wait" | "error";
 
 export interface Step {
   title: React.ReactNode;
-  description: React.ReactNode;
+  content: React.ReactNode;
   state: StepState;
 }
 

--- a/clients/admin-ui/src/features/integrations/setup-steps/hooks/useAddManualTaskStep.ts
+++ b/clients/admin-ui/src/features/integrations/setup-steps/hooks/useAddManualTaskStep.ts
@@ -26,7 +26,7 @@ export const useAddManualTaskStep = ({
 
   return {
     title: "Add a manual task",
-    description: isComplete
+    content: isComplete
       ? "Manual tasks have been configured"
       : "Configure a manual task for this integration. ",
     state: isComplete ? "finish" : "process",

--- a/clients/admin-ui/src/features/integrations/setup-steps/hooks/useAssignTasksToUsersStep.ts
+++ b/clients/admin-ui/src/features/integrations/setup-steps/hooks/useAssignTasksToUsersStep.ts
@@ -30,7 +30,7 @@ export const useAssignTasksToUsersStep = ({
 
   return {
     title: "Assign the tasks to users",
-    description: isComplete
+    content: isComplete
       ? "Tasks have been assigned to users"
       : "Assign the configured manual tasks to one or more users.",
     state: isComplete ? "finish" : "process",

--- a/clients/admin-ui/src/features/integrations/setup-steps/hooks/useAuthorizeIntegrationStep.tsx
+++ b/clients/admin-ui/src/features/integrations/setup-steps/hooks/useAuthorizeIntegrationStep.tsx
@@ -27,7 +27,7 @@ export const useAuthorizeIntegrationStep = ({
 
   return {
     title: "Authorize integration",
-    description: <span>{getAuthorizationDescription()}</span>,
+    content: <span>{getAuthorizationDescription()}</span>,
     state: testData?.authorized ? "finish" : "process",
   };
 };

--- a/clients/admin-ui/src/features/integrations/setup-steps/hooks/useConfigureTicketsStep.tsx
+++ b/clients/admin-ui/src/features/integrations/setup-steps/hooks/useConfigureTicketsStep.tsx
@@ -20,7 +20,7 @@ export const useConfigureTicketsStep = ({
 
   return {
     title: "Configure tickets",
-    description: isComplete ? (
+    content: isComplete ? (
       <span>Ticket configuration saved</span>
     ) : (
       <span>Set up project, issue type, and templates</span>

--- a/clients/admin-ui/src/features/integrations/setup-steps/hooks/useCreateIntegrationStep.ts
+++ b/clients/admin-ui/src/features/integrations/setup-steps/hooks/useCreateIntegrationStep.ts
@@ -3,7 +3,7 @@ import { Step } from "./types";
 export const useCreateIntegrationStep = (): Step => {
   return {
     title: "Create integration",
-    description: "Integration created successfully",
+    content: "Integration created successfully",
     state: "finish", // If we're viewing the integration, it's already added
   };
 };

--- a/clients/admin-ui/src/features/integrations/setup-steps/hooks/useCreateMonitorStep.ts
+++ b/clients/admin-ui/src/features/integrations/setup-steps/hooks/useCreateMonitorStep.ts
@@ -40,7 +40,7 @@ export const useCreateMonitorStep = (
 
   return {
     title: "Create monitor",
-    description: hasMonitors
+    content: hasMonitors
       ? "Data monitor created successfully"
       : "Use the Data discovery tab in this page to add a new monitor",
     state: hasMonitors ? "finish" : "process",

--- a/clients/admin-ui/src/features/messaging/MessagingConfigurations.tsx
+++ b/clients/admin-ui/src/features/messaging/MessagingConfigurations.tsx
@@ -74,7 +74,7 @@ export const MessagingConfigurations = () => {
       <Flex flex={1} direction="column" overflow="auto">
         {userCanUpdate && (
           <Space
-            direction="horizontal"
+            orientation="horizontal"
             style={{
               width: "100%",
               justifyContent: "flex-end",
@@ -88,7 +88,7 @@ export const MessagingConfigurations = () => {
               role="link"
               type="primary"
               icon={<Icons.Add />}
-              iconPosition="end"
+              iconPlacement="end"
               data-testid="add-messaging-provider-btn"
             >
               Add a messaging provider

--- a/clients/admin-ui/src/features/messaging/hooks/useMessagingConfigurationsTable.tsx
+++ b/clients/admin-ui/src/features/messaging/hooks/useMessagingConfigurationsTable.tsx
@@ -341,7 +341,7 @@ export const useMessagingConfigurationsTable = () => {
           </Button>,
         ]}
       >
-        <Space direction="vertical">
+        <Space orientation="vertical">
           <Text>
             Are you sure you want to delete &quot;
             <strong>{configToDelete?.name}</strong>&quot; messaging

--- a/clients/admin-ui/src/features/monitors/SharedMonitorConfigForm.tsx
+++ b/clients/admin-ui/src/features/monitors/SharedMonitorConfigForm.tsx
@@ -222,7 +222,7 @@ const SharedMonitorConfigForm = ({
                     >
                       <Button
                         icon={<Icons.Upload />}
-                        iconPosition="end"
+                        iconPlacement="end"
                         size="small"
                         data-testid="upload-csv-btn"
                       >

--- a/clients/admin-ui/src/features/openid-authentication/AddSSOProviderModal.tsx
+++ b/clients/admin-ui/src/features/openid-authentication/AddSSOProviderModal.tsx
@@ -29,7 +29,7 @@ const AddSSOProviderModal = ({
         onClose={onClose}
         getIsDirty={() => formik.dirty}
         centered
-        destroyOnClose
+        destroyOnHidden
         title="Add SSO Provider"
         footer={null}
       >

--- a/clients/admin-ui/src/features/openid-authentication/EditSSOProviderModal.tsx
+++ b/clients/admin-ui/src/features/openid-authentication/EditSSOProviderModal.tsx
@@ -33,7 +33,7 @@ const EditSSOProviderModal = ({
         onClose={onClose}
         getIsDirty={() => formik.dirty}
         centered
-        destroyOnClose
+        destroyOnHidden
         title="Edit SSO Provider"
         footer={null}
       >

--- a/clients/admin-ui/src/features/poc/MessageDemoCard.tsx
+++ b/clients/admin-ui/src/features/poc/MessageDemoCard.tsx
@@ -5,7 +5,7 @@ const MessageDemoCard = () => {
 
   return (
     <Card title="Toasting" variant="borderless">
-      <Space direction="vertical">
+      <Space orientation="vertical">
         <Button onClick={() => message.success("Success message!")}>
           Success
         </Button>

--- a/clients/admin-ui/src/features/poc/privacy-notices-sandbox/PrivacyNoticeSandboxRealData.tsx
+++ b/clients/admin-ui/src/features/poc/privacy-notices-sandbox/PrivacyNoticeSandboxRealData.tsx
@@ -166,7 +166,7 @@ const PrivacyNoticeSandboxRealData = () => {
       {/* Info Banner */}
       <Alert
         type="info"
-        message="This page makes real API calls to the Consent V3 API."
+        title="This page makes real API calls to the Consent V3 API."
         description={
           <>
             <Typography.Paragraph className="mb-0 mt-3">

--- a/clients/admin-ui/src/features/privacy-assessments/AssessmentDetail.tsx
+++ b/clients/admin-ui/src/features/privacy-assessments/AssessmentDetail.tsx
@@ -205,7 +205,7 @@ export const AssessmentDetail = ({ assessment }: AssessmentDetailProps) => {
           />
         ),
         children: (
-          <Space direction="vertical" size="medium" className="w-full">
+          <Space orientation="vertical" size="medium" className="w-full">
             {group.questions.map((q) => (
               <QuestionCard
                 key={q.id}
@@ -225,7 +225,7 @@ export const AssessmentDetail = ({ assessment }: AssessmentDetailProps) => {
   );
 
   return (
-    <Space direction="vertical" size="small" className="w-full">
+    <Space orientation="vertical" size="small" className="w-full">
       {notificationHolder}
       <div>
         <Flex align="center" gap="small" className="mb-1">

--- a/clients/admin-ui/src/features/privacy-assessments/AssessmentSettingsModal.tsx
+++ b/clients/admin-ui/src/features/privacy-assessments/AssessmentSettingsModal.tsx
@@ -189,7 +189,7 @@ const AssessmentSettingsModal = ({
           {channelOptions.length === 0 && !isLoadingChannels ? (
             <Alert
               type="info"
-              message="Configure Slack to enable channel notifications."
+              title="Configure Slack to enable channel notifications."
               action={
                 <NextLink href={CHAT_PROVIDERS_ROUTE} target="_blank" passHref>
                   <Button size="small" type="link">

--- a/clients/admin-ui/src/features/privacy-assessments/AssessmentTaskPopoverContent.tsx
+++ b/clients/admin-ui/src/features/privacy-assessments/AssessmentTaskPopoverContent.tsx
@@ -36,7 +36,7 @@ export const AssessmentTaskPopoverContent = ({
             </Flex>
           </Descriptions.Item>
           <Descriptions.Item label="Progress">
-            <Space direction="vertical" size="small" className="w-full">
+            <Space orientation="vertical" size="small" className="w-full">
               <Text size="sm">
                 {activeTask.completed_count} of {activeTask.total_count}{" "}
                 assessments

--- a/clients/admin-ui/src/features/privacy-assessments/EvidenceCardGroup.tsx
+++ b/clients/admin-ui/src/features/privacy-assessments/EvidenceCardGroup.tsx
@@ -13,7 +13,7 @@ export interface EvidenceCardGroupProps {
 }
 
 export const EvidenceCardGroup = ({ items }: EvidenceCardGroupProps) => (
-  <Space direction="vertical" size="small" className={styles.itemList}>
+  <Space orientation="vertical" size="small" className={styles.itemList}>
     {items.map((item) =>
       item.type === EvidenceType.TEAM_INPUT ? (
         <SlackThreadCard key={item.id} item={item} />

--- a/clients/admin-ui/src/features/privacy-assessments/EvidenceDrawer.tsx
+++ b/clients/admin-ui/src/features/privacy-assessments/EvidenceDrawer.tsx
@@ -52,7 +52,7 @@ export const EvidenceDrawer = ({
         />
       </div>
       <div className={styles.body}>
-        <Space direction="vertical" size="large" className={styles.content}>
+        <Space orientation="vertical" size="large" className={styles.content}>
           {focusedGroupId && (
             <EvidenceSection
               groupId={focusedGroupId}

--- a/clients/admin-ui/src/features/privacy-assessments/GenerateAssessmentsModal.tsx
+++ b/clients/admin-ui/src/features/privacy-assessments/GenerateAssessmentsModal.tsx
@@ -123,7 +123,7 @@ export const GenerateAssessmentsModal = ({
       footer={null}
       width={MODAL_SIZE.md}
     >
-      <Space direction="vertical" size="large" className="w-full pt-2">
+      <Space orientation="vertical" size="large" className="w-full pt-2">
         <Form
           form={form}
           layout="vertical"

--- a/clients/admin-ui/src/features/privacy-assessments/RequestInputModal.tsx
+++ b/clients/admin-ui/src/features/privacy-assessments/RequestInputModal.tsx
@@ -124,7 +124,7 @@ export const RequestInputModal = ({
         className="w-full"
       >
         <Space
-          direction="vertical"
+          orientation="vertical"
           size="small"
           className={classNames("w-full", styles.questionList)}
         >
@@ -133,7 +133,7 @@ export const RequestInputModal = ({
               <Flex align="flex-start" gap="small">
                 <Checkbox value={question.question_id} className="mt-0.5" />
                 <div className="min-w-0 flex-1">
-                  <Space direction="vertical" size={4} className="w-full">
+                  <Space orientation="vertical" size={4} className="w-full">
                     <Text>
                       {question.id}. {question.question_text}
                     </Text>

--- a/clients/admin-ui/src/features/privacy-experience/JavaScriptTag.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/JavaScriptTag.tsx
@@ -45,7 +45,7 @@ const JavaScriptTag = () => {
       <Button
         onClick={modal.onOpen}
         icon={<Icons.Copy />}
-        iconPosition="end"
+        iconPlacement="end"
         data-testid="js-tag-btn"
       >
         Get JavaScript tag

--- a/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
@@ -709,7 +709,7 @@ export const PrivacyExperienceForm = ({
             ) : (
               <Button
                 icon={<Icons.ArrowRight />}
-                iconPosition="end"
+                iconPlacement="end"
                 onClick={() => {
                   const t = form.getFieldValue("translations");
                   if (t?.[0]) {

--- a/clients/admin-ui/src/features/privacy-experience/usePrivacyExperiencesTable.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/usePrivacyExperiencesTable.tsx
@@ -44,7 +44,7 @@ const EmptyTableExperience = ({ canCreate }: { canCreate: boolean }) => {
                   size="small"
                   data-testid="add-privacy-experience-btn"
                   icon={<Icons.Add />}
-                  iconPosition="end"
+                  iconPlacement="end"
                 >
                   Create new experience
                 </Button>

--- a/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeTranslationForm.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeTranslationForm.tsx
@@ -77,7 +77,7 @@ const AddTranslationMenu = ({
     <Button
       block
       icon={<Icons.Add />}
-      iconPosition="end"
+      iconPlacement="end"
       onClick={() => setIsSelectingLanguage(true)}
       data-testid="add-language-btn"
       className="mb-1"

--- a/clients/admin-ui/src/features/privacy-notices/table/usePrivacyNoticesTable.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/table/usePrivacyNoticesTable.tsx
@@ -45,7 +45,7 @@ const EmptyTableNotice = () => {
               size="small"
               data-testid="add-privacy-notice-btn"
               icon={<Icons.Add />}
-              iconPosition="end"
+              iconPlacement="end"
             >
               Add a privacy notice
             </Button>

--- a/clients/admin-ui/src/features/privacy-requests/PrivacyRequestActionsDropdown.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/PrivacyRequestActionsDropdown.tsx
@@ -154,7 +154,7 @@ const PrivacyRequestActionsDropdown = ({
         <Button
           icon={<Icons.CaretDown />}
           data-testid="privacy-request-actions-dropdown-btn"
-          iconPosition="end"
+          iconPlacement="end"
           type="primary"
           disabled={!menuItems.length}
           size="large"

--- a/clients/admin-ui/src/features/privacy-requests/SubmitPrivacyRequest.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/SubmitPrivacyRequest.tsx
@@ -1,4 +1,12 @@
-import { Dropdown, Flex, Icons, Modal, useMessage } from "fidesui";
+import {
+  Button,
+  Dropdown,
+  Flex,
+  Icons,
+  Modal,
+  Space,
+  useMessage,
+} from "fidesui";
 import { useState } from "react";
 
 import { getErrorMessage } from "~/features/common/helpers";
@@ -132,25 +140,30 @@ const SubmitPrivacyRequest = () => {
         isOpen={submitRequestOpen}
         onClose={handleClose}
       />
-      <Dropdown.Button
-        type="primary"
-        onClick={handleSubmitRequestOpen}
-        data-testid="submit-request-btn"
-        menu={{
-          items: [
-            {
-              label: "Create request link",
-              key: "create-request-link",
-              icon: <Icons.Link />,
-              onClick: handleCreateLinkOpen,
-              disabled: !hasPrivacyCenterUrl,
-            },
-          ],
-        }}
-        icon={<Icons.ChevronDown />}
-      >
-        Create request
-      </Dropdown.Button>
+      <Space.Compact data-testid="submit-request-btn">
+        <Button type="primary" onClick={handleSubmitRequestOpen}>
+          Create request
+        </Button>
+        <Dropdown
+          menu={{
+            items: [
+              {
+                label: "Create request link",
+                key: "create-request-link",
+                icon: <Icons.Link />,
+                onClick: handleCreateLinkOpen,
+                disabled: !hasPrivacyCenterUrl,
+              },
+            ],
+          }}
+        >
+          <Button
+            type="primary"
+            icon={<Icons.ChevronDown />}
+            aria-label="More privacy request options"
+          />
+        </Dropdown>
+      </Space.Compact>
     </>
   );
 };

--- a/clients/admin-ui/src/features/privacy-requests/attachments/RequestAttachments.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/attachments/RequestAttachments.tsx
@@ -154,7 +154,7 @@ const RequestAttachments = ({ subjectRequest }: RequestAttachmentsProps) => {
                 <Flex align="center" gap={12} className="mb-4">
                   <Button
                     icon={<Icons.Add />}
-                    iconPosition="end"
+                    iconPlacement="end"
                     disabled={!isAddButtonEnabled || isUploadingFile}
                     loading={isUploadingFile}
                   >

--- a/clients/admin-ui/src/features/privacy-requests/configuration/ConfigurationNotificationBanner.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/configuration/ConfigurationNotificationBanner.tsx
@@ -15,7 +15,7 @@ const ConfigurationNotificationBanner = () => {
       className="my-5"
       type="info"
       showIcon
-      message="Configure your storage and messaging provider"
+      title="Configure your storage and messaging provider"
       description="Before Fides can process your privacy requests we need two simple steps to configure your storage and email client."
       action={<Button onClick={handleClick}>Configure</Button>}
     />

--- a/clients/admin-ui/src/features/privacy-requests/drawers/ConfigureAlerts.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/drawers/ConfigureAlerts.tsx
@@ -141,7 +141,7 @@ const ConfigureAlerts = () => {
             Get notified when processing failures occur. Set a threshold to
             receive alerts after a specific number of errors.
           </Typography.Text>
-          <Space direction="vertical" size="medium" className="w-full">
+          <Space orientation="vertical" size="medium" className="w-full">
             <Form.Item className="mb-0">
               <Flex justify="space-between" align="center">
                 <label htmlFor="enable-email-notifications">

--- a/clients/admin-ui/src/features/privacy-requests/pre-approval-webhooks/PreApprovalWebhooksPage.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/pre-approval-webhooks/PreApprovalWebhooksPage.tsx
@@ -234,7 +234,7 @@ const PreApprovalWebhooksPage = () => {
         open={isModalOpen}
         onCancel={handleCancel}
         footer={null}
-        destroyOnClose
+        destroyOnHidden
       >
         <Form
           form={form}

--- a/clients/admin-ui/src/features/prompt-explorer/QuestionnaireControls.tsx
+++ b/clients/admin-ui/src/features/prompt-explorer/QuestionnaireControls.tsx
@@ -107,7 +107,7 @@ export const QuestionnaireControls = ({
       {/* Intent Classification specific controls */}
       {promptType === "intent_classification" && (
         <Card title="Conversation State" size="small">
-          <Space direction="vertical" className="w-full">
+          <Space orientation="vertical" className="w-full">
             <div>
               <Text strong className="mb-1 block">
                 Current Question ({currentQuestionIndex + 1} of{" "}
@@ -158,7 +158,7 @@ export const QuestionnaireControls = ({
       {/* Message Generation specific controls */}
       {promptType === "message_generation" && (
         <Card title="Action Context" size="small">
-          <Space direction="vertical" className="w-full">
+          <Space orientation="vertical" className="w-full">
             <div>
               <Text strong className="mb-1 block">
                 Action Type
@@ -208,7 +208,7 @@ export const QuestionnaireControls = ({
       {/* Question Rephrase specific controls */}
       {promptType === "question_rephrase" && (
         <Card title="Rephrase Input" size="small">
-          <Space direction="vertical" className="w-full">
+          <Space orientation="vertical" className="w-full">
             <div>
               <Text strong className="mb-1 block">
                 Question to Rephrase

--- a/clients/admin-ui/src/features/seed-data/SeedDataPanel.tsx
+++ b/clients/admin-ui/src/features/seed-data/SeedDataPanel.tsx
@@ -260,7 +260,7 @@ const SeedDataPanel = () => {
         multiple times. Not for production use.
       </Paragraph>
 
-      <Space direction="vertical" size="middle" className="mb-6 w-full">
+      <Space orientation="vertical" size="middle" className="mb-6 w-full">
         <Flex vertical gap="small">
           <Text strong>Seed profile</Text>
           {profiles && profiles.length > 0 ? (
@@ -277,7 +277,7 @@ const SeedDataPanel = () => {
           ) : (
             <Alert
               type="info"
-              message="No seed profiles configured. Set FIDESPLUS__SAMPLE_DATA__PROFILES to configure 1Password-backed profiles."
+              title="No seed profiles configured. Set FIDESPLUS__SAMPLE_DATA__PROFILES to configure 1Password-backed profiles."
               showIcon
             />
           )}
@@ -318,7 +318,7 @@ const SeedDataPanel = () => {
                 </Text>
               ),
               children: (
-                <Space direction="vertical" size="small" className="w-full">
+                <Space orientation="vertical" size="small" className="w-full">
                   <Flex justify="space-between" align="center" className="mb-2">
                     <Text type="secondary" style={{ fontSize: 12 }}>
                       Toggle scenarios on or off. Checked items match the
@@ -388,7 +388,7 @@ const SeedDataPanel = () => {
       {isTriggerError ? (
         <Alert
           type="error"
-          message="Failed to start seed. Please try again."
+          title="Failed to start seed. Please try again."
           className="mt-4"
           showIcon
         />
@@ -400,7 +400,7 @@ const SeedDataPanel = () => {
             percent={computeProgress(statusData.steps)}
             status={statusData.status === "error" ? "exception" : undefined}
           />
-          <Space direction="vertical" size="small" className="mt-2 w-full">
+          <Space orientation="vertical" size="small" className="mt-2 w-full">
             {Object.entries(statusData.steps).map(([stepName, stepStatus]) => (
               <Flex key={stepName} justify="space-between" align="center">
                 <Text>{stepName.replace(/_/g, " ")}</Text>
@@ -411,7 +411,7 @@ const SeedDataPanel = () => {
           {statusData.error ? (
             <Alert
               type="error"
-              message={statusData.error}
+              title={statusData.error}
               className="mt-2"
               showIcon
             />
@@ -419,7 +419,7 @@ const SeedDataPanel = () => {
           {statusData.status === "complete" ? (
             <Alert
               type="success"
-              message="Seed completed successfully"
+              title="Seed completed successfully"
               className="mt-2"
               showIcon
             />

--- a/clients/admin-ui/src/features/system/AddNewSystemModal.tsx
+++ b/clients/admin-ui/src/features/system/AddNewSystemModal.tsx
@@ -190,7 +190,7 @@ export const AddNewSystemModal = ({
         getIsDirty={() => formik.dirty}
         centered
         data-testid="add-modal-content"
-        destroyOnClose
+        destroyOnHidden
         footer={null}
       >
         <Form>

--- a/clients/admin-ui/src/features/system/SystemInformationForm.tsx
+++ b/clients/admin-ui/src/features/system/SystemInformationForm.tsx
@@ -437,7 +437,7 @@ const SystemInformationForm = ({
           <FormGuard id="SystemInfoTab" name="System Info" />
           {isReadOnly && (
             <Alert
-              message="Read-only access"
+              title="Read-only access"
               description="You have read-only access to this system. Contact an administrator if you need to make changes."
               type="info"
               showIcon

--- a/clients/admin-ui/src/features/system/system-form-declaration-tab/EmptyTableState.tsx
+++ b/clients/admin-ui/src/features/system/system-form-declaration-tab/EmptyTableState.tsx
@@ -45,7 +45,7 @@ const EmptyTableState = ({ title, description, handleAdd }: Props) => (
             data-testid="add-btn"
             onClick={handleAdd}
             icon={<Icons.Add size={16} />}
-            iconPosition="end"
+            iconPlacement="end"
           >
             Add data use
           </Button>

--- a/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationDisplayGroup.tsx
+++ b/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationDisplayGroup.tsx
@@ -161,7 +161,7 @@ export const PrivacyDeclarationDisplayGroup = ({
             onClick={handleAdd}
             size="small"
             icon={<Icons.Add size={16} />}
-            iconPosition="end"
+            iconPlacement="end"
             data-testid="add-btn"
           >
             Add data use

--- a/clients/admin-ui/src/features/system/tabs/system-assets/AddEditAssetModal.tsx
+++ b/clients/admin-ui/src/features/system/tabs/system-assets/AddEditAssetModal.tsx
@@ -130,7 +130,7 @@ const AddEditAssetModal = ({
         getIsDirty={() => formik.dirty}
         open={isOpen}
         centered
-        destroyOnClose
+        destroyOnHidden
         footer={null}
         data-testid="add-modal-content"
       >

--- a/clients/admin-ui/src/features/system/tabs/system-assets/SystemAssetsTable.tsx
+++ b/clients/admin-ui/src/features/system/tabs/system-assets/SystemAssetsTable.tsx
@@ -164,7 +164,7 @@ const SystemAssetsTable = ({ system }: { system: SystemResponse }) => {
             <Spacer />
             <Button
               icon={<Icons.Add />}
-              iconPosition="end"
+              iconPlacement="end"
               onClick={onOpenAddEditModal}
               data-testid="add-asset-btn"
             >
@@ -178,7 +178,7 @@ const SystemAssetsTable = ({ system }: { system: SystemResponse }) => {
             />
             <Button
               icon={<Icons.TrashCan />}
-              iconPosition="end"
+              iconPlacement="end"
               onClick={onOpenDeleteModal}
               disabled={!selectedAssetIds.length}
               data-testid="bulk-delete-btn"

--- a/clients/admin-ui/src/features/test-datasets/DatasetEditorSection.tsx
+++ b/clients/admin-ui/src/features/test-datasets/DatasetEditorSection.tsx
@@ -275,7 +275,7 @@ const EditorSection = ({ connectionKey }: EditorSectionProps) => {
       {reachability && (
         <Alert
           type={reachability?.reachable ? "success" : "error"}
-          message={
+          title={
             reachability?.reachable
               ? "Dataset is reachable"
               : `Dataset is not reachable. ${getReachabilityMessage(reachability?.details)}`

--- a/clients/admin-ui/src/features/test-monitors/TestDatastoreMonitor.tsx
+++ b/clients/admin-ui/src/features/test-monitors/TestDatastoreMonitor.tsx
@@ -183,7 +183,7 @@ const TestDatastoreMonitor = () => {
                 min={0}
                 max={100}
                 step={5}
-                addonAfter="%"
+                suffix="%"
                 className="w-full"
               />
             </Form.Item>

--- a/clients/admin-ui/src/features/test-monitors/TestWebsiteMonitor.tsx
+++ b/clients/admin-ui/src/features/test-monitors/TestWebsiteMonitor.tsx
@@ -203,7 +203,7 @@ const TestWebsiteMonitor = () => {
                 min={0}
                 max={100}
                 step={5}
-                addonAfter="%"
+                suffix="%"
                 className="w-full"
               />
             </Form.Item>
@@ -214,7 +214,7 @@ const TestWebsiteMonitor = () => {
                 min={0}
                 max={100}
                 step={5}
-                addonAfter="%"
+                suffix="%"
                 className="w-full"
               />
             </Form.Item>
@@ -225,7 +225,7 @@ const TestWebsiteMonitor = () => {
                 min={0}
                 max={100}
                 step={5}
-                addonAfter="%"
+                suffix="%"
                 className="w-full"
               />
             </Form.Item>

--- a/clients/admin-ui/src/features/user-management/EditUserForm.tsx
+++ b/clients/admin-ui/src/features/user-management/EditUserForm.tsx
@@ -103,7 +103,7 @@ const ReinviteSection = ({ user }: ReinviteSectionProps) => {
       {contextHolder}
       <div className="mb-4">
         <Alert
-          message={user.invite_expired ? "Invite expired" : "Invite pending"}
+          title={user.invite_expired ? "Invite expired" : "Invite pending"}
           description={
             user.invite_expired
               ? "This user's invitation has expired. Use the button to send a new invitation email."

--- a/clients/admin-ui/src/home/AgentBriefingBanner.tsx
+++ b/clients/admin-ui/src/home/AgentBriefingBanner.tsx
@@ -62,7 +62,7 @@ export const AgentBriefingBanner = () => {
         showIcon
         icon={<SparkleIcon size={14} />}
         closable
-        message={
+        title={
           <>
             {text}
             {alphaDashboardAgentBriefingActions && (

--- a/clients/admin-ui/src/home/AstralisPanel.tsx
+++ b/clients/admin-ui/src/home/AstralisPanel.tsx
@@ -48,7 +48,7 @@ export const AstralisPanel = () => {
             >
               <Statistic
                 value={value}
-                valueStyle={color ? { color } : undefined}
+                styles={color ? { content: { color } } : undefined}
               />
               <Text
                 type={variant ? undefined : "secondary"}

--- a/clients/admin-ui/src/home/DSRStatusCard.tsx
+++ b/clients/admin-ui/src/home/DSRStatusCard.tsx
@@ -112,9 +112,11 @@ export const DSRStatusCard = () => {
                     <Statistic
                       value={data?.statuses?.[key] ?? 0}
                       title={title}
-                      valueStyle={{
-                        fontSize: token.fontSize,
-                        fontWeight: 600,
+                      styles={{
+                        content: {
+                          fontSize: token.fontSize,
+                          fontWeight: 600,
+                        },
                       }}
                     />
                   </Flex>

--- a/clients/admin-ui/src/home/DashboardDrawer.tsx
+++ b/clients/admin-ui/src/home/DashboardDrawer.tsx
@@ -22,7 +22,7 @@ export const DashboardDrawer = () => {
       placement="right"
       width={480}
       title={config?.title}
-      destroyOnClose
+      destroyOnHidden
       styles={{
         header: { background: token.colorBgContainer, borderBottom: "none" },
         body: { background: token.colorBgContainer },

--- a/clients/admin-ui/src/home/PostureBreakdownContent.tsx
+++ b/clients/admin-ui/src/home/PostureBreakdownContent.tsx
@@ -67,7 +67,7 @@ export const PostureBreakdownContent = () => {
           type="info"
           showIcon
           icon={<SparkleIcon size={14} />}
-          message={posture.agent_annotation}
+          title={posture.agent_annotation}
         />
       )}
 

--- a/clients/admin-ui/src/home/PostureCard.tsx
+++ b/clients/admin-ui/src/home/PostureCard.tsx
@@ -135,7 +135,7 @@ export const PostureCard = () => {
             type="info"
             showIcon={false}
             className={styles.summaryAlert}
-            message={
+            title={
               <Flex align="center" gap="middle">
                 <div>
                   <Flex vertical>

--- a/clients/admin-ui/src/home/TrendCard.tsx
+++ b/clients/admin-ui/src/home/TrendCard.tsx
@@ -131,7 +131,10 @@ export const TrendCard = ({ metricKey, metric, isLoading }: TrendCardProps) => {
     }
     if (!metric) {
       return (
-        <Statistic value="—" valueStyle={{ color: token.colorTextDisabled }} />
+        <Statistic
+          value="—"
+          styles={{ content: { color: token.colorTextDisabled } }}
+        />
       );
     }
     return (

--- a/clients/admin-ui/src/pages/poc/ant-components.tsx
+++ b/clients/admin-ui/src/pages/poc/ant-components.tsx
@@ -56,7 +56,7 @@ const AntPOC: NextPage = () => {
         <Row gutter={16} className="mt-6">
           <Col span={8}>
             <Card title="Button" variant="borderless" className="h-full">
-              <Space direction="vertical">
+              <Space orientation="vertical">
                 <Button type="primary">Primary Button</Button>
                 <Button>Default Button</Button>
                 <Button type="dashed">Dashed Button</Button>
@@ -73,7 +73,7 @@ const AntPOC: NextPage = () => {
           </Col>
           <Col span={8}>
             <Card title="Switch" variant="borderless" className="h-full">
-              <Space direction="vertical">
+              <Space orientation="vertical">
                 <Switch defaultChecked />
                 <Switch size="small" defaultChecked />
                 <Switch loading defaultChecked />
@@ -82,7 +82,7 @@ const AntPOC: NextPage = () => {
           </Col>
           <Col span={8}>
             <Card title="Select" variant="borderless" className="h-full">
-              <Space direction="vertical">
+              <Space orientation="vertical">
                 <Select
                   defaultValue="lucy"
                   className="w-32"
@@ -141,7 +141,7 @@ const AntPOC: NextPage = () => {
         <Row gutter={16}>
           <Col span={8}>
             <Card title="Checkbox" variant="borderless" className="h-full">
-              <Space direction="vertical">
+              <Space orientation="vertical">
                 <Checkbox>Checkbox</Checkbox>
                 <Checkbox defaultChecked>Checkbox</Checkbox>
                 <Checkbox disabled>Disabled</Checkbox>
@@ -159,7 +159,7 @@ const AntPOC: NextPage = () => {
           </Col>
           <Col span={8}>
             <Card title="Radio" variant="borderless" className="h-full">
-              <Space direction="vertical">
+              <Space orientation="vertical">
                 <Radio>Radio</Radio>
                 <Radio defaultChecked>Radio</Radio>
                 <Radio disabled>Disabled</Radio>
@@ -195,7 +195,7 @@ const AntPOC: NextPage = () => {
           </Col>
           <Col span={8}>
             <Card title="Input" variant="borderless" className="h-full">
-              <Space direction="vertical" size="medium">
+              <Space orientation="vertical" size="medium">
                 <Space.Compact>
                   <Input defaultValue="26888888" aria-label="Input" />
                 </Space.Compact>
@@ -213,7 +213,7 @@ const AntPOC: NextPage = () => {
                 </Space.Compact>
                 <Space.Compact>
                   <Input.Search
-                    addonBefore="https://"
+                    prefix="https://"
                     placeholder="input search text"
                     allowClear
                     aria-label="Input"
@@ -245,7 +245,7 @@ const AntPOC: NextPage = () => {
         <Row gutter={16}>
           <Col span={8}>
             <Card title="Tooltip" variant="borderless" className="h-full">
-              <Space direction="vertical">
+              <Space orientation="vertical">
                 <Tooltip title="I'm a tooltip">
                   Hover or focus this text
                 </Tooltip>
@@ -258,11 +258,11 @@ const AntPOC: NextPage = () => {
           </Col>
           <Col span={8}>
             <Card title="Alert" variant="borderless" className="h-full">
-              <Space direction="vertical">
-                <Alert message="Success Tips" type="success" showIcon />
-                <Alert message="Informational Notes" type="info" showIcon />
-                <Alert message="Warning" type="warning" showIcon closable />
-                <Alert message="Error" type="error" showIcon />
+              <Space orientation="vertical">
+                <Alert title="Success Tips" type="success" showIcon />
+                <Alert title="Informational Notes" type="info" showIcon />
+                <Alert title="Warning" type="warning" showIcon closable />
+                <Alert title="Error" type="error" showIcon />
               </Space>
             </Card>
           </Col>
@@ -315,7 +315,7 @@ const AntPOC: NextPage = () => {
               variant="borderless"
               className="h-full"
             >
-              <Space direction="vertical">
+              <Space orientation="vertical">
                 <Title level={1}>H1 default</Title>
                 <Title level={1} headingSize={2}>
                   H1 sized as H2
@@ -376,7 +376,7 @@ const AntPOC: NextPage = () => {
               variant="borderless"
               className="h-full"
             >
-              <Space direction="vertical">
+              <Space orientation="vertical">
                 <Text>Ant Design (default)</Text>
                 <Text size="sm">Ant Design (small)</Text>
                 <Text size="lg">Ant Design (large)</Text>
@@ -407,7 +407,7 @@ const AntPOC: NextPage = () => {
               variant="borderless"
               className="h-full"
             >
-              <Space direction="vertical" className="w-full">
+              <Space orientation="vertical" className="w-full">
                 <Text>
                   CustomList supports rowSelection similar to Table, with
                   checkboxes in the avatar position. Selected items:{" "}
@@ -457,9 +457,9 @@ const AntPOC: NextPage = () => {
                 />
                 {selectedListKeys.length > 0 && (
                   <Alert
-                    message={`${selectedListKeys.length} item(s) selected`}
+                    title={`${selectedListKeys.length} item(s) selected`}
                     description={
-                      <Space direction="vertical" size="small">
+                      <Space orientation="vertical" size="small">
                         <Text>
                           You can perform bulk actions on selected items.
                         </Text>

--- a/clients/admin-ui/src/pages/poc/prompt-explorer.tsx
+++ b/clients/admin-ui/src/pages/poc/prompt-explorer.tsx
@@ -261,7 +261,7 @@ const PromptExplorer: NextPage = () => {
       <Layout>
         <Content className="overflow-auto px-10 py-6">
           <Alert
-            message="Plus Required"
+            title="Plus Required"
             description="The Prompt Explorer requires Fides Plus."
             type="warning"
             showIcon
@@ -282,7 +282,7 @@ const PromptExplorer: NextPage = () => {
 
         {promptsError && (
           <Alert
-            message="Failed to load prompts"
+            title="Failed to load prompts"
             description="Make sure fidesplus is running in dev mode."
             type="error"
             showIcon
@@ -321,7 +321,7 @@ const PromptExplorer: NextPage = () => {
                   onChange={(e) => setSelectedPromptId(e.target.value)}
                   className="w-full"
                 >
-                  <Space direction="vertical" className="w-full">
+                  <Space orientation="vertical" className="w-full">
                     {prompts?.map((prompt: PromptInfo) => (
                       <Card
                         key={prompt.id}
@@ -351,14 +351,14 @@ const PromptExplorer: NextPage = () => {
 
           {/* Middle - Configuration */}
           <Col xs={24} md={6}>
-            <Space direction="vertical" className="w-full" size="medium">
+            <Space orientation="vertical" className="w-full" size="medium">
               {/* Data Sections - only for assessment prompts */}
               {selectedPrompt?.category === "assessment" && (
                 <Card title="Data Sections" size="small">
                   <Text type="secondary" className="mb-3 block">
                     Toggle which Fides data to include in the prompt context.
                   </Text>
-                  <Space direction="vertical" className="w-full">
+                  <Space orientation="vertical" className="w-full">
                     {dataSectionsList?.map(
                       (section: { id: string; name: string }) => (
                         <Checkbox
@@ -386,7 +386,7 @@ const PromptExplorer: NextPage = () => {
                   <Text type="secondary" className="mb-3 block">
                     Select a template for questions, or an existing assessment.
                   </Text>
-                  <Space direction="vertical" className="w-full">
+                  <Space orientation="vertical" className="w-full">
                     <div>
                       <Text strong className="mb-1 block">
                         Template (for questions)
@@ -466,7 +466,7 @@ const PromptExplorer: NextPage = () => {
 
               {/* Actions */}
               <Card size="small">
-                <Space direction="vertical" className="w-full">
+                <Space orientation="vertical" className="w-full">
                   <Button
                     type="primary"
                     block
@@ -503,7 +503,7 @@ const PromptExplorer: NextPage = () => {
 
           {/* Right - Output */}
           <Col xs={24} md={12}>
-            <Space direction="vertical" className="size-full" size="medium">
+            <Space orientation="vertical" className="size-full" size="medium">
               {/* Rendered Prompt */}
               <Card
                 title="Rendered Prompt"

--- a/clients/admin-ui/src/pages/privacy-assessments/[id].tsx
+++ b/clients/admin-ui/src/pages/privacy-assessments/[id].tsx
@@ -70,7 +70,7 @@ const PrivacyAssessmentDetailPage: NextPage = () => {
     modalApi.confirm({
       title: "Delete assessment",
       content: (
-        <Space direction="vertical" size="medium" className="w-full">
+        <Space orientation="vertical" size="medium" className="w-full">
           <Text>Are you sure you want to delete this assessment?</Text>
           <Text type="secondary">
             This action cannot be undone. All assessment data, including any

--- a/clients/admin-ui/src/pages/privacy-assessments/index.tsx
+++ b/clients/admin-ui/src/pages/privacy-assessments/index.tsx
@@ -84,7 +84,7 @@ const PrivacyAssessmentsPage: NextPage = () => {
         <EmptyState onRunAssessment={() => setGenerateModalOpen(true)} />
       ) : (
         <div className="py-6">
-          <Space direction="vertical" size="large" className="w-full">
+          <Space orientation="vertical" size="large" className="w-full">
             {groups.map((group, i) => (
               <AssessmentGroup
                 key={group.data_use ?? `uncategorized-${i}`}

--- a/clients/admin-ui/src/pages/settings/consent/[configuration_id]/[purpose_id].tsx
+++ b/clients/admin-ui/src/pages/settings/consent/[configuration_id]/[purpose_id].tsx
@@ -66,8 +66,8 @@ const ConsentConfigurationPage: NextPage = () => {
           },
         ]}
       />
-      <Space direction="vertical" size="medium">
-        <Space direction="vertical" size="medium">
+      <Space orientation="vertical" size="medium">
+        <Space orientation="vertical" size="medium">
           <SettingsBox
             title={`TCF purpose ${purposeId}${
               purpose?.name ? `: ${purpose?.name}` : ""
@@ -84,7 +84,7 @@ const ConsentConfigurationPage: NextPage = () => {
             )}
           </SettingsBox>
           <SettingsBox title={configuration?.name || "Configuration"}>
-            <Space direction="vertical" className="gap-3">
+            <Space orientation="vertical" className="gap-3">
               <Text fontSize="sm">
                 Add restrictions to control how vendors process data for
                 specific purposes. For each restriction, choose a restriction

--- a/clients/admin-ui/src/pages/user-management/profile/[id].tsx
+++ b/clients/admin-ui/src/pages/user-management/profile/[id].tsx
@@ -73,7 +73,7 @@ const Profile = () => {
       {!isLoadingUser && !existingUser && (
         <Flex justify="center">
           <Alert
-            message="Could not find user with this profile ID."
+            title="Could not find user with this profile ID."
             type="warning"
             showIcon
           />

--- a/clients/fidesui/src/components/dashboard/StatCard.stories.tsx
+++ b/clients/fidesui/src/components/dashboard/StatCard.stories.tsx
@@ -64,7 +64,7 @@ export const Default: Story = {
           trend="up"
           value="112,893"
           prefix={<ArrowUpOutlined />}
-          valueStyle={{ fontSize: token.fontSize }}
+          styles={{ content: { fontSize: token.fontSize } }}
         />
       </Card>
     );
@@ -85,7 +85,7 @@ export const NoTitle: Story = {
           trend="up"
           value="112,893"
           prefix={<ArrowUpOutlined />}
-          valueStyle={{ fontSize: token.fontSize }}
+          styles={{ content: { fontSize: token.fontSize } }}
         />
       </Card>
     );
@@ -112,7 +112,7 @@ export const WithSparkline: Story = {
           trend="down"
           value="1,204"
           prefix={<ArrowDownOutlined />}
-          valueStyle={{ fontSize: token.fontSize }}
+          styles={{ content: { fontSize: token.fontSize } }}
         />
       </Card>
     );
@@ -133,7 +133,7 @@ export const WithRadarChart: Story = {
             trend="up"
             value="4"
             prefix={<ArrowUpOutlined />}
-            valueStyle={{ fontSize: token.fontSize }}
+            styles={{ content: { fontSize: token.fontSize } }}
           />
           <div
             className="aspect-square"
@@ -250,7 +250,7 @@ export const DashboardRow: Story = {
               trend="up"
               value="112,893"
               prefix={<ArrowUpOutlined />}
-              valueStyle={{ fontSize: token.fontSize }}
+              styles={{ content: { fontSize: token.fontSize } }}
             />
           </Card>
           <Card
@@ -269,7 +269,7 @@ export const DashboardRow: Story = {
               trend="down"
               value="1,204"
               prefix={<ArrowDownOutlined />}
-              valueStyle={{ fontSize: token.fontSize }}
+              styles={{ content: { fontSize: token.fontSize } }}
             />
           </Card>
           <Card

--- a/clients/fidesui/src/components/data-display/Filter.tsx
+++ b/clients/fidesui/src/components/data-display/Filter.tsx
@@ -189,7 +189,7 @@ export const Filter = ({
     >
       <Button
         icon={activeFiltersCount > 0 ? undefined : <ChevronDown />}
-        iconPosition="end"
+        iconPlacement="end"
         aria-label={
           activeFiltersCount > 0
             ? `Filter, ${activeFiltersCount} active`

--- a/clients/fidesui/src/hoc/CustomDrawer.tsx
+++ b/clients/fidesui/src/hoc/CustomDrawer.tsx
@@ -6,13 +6,12 @@ const DEFAULT_WIDTH = 480;
 
 /**
  * Wrapper around Ant Drawer that sets the default width to 480px.
+ *
+ * In antd v6, `width` is deprecated in favor of `size`, which accepts both
+ * the enum values (`"default"` / `"large"`) and numeric/string pixel widths.
+ * We forward the deprecated `width` prop into `size` for backward compatibility
+ * with existing call sites.
  */
 export const CustomDrawer = ({ width, size, ...props }: DrawerProps) => {
-  return (
-    <Drawer
-      width={size ? undefined : (width ?? DEFAULT_WIDTH)}
-      size={size}
-      {...props}
-    />
-  );
+  return <Drawer size={size ?? width ?? DEFAULT_WIDTH} {...props} />;
 };

--- a/clients/fidesui/src/hoc/CustomStatistic.tsx
+++ b/clients/fidesui/src/hoc/CustomStatistic.tsx
@@ -47,19 +47,25 @@ const withCustomProps = (WrappedComponent: typeof Statistic) => {
   const WrappedStatistic = React.forwardRef<
     React.ComponentRef<typeof Statistic>,
     CustomStatisticProps
-  >(({ trend = "neutral", size, valueStyle, ...props }, ref) => {
+  >(({ trend = "neutral", size, styles, ...props }, ref) => {
     const { token } = theme.useToken();
     const trendColor = token[TREND_TOKEN_MAP[trend]];
     const fontSize = size ? token[SIZE_TOKEN_MAP[size]] : undefined;
+    // antd v6 allows `styles` to be a function; we only merge when it's a
+    // plain object so per-instance overrides win over our defaults.
+    const userStyles = typeof styles === "object" ? styles : undefined;
     return (
       <WrappedComponent
         ref={ref}
-        valueStyle={{
-          fontWeight: 600, // semibold
-          color: trendColor,
-          fontFamily: token.fontFamilyCode,
-          ...(fontSize != null && { fontSize }),
-          ...valueStyle, // allow per-instance overrides
+        styles={{
+          ...userStyles,
+          content: {
+            fontWeight: 600, // semibold
+            color: trendColor,
+            fontFamily: token.fontFamilyCode,
+            ...(fontSize != null && { fontSize }),
+            ...userStyles?.content, // allow per-instance overrides
+          },
         }}
         {...props}
       />
@@ -88,7 +94,7 @@ const withCustomProps = (WrappedComponent: typeof Statistic) => {
  *   trend="up"
  *   value="112,893"
  *   prefix={<ArrowUpOutlined />}
- *   valueStyle={{ fontSize: token.fontSize }}
+ *   styles={{ content: { fontSize: token.fontSize } }}
  * />
  */
 export const CustomStatistic = withCustomProps(Statistic);

--- a/clients/fidesui/src/hoc/CustomTableHeaderCell.tsx
+++ b/clients/fidesui/src/hoc/CustomTableHeaderCell.tsx
@@ -23,7 +23,7 @@ export const CustomTableHeaderCell = (
             placement="bottomRight"
             {...(columnKey
               ? {
-                  overlayClassName: `${columnKey}-header-menu-list`,
+                  classNames: { root: `${columnKey}-header-menu-list` },
                 }
               : {})}
           >


### PR DESCRIPTION
Ticket [ENG-3435]

### Description Of Changes

After the Admin UI migration to Ant Design v6, the browser console was spewing deprecation warnings on page load. This PR is a mechanical cleanup of those warnings so the console is quiet again -- easier to spot real errors in development and less noise in QA.

Scope was agreed with the reporter to be **antd-only**. The non-antd console warnings called out in the ticket (`includeCountryOnlyOptions` leaking to DOM, `<button>` nesting, `Form.Item` layout-only usage, React 19 `element.ref` access) need live browser inspection to trace and are deferred to a follow-up ticket.

Most of the work is absorbed by three shared wrappers in `fidesui`, so call-sites of `Drawer`, `Statistic`, and `CustomTableHeaderCell` didn't all need hand-editing.

### Code Changes

**Wrappers (`clients/fidesui/src/hoc/`)**

* `CustomDrawer.tsx`: forward the deprecated `width` prop into `size` (which accepts numeric/string pixel widths in v6).
* `CustomStatistic.tsx`: migrate from `valueStyle` to `styles.content`, merging user-provided overrides.
* `CustomTableHeaderCell.tsx`: use `classNames.root` instead of `overlayClassName` on the inner Dropdown.

**Prop renames across ~90 admin-ui files**

* `Button` `iconPosition` to `iconPlacement` (29 files)
* `Modal`/`Drawer` `destroyOnClose` to `destroyOnHidden` (21 prod + 2 test mocks)
* `Space`/`Steps` `direction` to `orientation`
* `Alert` `message` to `title`
* `AutoComplete` `popupClassName` to `classNames.popup.root`
* `Dropdown` `overlayClassName` to `classNames.root`
* `Statistic` `valueStyle` to `styles.content` at 5 call sites
* `InputNumber`/`Input` `addonAfter`/`addonBefore` to `suffix`/`prefix` for simple unit/prefix labels

**Structural**

* `Step` interface `description` field to `content` (in `features/integrations/setup-steps/hooks/types.ts`) plus update of all six hooks that populate it.
* `Dropdown.Button` rewritten as `Space.Compact + Button + Dropdown` in `features/privacy-requests/SubmitPrivacyRequest.tsx`. `data-testid="submit-request-btn"` preserved on the wrapper.

### Steps to Confirm

1. Pull the branch, `cd clients/admin-ui && npm run dev`, log in (`root_user` / `Testpassword1!`).
2. Open the browser devtools console.
3. Navigate through the following surfaces and confirm **none** of the listed deprecation warnings fire:
    * Dashboard (Statistic, Drawer, Alert via AgentBriefingBanner)
    * Integrations setup flow (`<Steps>` with items + vertical orientation)
    * Create privacy request (dropdown split button)
    * Datamap report table (Dropdown menus, Group-by / more-options)
    * Privacy requests filter bar (LocationSelect -- still warns about `includeCountryOnlyOptions`, that's deferred)
    * Nav sidebar & nav search (AutoComplete)
    * Any modal with a form (destroyOnHidden behavior)
    * Test monitors page (InputNumber suffix rendering)
4. Known non-regressions still firing (out of scope, deferred): `[antd: Input] addonBefore`, `[antd: List] List is deprecated`, and the 4 non-antd warnings called out in the ticket.

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
    * [ ] Add a db-migration label to the entry if your change includes a DB migration
    * [ ] Add a high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
    * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
    * [ ] All UX related changes have been reviewed by a designer
    * [x] No UX review needed
* Followup issues:
    * [x] Followup issues created -- non-antd warnings (button-in-button, React 19 `element.ref`, `includeCountryOnlyOptions` DOM leak, Form.Item layout-only) deferred to a new ticket.
    * [ ] No followup issues
* Database migrations:
    * [ ] Ensure that your downrev is up to date with the latest revision on `main`
    * [ ] Ensure that your `downgrade()` migration is correct and works
        * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
    * [x] No migrations
* Documentation:
    * [ ] Documentation complete, PR opened in fidesdocs
    * [ ] Documentation issue created in fidesdocs
    * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
    * [x] No documentation updates required

[ENG-3435]: https://ethyca.atlassian.net/browse/ENG-3435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ