### PR TITLE
Reword "click here" links for accessibility

### DIFF
--- a/changelog/7937-reword-click-here-links.yaml
+++ b/changelog/7937-reword-click-here-links.yaml
@@ -1,0 +1,4 @@
+type: Changed
+description: Reworded "click here" link text across the admin UI, docs, and email templates for accessibility
+pr: 7937
+labels: []

--- a/clients/admin-ui/src/features/system/GVLNotice.tsx
+++ b/clients/admin-ui/src/features/system/GVLNotice.tsx
@@ -17,7 +17,7 @@ const GVLNotice = () => (
             isExternal
             color="complimentary.500"
           >
-            For more information on the Global Vendor List, click here.
+            More information on the Global Vendor List.
           </Link>
         </>
       }

--- a/docs/fides/overrides/404.html
+++ b/docs/fides/overrides/404.html
@@ -91,7 +91,7 @@
 
                 You're not viewing the latest version.
                 <a href="..//fides/">
-                    <strong>Click here to go to the latest stable version.</strong>
+                    <strong>Latest stable version</strong>
                 </a>
 
             </div>

--- a/docs/fides/overrides/404.html
+++ b/docs/fides/overrides/404.html
@@ -91,7 +91,7 @@
 
                 You're not viewing the latest version.
                 <a href="..//fides/">
-                    <strong>Latest stable version</strong>
+                    <strong>Go to latest stable version</strong>
                 </a>
 
             </div>

--- a/docs/fides/overrides/main.html
+++ b/docs/fides/overrides/main.html
@@ -1,6 +1,8 @@
-{% extends "base.html" %} {% block outdated %} You're not viewing the latest
-version.
+{% extends "base.html" %}
+
+{% block outdated %}
+You're not viewing the latest version.
 <a href="{{ '../' ~ base_url }}">
-  <strong>Latest stable version</strong>
+    <strong>Latest stable version</strong>
 </a>
 {% endblock %}

--- a/docs/fides/overrides/main.html
+++ b/docs/fides/overrides/main.html
@@ -3,6 +3,6 @@
 {% block outdated %}
 You're not viewing the latest version.
 <a href="{{ '../' ~ base_url }}">
-    <strong>Latest stable version</strong>
+    <strong>Go to latest stable version</strong>
 </a>
 {% endblock %}

--- a/docs/fides/overrides/main.html
+++ b/docs/fides/overrides/main.html
@@ -1,8 +1,6 @@
-{% extends "base.html" %}
-
-{% block outdated %}
-You're not viewing the latest version.
+{% extends "base.html" %} {% block outdated %} You're not viewing the latest
+version.
 <a href="{{ '../' ~ base_url }}">
-    <strong>Click here to go to the latest stable version.</strong>
+  <strong>Latest stable version</strong>
 </a>
 {% endblock %}

--- a/src/fides/api/email_templates/templates/password_reset.html
+++ b/src/fides/api/email_templates/templates/password_reset.html
@@ -6,7 +6,7 @@
   </head>
   <body>
     <main>
-      <p>We received a request to reset your Fides account password. Click <a href="{{admin_ui_url}}/login?reset_token={{reset_token}}&amp;username={{username | urlencode}}">here</a> to reset your password.</p>
+      <p>We received a request to <a href="{{admin_ui_url}}/login?reset_token={{reset_token}}&amp;username={{username | urlencode}}">reset your Fides account password</a>.
       <p>This link will expire in {{ttl_minutes}} minutes. If you did not request this reset, you can safely ignore this email.</p>
     </main>
   </body>

--- a/src/fides/api/email_templates/templates/password_reset.html
+++ b/src/fides/api/email_templates/templates/password_reset.html
@@ -6,7 +6,7 @@
   </head>
   <body>
     <main>
-      <p>We received a request to <a href="{{admin_ui_url}}/login?reset_token={{reset_token}}&amp;username={{username | urlencode}}">reset your Fides account password</a>.
+      <p>We received a request to <a href="{{admin_ui_url}}/login?reset_token={{reset_token}}&amp;username={{username | urlencode}}">reset your Fides account password</a>.</p>
       <p>This link will expire in {{ttl_minutes}} minutes. If you did not request this reset, you can safely ignore this email.</p>
     </main>
   </body>

--- a/src/fides/api/email_templates/templates/user_invite.html
+++ b/src/fides/api/email_templates/templates/user_invite.html
@@ -6,7 +6,7 @@
   </head>
   <body>
     <main>
-      <p>You've been invited to join Fides, click <a href={{admin_ui_url}}/login?invite_code={{invite_code}}&username={{username}}>here</a> to accept the invite and setup your account.</p>
+      <p>You've been invited to join Fides, <a href={{admin_ui_url}}/login?invite_code={{invite_code}}&username={{username}}>accept the invite</a> and setup your account.</p>
     </main>
   </body>
 </html>

--- a/tests/ops/service/messaging/message_dispatch_service_test.py
+++ b/tests/ops/service/messaging/message_dispatch_service_test.py
@@ -1051,7 +1051,7 @@ class TestMessageDispatchService:
             ),
         )
 
-        body = '<!DOCTYPE html>\n<html lang="en">\n  <head>\n    <meta charset="UTF-8" />\n    <title>Welcome to Fides</title>\n  </head>\n  <body>\n    <main>\n      <p>You\'ve been invited to join Fides, click <a href=http://localhost:3000/login?invite_code=123&username=test>here</a> to accept the invite and setup your account.</p>\n    </main>\n  </body>\n</html>'
+        body = '<!DOCTYPE html>\n<html lang="en">\n  <head>\n    <meta charset="UTF-8" />\n    <title>Welcome to Fides</title>\n  </head>\n  <body>\n    <main>\n      <p>You\'ve been invited to join Fides, <a href=http://localhost:3000/login?invite_code=123&username=test>accept the invite</a> and setup your account.</p>\n    </main>\n  </body>\n</html>'
 
         mock_mailgun_dispatcher.assert_called_with(
             messaging_config,


### PR DESCRIPTION
Ticket [N/A]

### Description Of Changes

Removes the "click here" anti-pattern from link text across the admin UI, docs overrides, and email templates. Link text should describe the destination rather than the action, both for accessibility (screen reader users navigating by link list) and general UX.

### Code Changes

* `clients/admin-ui/src/features/system/GVLNotice.tsx`: GVL info link reworded
* `docs/fides/overrides/404.html`: latest-stable-version link reworded
* `docs/fides/overrides/main.html`: latest-stable-version link reworded in outdated-version banner
* `src/fides/api/email_templates/templates/password_reset.html`: reset-password link reworded
* `src/fides/api/email_templates/templates/user_invite.html`: accept-invite link reworded
* `tests/ops/service/messaging/message_dispatch_service_test.py`: updated expected email body to match new template

### Steps to Confirm

1. Trigger a password reset email in a local env and confirm the link text reads "reset your Fides account password" (no "click here")
2. Trigger a user invite email and confirm the link text reads "accept the invite" (no "click here")
3. Visit the outdated-docs banner / 404 page and confirm the link reads "Latest stable version"
4. Open the GVL notice in the admin UI (System edit page, GVL vendor) and confirm the link reads "More information on the Global Vendor List"

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required