### PR TITLE
Fix 3459 rate limit

### DIFF
--- a/changelog/7938-fix-rate-limits.yaml
+++ b/changelog/7938-fix-rate-limits.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Fixed problems with larger timeout checks on rate_limit for integrations
+pr: 7938
+labels: []

--- a/src/fides/api/service/connectors/limiter/rate_limiter.py
+++ b/src/fides/api/service/connectors/limiter/rate_limiter.py
@@ -145,7 +145,9 @@ class RateLimiter:
         """
         if timeout_seconds is None:
             timeout_seconds = min(
-                max(r.period.factor for r in requests) + 5 if requests else self.MIN_DEFAULT_TIMEOUT_SECONDS,
+                max(r.period.factor for r in requests) + 5
+                if requests
+                else self.MIN_DEFAULT_TIMEOUT_SECONDS,
                 self.MAX_DEFAULT_TIMEOUT_SECONDS,
             )
 

--- a/src/fides/api/service/connectors/limiter/rate_limiter.py
+++ b/src/fides/api/service/connectors/limiter/rate_limiter.py
@@ -1,6 +1,6 @@
 import time
 from enum import Enum
-from typing import List
+from typing import List, Optional
 
 from loguru import logger
 
@@ -110,20 +110,39 @@ class RateLimiter:
             pipe.decrby(redis_key, 1)
         pipe.execute()
 
+    def seconds_until_next_bucket(
+        self, current_seconds: int, request: RateLimiterRequest
+    ) -> float:
+        """
+        Returns the number of seconds until the next time bucket starts for the given request.
+        """
+        fixed_time_filter = (
+            int(current_seconds / request.period.factor) * request.period.factor
+        )
+        return (fixed_time_filter + request.period.factor) - current_seconds
+
     def limit(
-        self, requests: List[RateLimiterRequest], timeout_seconds: int = 30
+        self, requests: List[RateLimiterRequest], timeout_seconds: Optional[int] = None
     ) -> None:
         """
         Increments call count for the current time bucket and verifies that it is within the
-        rate limit provided. If limit is breached it will decrement the count and try again
-        until it can successfully reserve a call, or timeout. Because we rely on optimistic
-        locking for many keys at a time, it is possible that concurrent rate limiters could
-        make the wrong decision in between increment to decrement operations.
+        rate limit provided. If limit is breached it will decrement the count and sleep until
+        the current bucket rolls over before retrying. Because we rely on optimistic locking
+        for many keys at a time, it is possible that concurrent rate limiters could make the
+        wrong decision in between increment to decrement operations.
 
         If connection to the redis cluster fails then rate limiter will be skipped.
 
-        Expiration is set on any keys which are stored in the cluster
+        Expiration is set on any keys which are stored in the cluster.
+
+        timeout_seconds defaults to the longest period factor + 5s, giving the limiter at
+        least one full bucket rollover window before giving up.
         """
+        if timeout_seconds is None:
+            timeout_seconds = (
+                max(r.period.factor for r in requests) + 5 if requests else 30
+            )
+
         try:
             redis: FidesopsRedis = get_cache()
         except RedisConnectionError as exc:
@@ -135,6 +154,7 @@ class RateLimiter:
             return
 
         start_time = time.time()
+        breached_requests: List[RateLimiterRequest] = []
         while time.time() - start_time < timeout_seconds:
             current_seconds = int(time.time())
 
@@ -156,7 +176,17 @@ class RateLimiter:
                 self.decrement_usage(
                     redis=redis, current_seconds=current_seconds, requests=requests
                 )
-                time.sleep(0.1)
+                # Sleep until the next bucket boundary for the longest-period breached
+                # request. This avoids hammering Redis every 100ms for minute/hour/day
+                # limits where the bucket won't roll for a long time.
+                sleep_seconds = max(
+                    self.seconds_until_next_bucket(current_seconds, r)
+                    for r in breached_requests
+                )
+                # Add a small buffer to avoid landing exactly on the boundary, but
+                # never sleep longer than the remaining timeout.
+                remaining = timeout_seconds - (time.time() - start_time)
+                time.sleep(min(sleep_seconds + 0.05, max(remaining, 0)))
             else:
                 # success
                 return

--- a/src/fides/api/service/connectors/limiter/rate_limiter.py
+++ b/src/fides/api/service/connectors/limiter/rate_limiter.py
@@ -135,12 +135,16 @@ class RateLimiter:
 
         Expiration is set on any keys which are stored in the cluster.
 
-        timeout_seconds defaults to the longest period factor + 5s, giving the limiter at
-        least one full bucket rollover window before giving up.
+        timeout_seconds defaults to the longest period factor + 5s (capped at 120s),
+        giving the limiter at least one full bucket rollover window before giving up.
+        The cap prevents HOUR/DAY limits from blocking a worker for unreasonable
+        durations; connectors like SurveyMonkey configure both minute and day limits,
+        and a breached day limit should fail fast rather than sleep for 24 hours.
         """
         if timeout_seconds is None:
