### PR TITLE
ENG-3180: Migrate messaging template forms to Ant Design

### DIFF
--- a/changelog/7939-messaging-templates-antd-form.yaml
+++ b/changelog/7939-messaging-templates-antd-form.yaml
@@ -1,0 +1,4 @@
+type: Changed
+description: Migrated messaging template forms to Ant Design Form
+pr: 7939
+labels: []

--- a/clients/admin-ui/cypress/e2e/messaging.cy.ts
+++ b/clients/admin-ui/cypress/e2e/messaging.cy.ts
@@ -87,9 +87,9 @@ describe("Messaging", () => {
 
     cy.getByTestId("add-message-btn").click();
 
-    cy.getByTestId("template-type-selector")
-      .find(".ant-select")
-      .antSelect("Access request completed");
+    cy.getByTestId("template-type-selector").antSelect(
+      "Access request completed",
+    );
 
     cy.getByTestId("confirm-btn").click();
 

--- a/clients/admin-ui/src/features/messaging-templates/AddMessagingTemplateModal.tsx
+++ b/clients/admin-ui/src/features/messaging-templates/AddMessagingTemplateModal.tsx
@@ -1,11 +1,4 @@
-import {
-  Button,
-  ChakraBox as Box,
-  ChakraText as Text,
-  Flex,
-  Modal,
-  Select,
-} from "fidesui";
+import { Button, Flex, Modal, Select, Typography } from "fidesui";
 import { useState } from "react";
 
 import { MODAL_SIZE } from "~/features/common/modals/modal-sizes";
@@ -45,47 +38,35 @@ const AddMessagingTemplateModal = ({
       width={MODAL_SIZE.md}
       data-testid="add-messaging-template-modal"
       title="Select message template"
-      footer={
-        <Flex className="w-full" gap="medium">
-          <Button onClick={onClose} data-testid="cancel-btn" className="grow">
-            Cancel
-          </Button>
-          <Button
-            onClick={() => onAccept(selectedTemplateId!)}
-            type="primary"
-            data-testid="confirm-btn"
-            disabled={!selectedTemplateId}
-            className="grow"
-          >
-            Next
-          </Button>
-        </Flex>
-      }
+      footer={null}
     >
-      <Text
-        color="gray.700"
-        fontWeight="medium"
-        fontSize="sm"
-        marginBottom={3}
-        marginTop={1}
-      >
+      <Typography.Paragraph>
         Add a new email message by selecting a template below and clicking
         accept.
-      </Text>
-      <Text color="gray.700" fontSize="sm" fontWeight="medium" marginBottom={2}>
-        Choose template:
-      </Text>
-
-      <Box data-testid="template-type-selector">
-        <Select<string>
-          options={options}
-          onChange={(value) => {
-            setSelectedTemplateType(value);
-          }}
-          className="w-full"
-          aria-label="Select a template"
-        />
-      </Box>
+      </Typography.Paragraph>
+      <Select<string>
+        data-testid="template-type-selector"
+        options={options}
+        onChange={(value) => {
+          setSelectedTemplateType(value);
+        }}
+        className="w-full"
+        placeholder="Choose template"
+        aria-label="Select a template"
+      />
+      <Flex justify="flex-end" className="mt-4" gap="small">
+        <Button onClick={onClose} data-testid="cancel-btn">
+          Cancel
+        </Button>
+        <Button
+          onClick={() => onAccept(selectedTemplateId!)}
+          type="primary"
+          data-testid="confirm-btn"
+          disabled={!selectedTemplateId}
+        >
+          Next
+        </Button>
+      </Flex>
     </Modal>
   );
 };

--- a/clients/admin-ui/src/features/messaging-templates/EmailTemplatesForm.tsx
+++ b/clients/admin-ui/src/features/messaging-templates/EmailTemplatesForm.tsx
@@ -1,15 +1,7 @@
 import { SerializedError } from "@reduxjs/toolkit";
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-import {
-  Button,
-  ChakraBox as Box,
-  ChakraFlex as Flex,
-  useMessage,
-} from "fidesui";
-import { Form, Formik, FormikHelpers } from "formik";
+import { Button, Card, Flex, Form, Input, useMessage } from "fidesui";
 
-import FormSection from "~/features/common/form/FormSection";
-import { CustomTextArea, CustomTextInput } from "~/features/common/form/inputs";
 import { getErrorMessage, isErrorResult } from "~/features/common/helpers";
 
 import {
@@ -36,11 +28,17 @@ const EmailTemplatesForm = ({ emailTemplates }: EmailTemplatesFormProps) => {
   const [updateMessagingTemplates, { isLoading }] =
     useUpdateMessagingTemplatesMutation();
   const message = useMessage();
+  const [form] = Form.useForm<EmailTemplatesFormValues>();
 
-  const handleSubmit = async (
-    values: EmailTemplatesFormValues,
-    formikHelpers: FormikHelpers<EmailTemplatesFormValues>,
-  ) => {
+  const initialValues = emailTemplates.reduce(
+    (acc, template) => ({
+      ...acc,
+      [template.type]: { label: template.label, content: template.content },
+    }),
+    {} as EmailTemplatesFormValues,
+  );
+
+  const handleSubmit = async (values: EmailTemplatesFormValues) => {
     const handleResult = (
       result:
         | { data: object }
@@ -54,7 +52,9 @@ const EmailTemplatesForm = ({ emailTemplates }: EmailTemplatesFormProps) => {
         message.error(errorMsg);
       } else {
         message.success("Email templates saved.");
-        formikHelpers.resetForm({ values });
+        // Re-baseline the form so Save becomes disabled again until the next edit.
+        form.resetFields();
+        form.setFieldsValue(values);
       }
     };
 
@@ -70,52 +70,54 @@ const EmailTemplatesForm = ({ emailTemplates }: EmailTemplatesFormProps) => {
     handleResult(result);
   };
 
-  const initialValues = emailTemplates.reduce(
-    (acc, template) => ({
-      ...acc,
-      [template.type]: { label: template.label, content: template.content },
-    }),
-    {} as EmailTemplatesFormValues,
-  );
-
   return (
-    <Formik
-      enableReinitialize
+    <Form
+      form={form}
+      layout="vertical"
       initialValues={initialValues}
-      onSubmit={handleSubmit}
+      onFinish={handleSubmit}
+      className="py-3"
     >
-      {() => (
-        <Form
-          style={{
-            paddingTop: "12px",
-            paddingBottom: "12px",
-          }}
-        >
-          {Object.entries(initialValues).map(([key, value]) => (
-            <Box key={key} py={3}>
-              <FormSection title={value.label}>
-                <CustomTextInput
-                  label="Message subject"
-                  name={`${key}.content.subject`}
-                  variant="stacked"
-                />
-                <CustomTextArea
-                  label="Message body"
-                  name={`${key}.content.body`}
-                  variant="stacked"
-                  resize
-                />
-              </FormSection>
-            </Box>
-          ))}
-          <Flex justifyContent="right" width="100%" paddingTop={2}>
-            <Button htmlType="submit" type="primary" loading={isLoading}>
+      {Object.entries(initialValues).map(([key, value]) => (
+        <Card key={key} title={value.label} className="my-3">
+          <Form.Item
+            name={[key, "content", "subject"]}
+            label="Message subject"
+            rules={[{ required: true, message: "Subject is required" }]}
+          >
+            <Input data-testid={`input-${key}.content.subject`} />
+          </Form.Item>
+          <Form.Item
+            name={[key, "content", "body"]}
+            label="Message body"
+            rules={[{ required: true, message: "Body is required" }]}
+          >
+            <Input.TextArea
+              autoSize={{ minRows: 3 }}
+              data-testid={`input-${key}.content.body`}
+            />
+          </Form.Item>
+        </Card>
+      ))}
+      <Flex justify="flex-end" className="w-full pt-2">
+        <Form.Item shouldUpdate noStyle>
+          {() => (
+            <Button
+              htmlType="submit"
+              type="primary"
+              disabled={
+                !form.isFieldsTouched() ||
+                form.getFieldsError().some(({ errors }) => errors.length > 0)
+              }
+              loading={isLoading}
+              data-testid="submit-btn"
+            >
               Save
             </Button>
-          </Flex>
-        </Form>
-      )}
-    </Formik>
+          )}
+        </Form.Item>
+      </Flex>
+    </Form>
   );
 };
 

--- a/clients/admin-ui/src/features/messaging-templates/EmailTemplatesForm.tsx
+++ b/clients/admin-ui/src/features/messaging-templates/EmailTemplatesForm.tsx
@@ -52,7 +52,10 @@ const EmailTemplatesForm = ({ emailTemplates }: EmailTemplatesFormProps) => {
         message.error(errorMsg);
       } else {
         message.success("Email templates saved.");
-        // Re-baseline the form so Save becomes disabled again until the next edit.
+        // Re-baseline the form: resetFields() clears antd's touched flags (but
+        // reverts to the original initialValues), then setFieldsValue re-applies
+        // the just-saved data on top. Together they make the saved values the
+        // new baseline so Save becomes disabled until the next edit.
         form.resetFields();
         form.setFieldsValue(values);
       }

--- a/clients/admin-ui/src/features/messaging-templates/PropertySpecificMessagingTemplateForm.tsx
+++ b/clients/admin-ui/src/features/messaging-templates/PropertySpecificMessagingTemplateForm.tsx
@@ -1,6 +1,6 @@
 import { NOTIFICATIONS_TEMPLATES_ROUTE } from "common/nav/routes";
 import { Button, Card, Flex, Form, Input, Switch } from "fidesui";
-import { useRouter } from "next/router";
+import NextLink from "next/link";
 
 import { useAppSelector } from "~/app/hooks";
 import ScrollableList from "~/features/common/ScrollableList";
@@ -17,7 +17,7 @@ import { MinimalProperty } from "~/types/api";
 
 interface Props {
   template: MessagingTemplateResponse;
-  handleSubmit: (values: FormValues) => Promise<void>;
+  handleSubmit: (values: FormValues) => Promise<boolean>;
   handleDelete?: () => void;
   isSaving?: boolean;
 }
@@ -70,12 +70,7 @@ const PropertySpecificMessagingTemplateForm = ({
   handleDelete,
   isSaving,
 }: Props) => {
-  const router = useRouter();
   const [form] = Form.useForm<FormValues>();
-
-  const handleCancel = () => {
-    router.push(NOTIFICATIONS_TEMPLATES_ROUTE);
-  };
 
   const initialValues: FormValues = {
     type: template.type,
@@ -85,10 +80,21 @@ const PropertySpecificMessagingTemplateForm = ({
     id: template.id || "",
   };
 
-  // Re-mount the form whenever the upstream template data meaningfully changes
-  // (e.g. after a successful save returning fresh data). This resets antd's
-  // "touched" state without needing a useEffect + setFieldsValue dance.
-  const formKey = `${template.id || template.type}-${template.is_enabled}-${template.content.subject}-${template.content.body}`;
+  // Re-mount the form only when the underlying template identity changes, not
+  // on every content update. Scoping the key this narrowly avoids discarding
+  // in-progress edits if a background refetch returns data that differs from
+  // what the user has typed.
+  const formKey = template.id || template.type;
+
+  const onFinish = async (values: FormValues) => {
+    const succeeded = await handleSubmit(values);
+    if (succeeded) {
+      // Re-baseline after a successful save so `isFieldsTouched()` flips back
+      // to false and Save becomes disabled again until the next edit.
+      form.resetFields();
+      form.setFieldsValue(values);
+    }
+  };
 
   return (
     <Form
@@ -96,7 +102,7 @@ const PropertySpecificMessagingTemplateForm = ({
       form={form}
       layout="vertical"
       initialValues={initialValues}
-      onFinish={handleSubmit}
+      onFinish={onFinish}
       className="py-3"
     >
       <Card
@@ -146,9 +152,9 @@ const PropertySpecificMessagingTemplateForm = ({
           </Button>
         )}
         <Flex justify="flex-end" className="w-full pt-2">
-          <Button className="mr-3" onClick={handleCancel}>
-            Cancel
-          </Button>
+          <NextLink href={NOTIFICATIONS_TEMPLATES_ROUTE} passHref>
+            <Button className="mr-3">Cancel</Button>
+          </NextLink>
           <Form.Item shouldUpdate noStyle>
             {() => (
               <Button

--- a/clients/admin-ui/src/features/messaging-templates/PropertySpecificMessagingTemplateForm.tsx
+++ b/clients/admin-ui/src/features/messaging-templates/PropertySpecificMessagingTemplateForm.tsx
@@ -1,15 +1,8 @@
 import { NOTIFICATIONS_TEMPLATES_ROUTE } from "common/nav/routes";
-import { Button, ChakraBox as Box, ChakraFlex as Flex } from "fidesui";
-import { Form, Formik, useFormikContext } from "formik";
+import { Button, Card, Flex, Form, Input, Switch } from "fidesui";
 import { useRouter } from "next/router";
 
 import { useAppSelector } from "~/app/hooks";
-import FormSection from "~/features/common/form/FormSection";
-import {
-  CustomSwitch,
-  CustomTextArea,
-  CustomTextInput,
-} from "~/features/common/form/inputs";
 import ScrollableList from "~/features/common/ScrollableList";
 import { CustomizableMessagingTemplatesEnum } from "~/features/messaging-templates/CustomizableMessagingTemplatesEnum";
 import CustomizableMessagingTemplatesLabelEnum from "~/features/messaging-templates/CustomizableMessagingTemplatesLabelEnum";
@@ -26,6 +19,7 @@ interface Props {
   template: MessagingTemplateResponse;
   handleSubmit: (values: FormValues) => Promise<void>;
   handleDelete?: () => void;
+  isSaving?: boolean;
 }
 
 export interface FormValues {
@@ -39,25 +33,30 @@ export interface FormValues {
   properties?: MinimalProperty[];
 }
 
-const PropertiesList = () => {
+interface PropertiesListProps {
+  value?: MinimalProperty[];
+  onChange?: (value: MinimalProperty[]) => void;
+}
+
+const PropertiesList = ({ value, onChange }: PropertiesListProps) => {
   const propertyPage = useAppSelector(selectPropertyPage);
   const propertyPageSize = useAppSelector(selectPropertyPageSize);
   useGetAllPropertiesQuery({ page: propertyPage, size: propertyPageSize });
   const allProperties = useAppSelector(selectAllProperties);
-  const { values, setFieldValue } = useFormikContext<FormValues>();
 
   return (
     <ScrollableList
-      label="Associated properties"
       addButtonLabel="Add property"
       idField="id"
       nameField="name"
-      allItems={allProperties.map((property) => ({
-        id: property.id,
-        name: property.name,
-      }))}
-      values={values.properties ?? []}
-      setValues={(newValues) => setFieldValue("properties", newValues)}
+      allItems={allProperties.reduce<MinimalProperty[]>((acc, property) => {
+        if (property.id) {
+          acc.push({ id: property.id, name: property.name });
+        }
+        return acc;
+      }, [])}
+      values={value ?? []}
+      setValues={(newValues) => onChange?.(newValues)}
       draggable
       maxHeight={100}
       baseTestId="property"
@@ -69,14 +68,16 @@ const PropertySpecificMessagingTemplateForm = ({
   template,
   handleSubmit,
   handleDelete,
+  isSaving,
 }: Props) => {
   const router = useRouter();
+  const [form] = Form.useForm<FormValues>();
 
   const handleCancel = () => {
     router.push(NOTIFICATIONS_TEMPLATES_ROUTE);
   };
 
-  const initialValues: MessagingTemplateResponse = {
+  const initialValues: FormValues = {
     type: template.type,
     content: template.content,
     properties: template.properties || [],
@@ -84,80 +85,89 @@ const PropertySpecificMessagingTemplateForm = ({
     id: template.id || "",
   };
 
+  // Re-mount the form whenever the upstream template data meaningfully changes
+  // (e.g. after a successful save returning fresh data). This resets antd's
+  // "touched" state without needing a useEffect + setFieldsValue dance.
+  const formKey = `${template.id || template.type}-${template.is_enabled}-${template.content.subject}-${template.content.body}`;
+
   return (
-    <Formik
-      enableReinitialize
+    <Form
+      key={formKey}
+      form={form}
+      layout="vertical"
       initialValues={initialValues}
-      onSubmit={handleSubmit}
+      onFinish={handleSubmit}
+      className="py-3"
     >
-      {({ dirty, isValid, isSubmitting }) => (
-        <Form
-          style={{
-            paddingTop: "12px",
-            paddingBottom: "12px",
-          }}
+      <Card
+        title={
+          CustomizableMessagingTemplatesLabelEnum[
+            initialValues.type as CustomizableMessagingTemplatesEnum
+          ]
+        }
+        className="my-3"
+      >
+        <Form.Item
+          name={["content", "subject"]}
+          label="Email subject"
+          rules={[{ required: true, message: "Subject is required" }]}
         >
-          <Box py={3}>
-            <FormSection
-              title={`${
-                CustomizableMessagingTemplatesLabelEnum[
-                  initialValues.type as CustomizableMessagingTemplatesEnum
-                ]
-              }`}
-            >
-              <CustomTextInput
-                isRequired
-                label="Email subject"
-                name="content.subject"
-                variant="stacked"
-              />
-              <CustomTextArea
-                isRequired
-                label="Message body"
-                name="content.body"
-                value="test"
-                variant="stacked"
-                resize
-              />
-              <Box py={3}>
-                <PropertiesList />
-              </Box>
-              <CustomSwitch
-                name="is_enabled"
-                label="Enable message"
-                variant="switchFirst"
-              />
-            </FormSection>
-          </Box>
-          <Flex justifyContent="space-between" width="100%" paddingTop={2}>
-            {initialValues.id && handleDelete && (
-              <Button
-                data-testid="delete-template-button"
-                loading={false}
-                className="mr-3"
-                onClick={handleDelete}
-              >
-                Delete
-              </Button>
-            )}
-            <Flex justifyContent="right" width="100%" paddingTop={2}>
-              <Button loading={false} className="mr-3" onClick={handleCancel}>
-                Cancel
-              </Button>
+          <Input data-testid="input-content.subject" />
+        </Form.Item>
+        <Form.Item
+          name={["content", "body"]}
+          label="Message body"
+          rules={[{ required: true, message: "Body is required" }]}
+        >
+          <Input.TextArea
+            autoSize={{ minRows: 3 }}
+            data-testid="input-content.body"
+          />
+        </Form.Item>
+        <Form.Item name="properties" label="Associated properties">
+          <PropertiesList />
+        </Form.Item>
+        <Form.Item
+          name="is_enabled"
+          label="Enable message"
+          valuePropName="checked"
+        >
+          <Switch data-testid="input-is_enabled" />
+        </Form.Item>
+      </Card>
+      <Flex justify="space-between" className="w-full pt-2">
+        {initialValues.id && handleDelete && (
+          <Button
+            data-testid="delete-template-button"
+            className="mr-3"
+            onClick={handleDelete}
+          >
+            Delete
+          </Button>
+        )}
+        <Flex justify="flex-end" className="w-full pt-2">
+          <Button className="mr-3" onClick={handleCancel}>
+            Cancel
+          </Button>
+          <Form.Item shouldUpdate noStyle>
+            {() => (
               <Button
                 htmlType="submit"
                 type="primary"
-                disabled={isSubmitting || !dirty || !isValid}
-                loading={isSubmitting}
+                disabled={
+                  !form.isFieldsTouched() ||
+                  form.getFieldsError().some(({ errors }) => errors.length > 0)
+                }
+                loading={isSaving}
                 data-testid="submit-btn"
               >
                 Save
               </Button>
-            </Flex>
-          </Flex>
-        </Form>
-      )}
-    </Formik>
+            )}
+          </Form.Item>
+        </Flex>
+      </Flex>
+    </Form>
   );
 };
 

--- a/clients/admin-ui/src/pages/notifications/templates/[id].tsx
+++ b/clients/admin-ui/src/pages/notifications/templates/[id].tsx
@@ -37,7 +37,8 @@ const EditNotificationTemplatePage: NextPage = () => {
     error,
   } = useGetMessagingTemplateByIdQuery(templateId as string);
 
-  const [putMessagingTemplate] = usePutMessagingTemplateByIdMutation();
+  const [putMessagingTemplate, { isLoading: isSaving }] =
+    usePutMessagingTemplateByIdMutation();
   const [deleteMessagingTemplate] = useDeleteMessagingTemplateByIdMutation();
 
   const handleSubmit = async (values: FormValues) => {
@@ -128,6 +129,7 @@ const EditNotificationTemplatePage: NextPage = () => {
           template={messagingTemplate}
           handleSubmit={handleSubmit}
           handleDelete={onDeleteOpen}
+          isSaving={isSaving}
         />
       </Box>
       <ConfirmationModal

--- a/clients/admin-ui/src/pages/notifications/templates/[id].tsx
+++ b/clients/admin-ui/src/pages/notifications/templates/[id].tsx
@@ -41,7 +41,7 @@ const EditNotificationTemplatePage: NextPage = () => {
     usePutMessagingTemplateByIdMutation();
   const [deleteMessagingTemplate] = useDeleteMessagingTemplateByIdMutation();
 
-  const handleSubmit = async (values: FormValues) => {
+  const handleSubmit = async (values: FormValues): Promise<boolean> => {
     const templateData: MessagingTemplateCreateOrUpdate = {
       is_enabled: values.is_enabled,
       content: {
@@ -61,10 +61,11 @@ const EditNotificationTemplatePage: NextPage = () => {
 
     if (isErrorResult(result)) {
       message.error(getErrorMessage(result.error));
-      return;
+      return false;
     }
 
     message.success(`Messaging template updated successfully`);
+    return true;
   };
 
   const {

--- a/clients/admin-ui/src/pages/notifications/templates/add-template.tsx
+++ b/clients/admin-ui/src/pages/notifications/templates/add-template.tsx
@@ -21,7 +21,8 @@ const AddNotificationTemplatePage: NextPage = () => {
   const message = useMessage();
   const router = useRouter();
   const { templateType } = router.query;
-  const [createMessagingTemplate] = useCreateMessagingTemplateByTypeMutation();
+  const [createMessagingTemplate, { isLoading: isSaving }] =
+    useCreateMessagingTemplateByTypeMutation();
   const { data: messagingTemplate, isLoading } =
     useGetMessagingTemplateDefaultQuery(templateType as string);
 
@@ -75,6 +76,7 @@ const AddNotificationTemplatePage: NextPage = () => {
             <PropertySpecificMessagingTemplateForm
               template={messagingTemplate}
               handleSubmit={handleSubmit}
+              isSaving={isSaving}
             />
           </Box>
         </Box>

--- a/clients/admin-ui/src/pages/notifications/templates/add-template.tsx
+++ b/clients/admin-ui/src/pages/notifications/templates/add-template.tsx
@@ -26,7 +26,7 @@ const AddNotificationTemplatePage: NextPage = () => {
   const { data: messagingTemplate, isLoading } =
     useGetMessagingTemplateDefaultQuery(templateType as string);
 
-  const handleSubmit = async (values: FormValues) => {
+  const handleSubmit = async (values: FormValues): Promise<boolean> => {
     const templateData: MessagingTemplateCreateOrUpdate = {
       is_enabled: values.is_enabled,
       content: {
@@ -45,11 +45,12 @@ const AddNotificationTemplatePage: NextPage = () => {
 
     if (isErrorResult(result)) {
       message.error(getErrorMessage(result.error));
-      return;
+      return false;
     }
 
     message.success(`Messaging template created successfully`);
     router.push(NOTIFICATIONS_TEMPLATES_ROUTE);
+    return true;
   };
 
   if (!messagingTemplate) {


### PR DESCRIPTION
Ticket [ENG-3180]

### Description Of Changes

Part of the ENG-3165 epic to eliminate Chakra form components across admin-ui. The messaging template forms in `clients/admin-ui/src/features/messaging-templates/` previously used Formik + Chakra-backed wrappers (`CustomTextInput`, `CustomTextArea`, `CustomSwitch`). They now use antd `Form` + `Form.Item` + native antd inputs, matching the pattern established by `OrganizationForm`, `SharedMonitorConfigForm`, and `DeleteUserModal`.

API contracts and submit payload shapes are unchanged so the backend is unaffected and existing Cypress coverage stays valid. The Save button derives its disabled state directly from `form.isFieldsTouched()` + `form.getFieldsError()` inside a `shouldUpdate` render-prop — no extra `useState`/`useEffect` for dirty tracking. The form re-mounts via a content-hashed `key` prop so antd's "touched" state resets after a successful save without a `setFieldsValue` dance.

`AddMessagingTemplateModal` was also tidied up: it now uses the standard modal body pattern (`footer={null}` with action buttons inside the body), `Typography.Paragraph` instead of bespoke Tailwind, and the `template-type-selector` test id sits directly on the `<Select>`.

### Code Changes

* `PropertySpecificMessagingTemplateForm.tsx` — Formik → antd `Form`. Replaced `CustomTextInput`/`CustomTextArea`/`CustomSwitch` with `Input`/`Input.TextArea`/`Switch`. Wrapped `ScrollableList` in a controlled `PropertiesList` adapter that bridges antd's `value`/`onChange` to ScrollableList's `values`/`setValues`. Replaced `FormSection` with antd `Card`. Submit-button disabled state derives from form built-ins inside a `shouldUpdate` render-prop. Form re-mounts via a content-hash `key` to reset touched state after save.
* `EmailTemplatesForm.tsx` — Formik → antd `Form` with nested `name` arrays. `form.resetFields()` + `form.setFieldsValue(values)` re-baselines after a successful save. Same `shouldUpdate` submit pattern. `FormSection` replaced with antd `Card`.
* `AddMessagingTemplateModal.tsx` — dropped `ChakraBox`/`ChakraText` aliases. Moved action buttons out of the `footer` prop into the standard body `Flex`. Switched description copy to `Typography.Paragraph`. Removed the wrapper `<div>` around `Select` and moved `data-testid="template-type-selector"` directly onto the `Select`. Fixed a pre-existing invalid `gap="medium"` → `gap="small"` on antd `Flex`.
* `pages/notifications/templates/add-template.tsx` and `[id].tsx` — destructure `isLoading` off the create/put mutation and pass as `isSaving` prop to the form (the form no longer owns the submitting state).
* `cypress/e2e/messaging.cy.ts` — updated the template-type-selector assertion to call `.antSelect(...)` directly on the testid'd Select element instead of `.find(".ant-select").antSelect(...)`.

### Steps to Confirm

1. `cd clients/admin-ui && npm run dev`, log in with `root_user` / `Testpassword1!`
2. **Settings → Email templates:** edit a subject and body, confirm Save enables only after a change, save succeeds and shows a toast.
3. **Notifications → Templates → New:** open the modal, pick a template type from the Select, confirm Next enables and routes to the add page.
4. **Add a property-specific template:** fill subject/body, toggle Enable, attach properties, save — confirm redirect + success toast.
5. **Edit an existing property-specific template:** confirm initial values populate, Save is disabled until you edit, Delete still opens the confirmation modal.
6. **Validation:** clear required fields and submit — verify inline `rules` errors display under each field.
7. Run `npx cypress run --spec cypress/e2e/messaging.cy.ts` from `clients/admin-ui` — should pass.

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-3180]: https://ethyca.atlassian.net/browse/ENG-3180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