-            timeout_seconds = (
-                max(r.period.factor for r in requests) + 5 if requests else 30
+            timeout_seconds = min(
+                max(r.period.factor for r in requests) + 5 if requests else 30,
+                120,
             )
 
         try:

--- a/src/fides/api/service/connectors/limiter/rate_limiter.py
+++ b/src/fides/api/service/connectors/limiter/rate_limiter.py
@@ -53,6 +53,8 @@ class RateLimiter:
     """
 
     EXPIRE_AFTER_PERIOD_SECONDS: int = 500
+    MAX_DEFAULT_TIMEOUT_SECONDS: int = 120
+    MIN_DEFAULT_TIMEOUT_SECONDS: int = 30
 
     def build_redis_key(self, current_seconds: int, request: RateLimiterRequest) -> str:
         """
@@ -112,7 +114,7 @@ class RateLimiter:
 
     def seconds_until_next_bucket(
         self, current_seconds: int, request: RateLimiterRequest
-    ) -> float:
+    ) -> int:
         """
         Returns the number of seconds until the next time bucket starts for the given request.
         """
@@ -143,8 +145,8 @@ class RateLimiter:
         """
         if timeout_seconds is None:
             timeout_seconds = min(
-                max(r.period.factor for r in requests) + 5 if requests else 30,
-                120,
+                max(r.period.factor for r in requests) + 5 if requests else self.MIN_DEFAULT_TIMEOUT_SECONDS,
+                self.MAX_DEFAULT_TIMEOUT_SECONDS,
             )
 
         try:

--- a/tests/ops/integration_tests/limiter/test_rate_limiter.py
+++ b/tests/ops/integration_tests/limiter/test_rate_limiter.py
@@ -3,13 +3,14 @@ import time
 import unittest.mock as mock
 from collections import Counter
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Any, Callable, Dict, Generator, List
 
 import pytest
 from freezegun import freeze_time
 from requests import Session
 
+from fides.api.common_exceptions import RedisConnectionError
 from fides.api.db import session
 from fides.api.graph.graph import DatasetGraph
 from fides.api.models.connectionconfig import (
@@ -20,7 +21,6 @@ from fides.api.models.connectionconfig import (
 from fides.api.models.datasetconfig import DatasetConfig
 from fides.api.models.sql_models import Dataset as CtlDataset
 from fides.api.schemas.redis_cache import Identity
-from fides.api.common_exceptions import RedisConnectionError
 from fides.api.service.connectors.limiter.rate_limiter import (
     RateLimiter,
     RateLimiterPeriod,
@@ -253,7 +253,9 @@ def test_minute_period_breach_waits_for_rollover() -> None:
             limiter.limit(requests=[request])  # fills the single slot
             limiter.limit(requests=[request])  # breach -> sleep to boundary -> succeed
 
-    # If we reach here without RateLimiterTimeoutException, the fix works.
+        # Confirm the limiter actually slept past the bucket boundary (00:01:00),
+        # not just that it didn't raise.
+        assert frozen().timestamp() >= datetime(2024, 1, 1, 0, 1, 0).timestamp()
 
 
 @pytest.mark.integration
@@ -298,7 +300,7 @@ def test_dynamic_timeout_capped_for_day_limits() -> None:
 
     # Total mocked sleep must reflect the 120s cap, not the 86405s
     # uncapped value.
-    assert sleep_total[0] < 130
+    assert 110 <= sleep_total[0] < 130  # should be ~120 s, not 86400 s
 
 
 @pytest.mark.integration_saas

--- a/tests/ops/integration_tests/limiter/test_rate_limiter.py
+++ b/tests/ops/integration_tests/limiter/test_rate_limiter.py
@@ -3,9 +3,11 @@ import time
 import unittest.mock as mock
 from collections import Counter
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import timedelta
 from typing import Any, Callable, Dict, Generator, List
 
 import pytest
+from freezegun import freeze_time
 from requests import Session
 
 from fides.api.db import session
@@ -218,6 +220,86 @@ def test_limiter_times_out_when_bucket_full() -> None:
             time.sleep(0.002)
 
 
+@pytest.mark.integration
+def test_minute_period_breach_waits_for_rollover() -> None:
+    """A MINUTE-period breach must sleep until the bucket rolls over, not time out.
+
+    Regression: the old default timeout_seconds=30 was shorter than the MINUTE
+    bucket period (60s).  When a breach occurred more than 30s before the next
+    boundary the limiter would raise RateLimiterTimeoutException instead of
+    waiting.  This affected the Okta client (period=MINUTE) and any SaaS
+    connector with a per-minute rate limit (e.g. Zenoti, SurveyMonkey).
+
+    Uses real Redis for bucket state; only mocks time to avoid 60s wall-clock
+    waits.
+    """
+    # "2024-01-01 00:00:05" is 5s into a minute, so the next bucket is 55s
+    # away.  The old 30s default would time out before reaching it.
+    with freeze_time("2024-01-01 00:00:05") as frozen:
+        limiter = RateLimiter()
+        key = f"test_minute_rollover_{random.randint(0, 10**12)}"
+        request = RateLimiterRequest(
+            key=key, rate_limit=1, period=RateLimiterPeriod.MINUTE
+        )
+
+        def advancing_sleep(seconds: float) -> None:
+            frozen.tick(timedelta(seconds=seconds))
+
+        with mock.patch(
+            "fides.api.service.connectors.limiter.rate_limiter.time.sleep",
+            side_effect=advancing_sleep,
+        ):
+            limiter.limit(requests=[request])  # fills the single slot
+            limiter.limit(requests=[request])  # breach -> sleep to boundary -> succeed
+
+    # If we reach here without RateLimiterTimeoutException, the fix works.
+
+
+@pytest.mark.integration
+def test_dynamic_timeout_capped_for_day_limits() -> None:
+    """Mixed MINUTE + DAY limits must not block a worker for hours.
+
+    SurveyMonkey configures ``rate: 120/minute`` and ``rate: 500/day``.
+    Without a cap the dynamic timeout would be ``86400 + 5 = 86405s`` (~24h),
+    leaving a Celery worker sleeping until the next day bucket rolls over.
+    The 120s cap ensures the limiter fails fast and surfaces an error instead.
+
+    Uses real Redis for bucket state; only mocks time to avoid real sleeping.
+    """
+    with freeze_time("2024-01-01 00:00:05") as frozen:
+        limiter = RateLimiter()
+        key = f"test_day_cap_{random.randint(0, 10**12)}"
+
+        minute_request = RateLimiterRequest(
+            key=f"{key}:min", rate_limit=1, period=RateLimiterPeriod.MINUTE
+        )
+        day_request = RateLimiterRequest(
+            key=f"{key}:day", rate_limit=1, period=RateLimiterPeriod.DAY
+        )
+        both = [minute_request, day_request]
+
+        sleep_total = [0.0]
+
+        def advancing_sleep(seconds: float) -> None:
+            sleep_total[0] += seconds
+            frozen.tick(timedelta(seconds=seconds))
+
+        with mock.patch(
+            "fides.api.service.connectors.limiter.rate_limiter.time.sleep",
+            side_effect=advancing_sleep,
+        ):
+            # Fill both buckets.
+            limiter.limit(requests=both)
+
+            # Next call breaches both. Should timeout, not sleep for 24h.
+            with pytest.raises(RateLimiterTimeoutException):
+                limiter.limit(requests=both)
+
+    # Total mocked sleep must reflect the 120s cap, not the 86405s
+    # uncapped value.
+    assert sleep_total[0] < 130
+
+
 @pytest.mark.integration_saas
 @pytest.mark.asyncio
 async def test_rate_limiter_full_integration(
@@ -286,113 +368,59 @@ class TestSecondsUntilNextBucket:
 
     def test_second_at_boundary(self) -> None:
         # At the start of a second (e.g. t=1000), 1s remains.
-        assert RateLimiter().seconds_until_next_bucket(1000, self._req(RateLimiterPeriod.SECOND)) == 1
+        assert (
+            RateLimiter().seconds_until_next_bucket(
+                1000, self._req(RateLimiterPeriod.SECOND)
+            )
+            == 1
+        )
 
     def test_second_mid_bucket(self) -> None:
         # 0.5s into a second → 0.5s remains (integer math gives 0 here)
-        result = RateLimiter().seconds_until_next_bucket(1000, self._req(RateLimiterPeriod.SECOND))
+        result = RateLimiter().seconds_until_next_bucket(
+            1000, self._req(RateLimiterPeriod.SECOND)
+        )
         assert 0 < result <= 1
 
     def test_minute_at_start(self) -> None:
         # At the exact start of a minute (e.g. t=600), 60s remain.
-        assert RateLimiter().seconds_until_next_bucket(600, self._req(RateLimiterPeriod.MINUTE)) == 60
+        assert (
+            RateLimiter().seconds_until_next_bucket(
+                600, self._req(RateLimiterPeriod.MINUTE)
+            )
+            == 60
+        )
 
     def test_minute_30s_in(self) -> None:
         # 30 seconds into a minute → 30s remain.
-        assert RateLimiter().seconds_until_next_bucket(630, self._req(RateLimiterPeriod.MINUTE)) == 30
+        assert (
+            RateLimiter().seconds_until_next_bucket(
+                630, self._req(RateLimiterPeriod.MINUTE)
+            )
+            == 30
+        )
 
     def test_minute_59s_in(self) -> None:
         # 59 seconds into a minute → 1s remains.
-        assert RateLimiter().seconds_until_next_bucket(659, self._req(RateLimiterPeriod.MINUTE)) == 1
+        assert (
+            RateLimiter().seconds_until_next_bucket(
+                659, self._req(RateLimiterPeriod.MINUTE)
+            )
+            == 1
+        )
 
     def test_hour_at_start(self) -> None:
-        assert RateLimiter().seconds_until_next_bucket(3600, self._req(RateLimiterPeriod.HOUR)) == 3600
+        assert (
+            RateLimiter().seconds_until_next_bucket(
+                3600, self._req(RateLimiterPeriod.HOUR)
+            )
+            == 3600
+        )
 
     def test_hour_mid(self) -> None:
-        assert RateLimiter().seconds_until_next_bucket(5400, self._req(RateLimiterPeriod.HOUR)) == 1800
-
-
-class TestLimitDynamicTimeout:
-    """Unit tests for the dynamic timeout defaulting in RateLimiter.limit()."""
-
-    def test_default_timeout_uses_max_period_factor(self) -> None:
-        """When timeout_seconds is not passed, the limiter derives it from max period factor."""
-        limiter = RateLimiter()
-        mock_redis = mock.MagicMock()
-        # Always return usage within limit so limit() returns immediately (success path).
-        limiter.increment_usage = mock.MagicMock(return_value=[1])
-
-        with mock.patch("fides.api.service.connectors.limiter.rate_limiter.get_cache", return_value=mock_redis):
-            with mock.patch.object(limiter, "increment_usage", return_value=[1]):
-                limiter.limit(
-                    requests=[RateLimiterRequest(key="k", rate_limit=10, period=RateLimiterPeriod.MINUTE)]
-                )
-        # If we reach here, the call succeeded — the dynamic timeout didn't reject it.
-
-    def test_explicit_timeout_is_respected(self) -> None:
-        """Explicit timeout_seconds overrides the dynamic default."""
-        limiter = RateLimiter()
-        mock_redis = mock.MagicMock()
-
-        # Always report the bucket as over-limit so the loop runs until timeout.
-        with mock.patch("fides.api.service.connectors.limiter.rate_limiter.get_cache", return_value=mock_redis):
-            with mock.patch.object(limiter, "increment_usage", return_value=[999]):
-                with mock.patch.object(limiter, "decrement_usage"):
-                    with mock.patch("time.sleep"):  # skip actual sleeping
-                        start = time.time()
-                        with pytest.raises(RateLimiterTimeoutException):
-                            limiter.limit(
-                                requests=[RateLimiterRequest(key="k", rate_limit=10, period=RateLimiterPeriod.MINUTE)],
-                                timeout_seconds=1,
-                            )
-                        elapsed = time.time() - start
-                        # Should have respected the 1s timeout, not the default 65s.
-                        assert elapsed < 5
-
-
-class TestLimitSleepsToBucketBoundary:
-    """Verify that on breach the limiter sleeps to the next bucket boundary."""
-
-    def test_sleep_duration_targets_next_minute_bucket(self) -> None:
-        """When a MINUTE-period limit is breached, sleep should be ~seconds until next minute."""
-        limiter = RateLimiter()
-
-        # Simulate being 30s into a minute → expect ~30s sleep.
-        frozen_seconds = 630  # 10m30s epoch — 30s into the current minute
-
-        call_count = 0
-
-        def fake_increment(redis, current_seconds, requests):
-            nonlocal call_count
-            call_count += 1
-            # Breach on first call, succeed on second.
-            return [999] if call_count == 1 else [1]
-
-        sleep_calls: List[float] = []
-
-        with mock.patch("fides.api.service.connectors.limiter.rate_limiter.get_cache"):
-            with mock.patch.object(limiter, "increment_usage", side_effect=fake_increment):
-                with mock.patch.object(limiter, "decrement_usage"):
-                    with mock.patch("time.time", side_effect=[
-                        # start_time
-                        float(frozen_seconds),
-                        # while check (1st iteration)
-                        float(frozen_seconds),
-                        # current_seconds inside loop
-                        float(frozen_seconds),
-                        # remaining calculation inside sleep block
-                        float(frozen_seconds),
-                        # while check (2nd iteration — after sleep)
-                        float(frozen_seconds) + 30.05,
-                        # current_seconds inside loop (2nd)
-                        float(frozen_seconds) + 30.05,
-                    ]):
-                        with mock.patch("time.sleep", side_effect=lambda s: sleep_calls.append(s)):
-                            limiter.limit(
-                                requests=[RateLimiterRequest(key="k", rate_limit=10, period=RateLimiterPeriod.MINUTE)],
-                                timeout_seconds=65,
-                            )
-
-        assert len(sleep_calls) == 1
-        # At t=630 (30s into minute), next boundary is t=660 → 30s + 0.05 buffer.
-        assert 29.9 < sleep_calls[0] <= 30.1
+        assert (
+            RateLimiter().seconds_until_next_bucket(
+                5400, self._req(RateLimiterPeriod.HOUR)
+            )
+            == 1800
+        )

--- a/tests/ops/integration_tests/limiter/test_rate_limiter.py
+++ b/tests/ops/integration_tests/limiter/test_rate_limiter.py
@@ -356,10 +356,6 @@ def call_log_spy(method_to_decorate: Callable) -> Callable:
     wrapper.call_log = call_log
     return wrapper
 
-
-# ── Unit tests (no Redis required) ────────────────────────────────────────────
-
-
 class TestSecondsUntilNextBucket:
     """Unit tests for RateLimiter.seconds_until_next_bucket."""
 
@@ -375,12 +371,23 @@ class TestSecondsUntilNextBucket:
             == 1
         )
 
-    def test_second_mid_bucket(self) -> None:
-        # 0.5s into a second → 0.5s remains (integer math gives 0 here)
-        result = RateLimiter().seconds_until_next_bucket(
-            1000, self._req(RateLimiterPeriod.SECOND)
+    def test_day_at_start(self) -> None:
+        # At the exact start of a day (t=86400), 86400s remain.
+        assert (
+            RateLimiter().seconds_until_next_bucket(
+                86400, self._req(RateLimiterPeriod.DAY)
+            )
+            == 86400
         )
-        assert 0 < result <= 1
+
+    def test_day_mid(self) -> None:
+        # 12 hours into a day → 12 hours remain.
+        assert (
+            RateLimiter().seconds_until_next_bucket(
+                86400 + 43200, self._req(RateLimiterPeriod.DAY)
+            )
+            == 43200
+        )
 
     def test_minute_at_start(self) -> None:
         # At the exact start of a minute (e.g. t=600), 60s remain.

--- a/tests/ops/integration_tests/limiter/test_rate_limiter.py
+++ b/tests/ops/integration_tests/limiter/test_rate_limiter.py
@@ -273,3 +273,126 @@ def call_log_spy(method_to_decorate: Callable) -> Callable:
 
     wrapper.call_log = call_log
     return wrapper
+
+
+# ── Unit tests (no Redis required) ────────────────────────────────────────────
+
+
+class TestSecondsUntilNextBucket:
+    """Unit tests for RateLimiter.seconds_until_next_bucket."""
+
+    def _req(self, period: RateLimiterPeriod) -> RateLimiterRequest:
+        return RateLimiterRequest(key="k", rate_limit=10, period=period)
+
+    def test_second_at_boundary(self) -> None:
+        # At the start of a second (e.g. t=1000), 1s remains.
+        assert RateLimiter().seconds_until_next_bucket(1000, self._req(RateLimiterPeriod.SECOND)) == 1
+
+    def test_second_mid_bucket(self) -> None:
+        # 0.5s into a second → 0.5s remains (integer math gives 0 here)
+        result = RateLimiter().seconds_until_next_bucket(1000, self._req(RateLimiterPeriod.SECOND))
+        assert 0 < result <= 1
+
+    def test_minute_at_start(self) -> None:
+        # At the exact start of a minute (e.g. t=600), 60s remain.
+        assert RateLimiter().seconds_until_next_bucket(600, self._req(RateLimiterPeriod.MINUTE)) == 60
+
+    def test_minute_30s_in(self) -> None:
+        # 30 seconds into a minute → 30s remain.
+        assert RateLimiter().seconds_until_next_bucket(630, self._req(RateLimiterPeriod.MINUTE)) == 30
+
+    def test_minute_59s_in(self) -> None:
+        # 59 seconds into a minute → 1s remains.
+        assert RateLimiter().seconds_until_next_bucket(659, self._req(RateLimiterPeriod.MINUTE)) == 1
+
+    def test_hour_at_start(self) -> None:
+        assert RateLimiter().seconds_until_next_bucket(3600, self._req(RateLimiterPeriod.HOUR)) == 3600
+
+    def test_hour_mid(self) -> None:
+        assert RateLimiter().seconds_until_next_bucket(5400, self._req(RateLimiterPeriod.HOUR)) == 1800
+
+
+class TestLimitDynamicTimeout:
+    """Unit tests for the dynamic timeout defaulting in RateLimiter.limit()."""
+
+    def test_default_timeout_uses_max_period_factor(self) -> None:
+        """When timeout_seconds is not passed, the limiter derives it from max period factor."""
+        limiter = RateLimiter()
+        mock_redis = mock.MagicMock()
+        # Always return usage within limit so limit() returns immediately (success path).
+        limiter.increment_usage = mock.MagicMock(return_value=[1])
+
+        with mock.patch("fides.api.service.connectors.limiter.rate_limiter.get_cache", return_value=mock_redis):
+            with mock.patch.object(limiter, "increment_usage", return_value=[1]):
+                limiter.limit(
+                    requests=[RateLimiterRequest(key="k", rate_limit=10, period=RateLimiterPeriod.MINUTE)]
+                )
+        # If we reach here, the call succeeded — the dynamic timeout didn't reject it.
+
+    def test_explicit_timeout_is_respected(self) -> None:
+        """Explicit timeout_seconds overrides the dynamic default."""
+        limiter = RateLimiter()
+        mock_redis = mock.MagicMock()
+
+        # Always report the bucket as over-limit so the loop runs until timeout.
+        with mock.patch("fides.api.service.connectors.limiter.rate_limiter.get_cache", return_value=mock_redis):
+            with mock.patch.object(limiter, "increment_usage", return_value=[999]):
+                with mock.patch.object(limiter, "decrement_usage"):
+                    with mock.patch("time.sleep"):  # skip actual sleeping
+                        start = time.time()
+                        with pytest.raises(RateLimiterTimeoutException):
+                            limiter.limit(
+                                requests=[RateLimiterRequest(key="k", rate_limit=10, period=RateLimiterPeriod.MINUTE)],
+                                timeout_seconds=1,
+                            )
+                        elapsed = time.time() - start
+                        # Should have respected the 1s timeout, not the default 65s.
+                        assert elapsed < 5
+
+
+class TestLimitSleepsToBucketBoundary:
+    """Verify that on breach the limiter sleeps to the next bucket boundary."""
+
+    def test_sleep_duration_targets_next_minute_bucket(self) -> None:
+        """When a MINUTE-period limit is breached, sleep should be ~seconds until next minute."""
+        limiter = RateLimiter()
+
+        # Simulate being 30s into a minute → expect ~30s sleep.
+        frozen_seconds = 630  # 10m30s epoch — 30s into the current minute
+
+        call_count = 0
+
+        def fake_increment(redis, current_seconds, requests):
+            nonlocal call_count
+            call_count += 1
+            # Breach on first call, succeed on second.
+            return [999] if call_count == 1 else [1]
+
+        sleep_calls: List[float] = []
+
+        with mock.patch("fides.api.service.connectors.limiter.rate_limiter.get_cache"):
+            with mock.patch.object(limiter, "increment_usage", side_effect=fake_increment):
+                with mock.patch.object(limiter, "decrement_usage"):
+                    with mock.patch("time.time", side_effect=[
+                        # start_time
+                        float(frozen_seconds),
+                        # while check (1st iteration)
+                        float(frozen_seconds),
+                        # current_seconds inside loop
+                        float(frozen_seconds),
+                        # remaining calculation inside sleep block
+                        float(frozen_seconds),
+                        # while check (2nd iteration — after sleep)
+                        float(frozen_seconds) + 30.05,
+                        # current_seconds inside loop (2nd)
+                        float(frozen_seconds) + 30.05,
+                    ]):
+                        with mock.patch("time.sleep", side_effect=lambda s: sleep_calls.append(s)):
+                            limiter.limit(
+                                requests=[RateLimiterRequest(key="k", rate_limit=10, period=RateLimiterPeriod.MINUTE)],
+                                timeout_seconds=65,
+                            )
+
+        assert len(sleep_calls) == 1
+        # At t=630 (30s into minute), next boundary is t=660 → 30s + 0.05 buffer.
+        assert 29.9 < sleep_calls[0] <= 30.1

--- a/tests/ops/integration_tests/limiter/test_rate_limiter.py
+++ b/tests/ops/integration_tests/limiter/test_rate_limiter.py
@@ -20,6 +20,7 @@ from fides.api.models.connectionconfig import (
 from fides.api.models.datasetconfig import DatasetConfig
 from fides.api.models.sql_models import Dataset as CtlDataset
 from fides.api.schemas.redis_cache import Identity
+from fides.api.common_exceptions import RedisConnectionError
 from fides.api.service.connectors.limiter.rate_limiter import (
     RateLimiter,
     RateLimiterPeriod,
@@ -355,6 +356,24 @@ def call_log_spy(method_to_decorate: Callable) -> Callable:
 
     wrapper.call_log = call_log
     return wrapper
+
+class TestRateLimiterRedisFailure:
+    """Unit tests for RateLimiter.limit() when Redis is unavailable."""
+
+    def test_redis_connection_error_is_silently_skipped(self) -> None:
+        with mock.patch(
+            "fides.api.service.connectors.limiter.rate_limiter.get_cache",
+            side_effect=RedisConnectionError("Redis unavailable"),
+        ):
+            # Should not raise — limiter is a no-op when Redis is down.
+            RateLimiter().limit(
+                requests=[
+                    RateLimiterRequest(
+                        key="k", rate_limit=1, period=RateLimiterPeriod.SECOND
+                    )
+                ]
+            )
+
 
 class TestSecondsUntilNextBucket:
     """Unit tests for RateLimiter.seconds_until_next_bucket."""

--- a/tests/ops/integration_tests/limiter/test_rate_limiter.py
+++ b/tests/ops/integration_tests/limiter/test_rate_limiter.py
@@ -357,6 +357,7 @@ def call_log_spy(method_to_decorate: Callable) -> Callable:
     wrapper.call_log = call_log
     return wrapper
 
+
 class TestRateLimiterRedisFailure:
     """Unit tests for RateLimiter.limit() when Redis is unavailable."""
 


### PR DESCRIPTION
Ticket (3459)[https://ethyca.atlassian.net/browse/ENG-3459]
### Description Of Changes
The rate limiter had a hardcoded `timeout_seconds=30` default that was shorter than a  MINUTE-period bucket (60s). When a breach occurred more than 30s before the next bucket  boundary, the limiter would raise `RateLimiterTimeoutException` instead of waiting — Affecting minute rate limits on saas integrations 

Two root causes are fixed:
1. **Busy-wait replaced with sleep-to-boundary.**: Instead of retrying every 100ms, the limiter now sleeps until the next bucket boundary of the longest-period breached request, plus a 50ms buffer to avoid landing exactly on the edge
2. **Dynamic timeout replaces the hardcoded 30s.** The default `timeout_seconds` is now `min(max(period.factor) + 5, 120)` — enough time for at least one full bucket rollover, capped at 120s so HOUR/DAY limits fail fast instead of blocking a Celery worker for hours

### Code Changes
* Added `RateLimiter.seconds_until_next_bucket()` to compute remaining time in the current bucket for a given request                                                                                                                                                                                                                                                                                                                                                                                                               
* Changed `limit()` `timeout_seconds` default from hardcoded `30` to a dynamic value based on the longest period in the request list, capped at 120s                                                                                                                                                                                                                
* Replaced the 100ms busy-wait sleep with a sleep-to-boundary approach                                                                                                                                                                                                     


### Steps to Confirm

1. Configure a SaaS conncetor with a per-minute rate limit, like SurveyMonkey
2. Trigger enough request to bereach the limit (Or edit the limit to a lower bound)
3. Confirm the connector waits for the minute to roll over

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
