### PR TITLE
ENG-3461: migrate admin-ui to RouterLink and remove legacyBehavior

### DIFF
--- a/changelog/7942-eng-3461-router-link-legacy-behavior.yaml
+++ b/changelog/7942-eng-3461-router-link-legacy-behavior.yaml
@@ -1,0 +1,4 @@
+type: Developer Experience
+description: Replaced deprecated `next/link` `legacyBehavior`/`passHref` usage in the Admin UI with a shared `RouterLink` component for internal navigation.
+pr: 7942
+labels: []

--- a/clients/admin-ui/cypress/e2e/action-center/aggregate-results.cy.ts
+++ b/clients/admin-ui/cypress/e2e/action-center/aggregate-results.cy.ts
@@ -82,14 +82,14 @@ describe("Action center", () => {
       // cy.getByTestId(`add-button-${webMonitorKey}`).should("exist");
       // Review button
       cy.getByTestId(`review-button-${webMonitorKey}`)
-        .parent("a")
+        .closest("a")
         .should(
           "have.attr",
           "href",
           `${ACTION_CENTER_ROUTE}/${APIMonitorType.WEBSITE}/${webMonitorKey}`,
         );
       cy.getByTestId(`review-button-${integrationMonitorKey}`)
-        .parent("a")
+        .closest("a")
         .should(
           "have.attr",
           "href",

--- a/clients/admin-ui/cypress/e2e/action-center/aggregate-results.cy.ts
+++ b/clients/admin-ui/cypress/e2e/action-center/aggregate-results.cy.ts
@@ -81,16 +81,20 @@ describe("Action center", () => {
       // TODO: [HJ-337] uncomment when Add button is implemented
       // cy.getByTestId(`add-button-${webMonitorKey}`).should("exist");
       // Review button
-      cy.getByTestId(`review-button-${webMonitorKey}`).should(
-        "have.attr",
-        "href",
-        `${ACTION_CENTER_ROUTE}/${APIMonitorType.WEBSITE}/${webMonitorKey}`,
-      );
-      cy.getByTestId(`review-button-${integrationMonitorKey}`).should(
-        "have.attr",
-        "href",
-        `${ACTION_CENTER_ROUTE}/${APIMonitorType.DATASTORE}/${integrationMonitorKey}`,
-      );
+      cy.getByTestId(`review-button-${webMonitorKey}`)
+        .parent("a")
+        .should(
+          "have.attr",
+          "href",
+          `${ACTION_CENTER_ROUTE}/${APIMonitorType.WEBSITE}/${webMonitorKey}`,
+        );
+      cy.getByTestId(`review-button-${integrationMonitorKey}`)
+        .parent("a")
+        .should(
+          "have.attr",
+          "href",
+          `${ACTION_CENTER_ROUTE}/${APIMonitorType.DATASTORE}/${integrationMonitorKey}`,
+        );
     });
     it.skip("Should paginate results", () => {
       // TODO: mock pagination and also test skeleton loading state

--- a/clients/admin-ui/src/features/access-policies/ControlForm.tsx
+++ b/clients/admin-ui/src/features/access-policies/ControlForm.tsx
@@ -1,7 +1,7 @@
 import { Button, Flex, Form, Input } from "fidesui";
-import NextLink from "next/link";
 import { useMemo } from "react";
 
+import { RouterLink } from "~/features/common/nav/RouterLink";
 import { CONTROLS_ROUTE } from "~/features/common/nav/routes";
 
 import type { Control } from "./access-policies.slice";
@@ -59,9 +59,9 @@ const ControlForm = ({
         <Button type="primary" htmlType="submit" loading={isSubmitting}>
           {isEditing ? "Save" : "Create control"}
         </Button>
-        <NextLink href={CONTROLS_ROUTE} passHref>
+        <RouterLink href={CONTROLS_ROUTE}>
           <Button>Cancel</Button>
-        </NextLink>
+        </RouterLink>
       </Flex>
     </Form>
   );

--- a/clients/admin-ui/src/features/access-policies/PolicyCard.tsx
+++ b/clients/admin-ui/src/features/access-policies/PolicyCard.tsx
@@ -8,18 +8,15 @@ import {
   Tag,
   Text,
   Tooltip,
-  Typography,
 } from "fidesui";
-import NextLink from "next/link";
 
+import { RouterLink } from "~/features/common/nav/RouterLink";
 import { ACCESS_POLICY_EDIT_ROUTE } from "~/features/common/nav/routes";
 
 import DecisionTag from "./DecisionTag";
 import styles from "./PolicyCard.module.scss";
 import { AccessPolicyListItem } from "./types";
 import { formatRelativeTime } from "./utils";
-
-const { Link: LinkText } = Typography;
 
 interface PolicyCardProps {
   policy: AccessPolicyListItem;
@@ -34,25 +31,18 @@ const PolicyCard = ({ policy, onToggle }: PolicyCardProps) => {
           {/* Header */}
           <Flex justify="space-between" align="flex-start">
             <Flex gap="small" align="center" className="min-w-0">
-              {/* legacyBehavior is required: Typography.Link renders <a>, and
-                  Next.js 13 Link also renders <a> — without it we'd get nested anchors */}
-              <NextLink
+              <RouterLink
                 href={{
                   pathname: ACCESS_POLICY_EDIT_ROUTE,
                   query: { id: policy.id },
                 }}
-                passHref
-                legacyBehavior
+                strong
+                ellipsis
+                variant="primary"
+                className={styles.policyName}
               >
-                <LinkText
-                  strong
-                  ellipsis
-                  variant="primary"
-                  className={styles.policyName}
-                >
-                  {policy.name}
-                </LinkText>
-              </NextLink>
+                {policy.name}
+              </RouterLink>
             </Flex>
             <Flex gap="small" align="center" className="shrink-0">
               {policy.is_recommendation && (

--- a/clients/admin-ui/src/features/common/nav/RouterLink.test.tsx
+++ b/clients/admin-ui/src/features/common/nav/RouterLink.test.tsx
@@ -1,22 +1,116 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { Button } from "fidesui";
 
-import { RouterLink } from "./RouterLink";
+import { formatHref, RouterLink } from "./RouterLink";
 
-const mockPush = jest.fn();
+const mockPush = jest.fn().mockResolvedValue(true);
+const mockReplace = jest.fn().mockResolvedValue(true);
+const mockPrefetch = jest.fn().mockResolvedValue(undefined);
 
 jest.mock("next/router", () => ({
   useRouter: () => ({
     push: mockPush,
+    replace: mockReplace,
+    prefetch: mockPrefetch,
     pathname: "/",
     query: {},
     asPath: "/",
   }),
 }));
 
+describe("formatHref", () => {
+  it("returns just the pathname when no query or hash is present", () => {
+    expect(formatHref({ pathname: "/policies" })).toBe("/policies");
+  });
+
+  it("returns an empty string when given an empty UrlObject", () => {
+    expect(formatHref({})).toBe("");
+  });
+
+  it("serializes a single query param", () => {
+    expect(formatHref({ pathname: "/policies", query: { id: "abc" } })).toBe(
+      "/policies?id=abc",
+    );
+  });
+
+  it("serializes multiple query params", () => {
+    expect(
+      formatHref({ pathname: "/policies", query: { id: "abc", page: "2" } }),
+    ).toBe("/policies?id=abc&page=2");
+  });
+
+  it("serializes array query values as repeated keys", () => {
+    expect(
+      formatHref({ pathname: "/policies", query: { tag: ["a", "b"] } }),
+    ).toBe("/policies?tag=a&tag=b");
+  });
+
+  it("skips null and undefined query values", () => {
+    expect(
+      formatHref({
+        pathname: "/policies",
+        query: {
+          id: "abc",
+          missing: undefined,
+          also: null as unknown as string,
+        },
+      }),
+    ).toBe("/policies?id=abc");
+  });
+
+  it("URL-encodes special characters in query values", () => {
+    expect(
+      formatHref({ pathname: "/policies", query: { name: "hello world&" } }),
+    ).toBe("/policies?name=hello+world%26");
+  });
+
+  it("appends a hash, prefixing # when missing", () => {
+    expect(formatHref({ pathname: "/docs", hash: "section" })).toBe(
+      "/docs#section",
+    );
+    expect(formatHref({ pathname: "/docs", hash: "#section" })).toBe(
+      "/docs#section",
+    );
+  });
+
+  it("uses an explicit search string and ignores query when both are set", () => {
+    expect(
+      formatHref({
+        pathname: "/policies",
+        search: "id=abc",
+        query: { ignored: "yes" },
+      }),
+    ).toBe("/policies?id=abc");
+  });
+
+  it("preserves a leading ? on search", () => {
+    expect(formatHref({ pathname: "/policies", search: "?id=abc" })).toBe(
+      "/policies?id=abc",
+    );
+  });
+
+  it("treats a string query as a pre-encoded query string", () => {
+    expect(formatHref({ pathname: "/policies", query: "id=abc&page=2" })).toBe(
+      "/policies?id=abc&page=2",
+    );
+  });
+
+  it("combines pathname, query, and hash", () => {
+    expect(
+      formatHref({
+        pathname: "/policies",
+        query: { id: "abc" },
+        hash: "details",
+      }),
+    ).toBe("/policies?id=abc#details");
+  });
+});
+
 describe("RouterLink", () => {
   beforeEach(() => {
     mockPush.mockClear();
+    mockReplace.mockClear();
+    mockPrefetch.mockClear();
   });
 
   describe("with an antd Button child", () => {
@@ -84,7 +178,9 @@ describe("RouterLink", () => {
       fireEvent.click(screen.getByRole("link", { name: "My policy" }), {
         button: 0,
       });
-      expect(mockPush).toHaveBeenCalledWith(href);
+      expect(mockPush).toHaveBeenCalledWith(href, undefined, {
+        scroll: undefined,
+      });
     });
 
     it("does not intercept meta/ctrl/shift/alt/middle clicks", () => {
@@ -140,7 +236,63 @@ describe("RouterLink", () => {
       // Text mode uses Typography.Link which renders an <a>; clicking should
       // trigger router.push, proving the component did not take the wrap path.
       fireEvent.click(screen.getByRole("link"));
-      expect(mockPush).toHaveBeenCalledWith("/details");
+      expect(mockPush).toHaveBeenCalledWith("/details", undefined, {
+        scroll: undefined,
+      });
+    });
+
+    it("calls router.replace instead of router.push when replace is true", () => {
+      render(
+        <RouterLink href="/details" replace>
+          Details
+        </RouterLink>,
+      );
+
+      fireEvent.click(screen.getByRole("link", { name: "Details" }));
+      expect(mockReplace).toHaveBeenCalledWith("/details", undefined, {
+        scroll: undefined,
+      });
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+
+    it("forwards the scroll option to router.push", () => {
+      render(
+        <RouterLink href="/details" scroll={false}>
+          Details
+        </RouterLink>,
+      );
+
+      fireEvent.click(screen.getByRole("link", { name: "Details" }));
+      expect(mockPush).toHaveBeenCalledWith("/details", undefined, {
+        scroll: false,
+      });
+    });
+
+    it("does not prefetch on mount when prefetch is false", () => {
+      render(
+        <RouterLink href="/details" prefetch={false}>
+          Details
+        </RouterLink>,
+      );
+      expect(mockPrefetch).not.toHaveBeenCalled();
+    });
+
+    it("does not prefetch on mount when prefetch is null but does on hover", () => {
+      render(
+        <RouterLink href="/details" prefetch={null}>
+          Details
+        </RouterLink>,
+      );
+      expect(mockPrefetch).not.toHaveBeenCalled();
+
+      fireEvent.mouseEnter(screen.getByRole("link", { name: "Details" }));
+      expect(mockPrefetch).toHaveBeenCalledWith("/details");
+    });
+
+    it("does not prefetch on mount in non-production builds", () => {
+      // jest runs with NODE_ENV=test, so default prefetch behaviour is a no-op
+      render(<RouterLink href="/details">Details</RouterLink>);
+      expect(mockPrefetch).not.toHaveBeenCalled();
     });
   });
 });

--- a/clients/admin-ui/src/features/common/nav/RouterLink.test.tsx
+++ b/clients/admin-ui/src/features/common/nav/RouterLink.test.tsx
@@ -32,6 +32,18 @@ describe("RouterLink", () => {
       expect(anchor.querySelector("button")).not.toBeNull();
     });
 
+    it("forwards target and rel to the next/link anchor", () => {
+      render(
+        <RouterLink href="/dashboard" target="_blank" rel="noopener noreferrer">
+          <Button>External</Button>
+        </RouterLink>,
+      );
+
+      const anchor = screen.getByRole("link", { name: "External" });
+      expect(anchor).toHaveAttribute("target", "_blank");
+      expect(anchor).toHaveAttribute("rel", "noopener noreferrer");
+    });
+
     it("does not call router.push on click (next/link handles it)", () => {
       render(
         <RouterLink href="/dashboard">
@@ -98,6 +110,20 @@ describe("RouterLink", () => {
 
       fireEvent.click(screen.getByRole("link", { name: "Details" }));
       expect(onClick).toHaveBeenCalledTimes(1);
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+
+    it("does not intercept clicks when target=_blank", () => {
+      render(
+        <RouterLink href="/details" target="_blank" rel="noopener noreferrer">
+          External details
+        </RouterLink>,
+      );
+      const anchor = screen.getByRole("link", { name: "External details" });
+      expect(anchor).toHaveAttribute("target", "_blank");
+      expect(anchor).toHaveAttribute("rel", "noopener noreferrer");
+
+      fireEvent.click(anchor, { button: 0 });
       expect(mockPush).not.toHaveBeenCalled();
     });
 

--- a/clients/admin-ui/src/features/common/nav/RouterLink.test.tsx
+++ b/clients/admin-ui/src/features/common/nav/RouterLink.test.tsx
@@ -1,0 +1,120 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { Button } from "fidesui";
+
+import { RouterLink } from "./RouterLink";
+
+const mockPush = jest.fn();
+
+jest.mock("next/router", () => ({
+  useRouter: () => ({
+    push: mockPush,
+    pathname: "/",
+    query: {},
+    asPath: "/",
+  }),
+}));
+
+describe("RouterLink", () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+  });
+
+  describe("with an antd Button child", () => {
+    it("wraps the button in a next/link anchor with the given href", () => {
+      render(
+        <RouterLink href="/dashboard">
+          <Button>Go</Button>
+        </RouterLink>,
+      );
+
+      const anchor = screen.getByRole("link", { name: "Go" });
+      expect(anchor).toHaveAttribute("href", "/dashboard");
+      expect(anchor.querySelector("button")).not.toBeNull();
+    });
+
+    it("does not call router.push on click (next/link handles it)", () => {
+      render(
+        <RouterLink href="/dashboard">
+          <Button>Go</Button>
+        </RouterLink>,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Go" }));
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("with non-Button children", () => {
+    it("renders a Typography.Link-styled anchor with the resolved href", () => {
+      render(<RouterLink href="/details">Details</RouterLink>);
+
+      const anchor = screen.getByRole("link", { name: "Details" });
+      expect(anchor).toHaveAttribute("href", "/details");
+    });
+
+    it("serializes a UrlObject href for the anchor attribute", () => {
+      render(
+        <RouterLink href={{ pathname: "/policies", query: { id: "abc" } }}>
+          My policy
+        </RouterLink>,
+      );
+
+      expect(screen.getByRole("link", { name: "My policy" })).toHaveAttribute(
+        "href",
+        "/policies?id=abc",
+      );
+    });
+
+    it("calls router.push with the original href on plain left click", () => {
+      const href = { pathname: "/policies", query: { id: "abc" } };
+      render(<RouterLink href={href}>My policy</RouterLink>);
+
+      fireEvent.click(screen.getByRole("link", { name: "My policy" }), {
+        button: 0,
+      });
+      expect(mockPush).toHaveBeenCalledWith(href);
+    });
+
+    it("does not intercept meta/ctrl/shift/alt/middle clicks", () => {
+      render(<RouterLink href="/details">Details</RouterLink>);
+      const anchor = screen.getByRole("link", { name: "Details" });
+
+      fireEvent.click(anchor, { button: 0, metaKey: true });
+      fireEvent.click(anchor, { button: 0, ctrlKey: true });
+      fireEvent.click(anchor, { button: 0, shiftKey: true });
+      fireEvent.click(anchor, { button: 0, altKey: true });
+      fireEvent.click(anchor, { button: 1 });
+
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+
+    it("runs a custom onClick before the default handler and respects preventDefault", () => {
+      const onClick = jest.fn((e) => e.preventDefault());
+      render(
+        <RouterLink href="/details" onClick={onClick}>
+          Details
+        </RouterLink>,
+      );
+
+      fireEvent.click(screen.getByRole("link", { name: "Details" }));
+      expect(onClick).toHaveBeenCalledTimes(1);
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+
+    it("falls through to text mode when a Button is wrapped in a fragment", () => {
+      render(
+        <RouterLink href="/details">
+          {/* eslint-disable-next-line react/jsx-no-useless-fragment */}
+          <>
+            <Button>Go</Button>
+          </>
+        </RouterLink>,
+      );
+
+      // Text mode uses Typography.Link which renders an <a>; clicking should
+      // trigger router.push, proving the component did not take the wrap path.
+      fireEvent.click(screen.getByRole("link"));
+      expect(mockPush).toHaveBeenCalledWith("/details");
+    });
+  });
+});

--- a/clients/admin-ui/src/features/common/nav/RouterLink.tsx
+++ b/clients/admin-ui/src/features/common/nav/RouterLink.tsx
@@ -63,6 +63,8 @@ export const RouterLink = ({
   replace,
   scroll,
   prefetch,
+  target,
+  rel,
   ...typographyProps
 }: RouterLinkProps) => {
   const router = useRouter();
@@ -74,6 +76,8 @@ export const RouterLink = ({
         replace={replace}
         scroll={scroll}
         prefetch={prefetch}
+        target={target}
+        rel={rel}
       >
         {children}
       </NextLink>
@@ -85,6 +89,8 @@ export const RouterLink = ({
   return (
     <TypographyLink
       href={hrefString}
+      target={target}
+      rel={rel}
       onClick={(e) => {
         onClick?.(e);
         if (
@@ -93,7 +99,8 @@ export const RouterLink = ({
           e.metaKey ||
           e.ctrlKey ||
           e.shiftKey ||
-          e.altKey
+          e.altKey ||
+          target === "_blank"
         ) {
           // Let the browser handle new-tab / modified clicks natively.
           return;

--- a/clients/admin-ui/src/features/common/nav/RouterLink.tsx
+++ b/clients/admin-ui/src/features/common/nav/RouterLink.tsx
@@ -1,5 +1,4 @@
 import { Button, Typography } from "fidesui";
-import { formatUrl } from "next/dist/shared/lib/router/utils/format-url";
 import NextLink, { LinkProps as NextLinkProps } from "next/link";
 import { useRouter } from "next/router";
 import {
@@ -8,12 +7,44 @@ import {
   isValidElement,
   MouseEvent,
   ReactNode,
+  useCallback,
+  useEffect,
 } from "react";
 import type { UrlObject } from "url";
 
 const { Link: TypographyLink } = Typography;
 
 type Href = string | UrlObject;
+
+export const formatHref = (url: UrlObject): string => {
+  const pathname = url.pathname ?? "";
+  let search = "";
+  if (url.search) {
+    search = url.search.startsWith("?") ? url.search : `?${url.search}`;
+  } else if (url.query) {
+    const params =
+      typeof url.query === "string"
+        ? url.query
+        : new URLSearchParams(
+            Object.entries(url.query).flatMap(([k, v]) => {
+              if (v === null || v === undefined) {
+                return [];
+              }
+              return Array.isArray(v)
+                ? v.map((item) => [k, String(item)] as [string, string])
+                : [[k, String(v)] as [string, string]];
+            }),
+          ).toString();
+    if (params) {
+      search = `?${params}`;
+    }
+  }
+  let hash = "";
+  if (url.hash) {
+    hash = url.hash.startsWith("#") ? url.hash : `#${url.hash}`;
+  }
+  return `${pathname}${search}${hash}`;
+};
 
 type TypographyLinkProps = Omit<
   ComponentProps<typeof TypographyLink>,
@@ -24,11 +55,8 @@ export interface RouterLinkProps extends TypographyLinkProps {
   href: Href;
   children: ReactNode;
   onClick?: (e: MouseEvent<HTMLElement>) => void;
-  /** Forwarded to next/link when the child is a Button. */
   replace?: NextLinkProps["replace"];
-  /** Forwarded to next/link when the child is a Button. */
   scroll?: NextLinkProps["scroll"];
-  /** Forwarded to next/link when the child is a Button. */
   prefetch?: NextLinkProps["prefetch"];
 }
 
@@ -68,8 +96,29 @@ export const RouterLink = ({
   ...typographyProps
 }: RouterLinkProps) => {
   const router = useRouter();
+  const isButtonChild = isAntButtonChild(children);
+  const hrefString = typeof href === "string" ? href : formatHref(href);
 
-  if (isAntButtonChild(children)) {
+  const prefetchHref = useCallback(() => {
+    router.prefetch(hrefString).catch(() => {
+      // prefetch is best-effort; ignore failures
+    });
+  }, [router, hrefString]);
+
+  useEffect(() => {
+    if (
+      isButtonChild ||
+      process.env.NODE_ENV !== "production" ||
+      prefetch === false ||
+      prefetch === null ||
+      target === "_blank"
+    ) {
+      return;
+    }
+    prefetchHref();
+  }, [isButtonChild, prefetch, prefetchHref, target]);
+
+  if (isButtonChild) {
     return (
       <NextLink
         href={href}
@@ -84,13 +133,12 @@ export const RouterLink = ({
     );
   }
 
-  const hrefString = typeof href === "string" ? href : formatUrl(href);
-
   return (
     <TypographyLink
       href={hrefString}
       target={target}
       rel={rel}
+      onMouseEnter={prefetch === null ? prefetchHref : undefined}
       onClick={(e) => {
         onClick?.(e);
         if (
@@ -106,7 +154,12 @@ export const RouterLink = ({
           return;
         }
         e.preventDefault();
-        router.push(href);
+        const navigation = replace
+          ? router.replace(href, undefined, { scroll })
+          : router.push(href, undefined, { scroll });
+        navigation.catch(() => {
+          // navigation errors are surfaced by Next's own error handling
+        });
       }}
       {...typographyProps}
     >

--- a/clients/admin-ui/src/features/common/nav/RouterLink.tsx
+++ b/clients/admin-ui/src/features/common/nav/RouterLink.tsx
@@ -1,0 +1,109 @@
+import { Button, Typography } from "fidesui";
+import { formatUrl } from "next/dist/shared/lib/router/utils/format-url";
+import NextLink, { LinkProps as NextLinkProps } from "next/link";
+import { useRouter } from "next/router";
+import {
+  Children,
+  ComponentProps,
+  isValidElement,
+  MouseEvent,
+  ReactNode,
+} from "react";
+import type { UrlObject } from "url";
+
+const { Link: TypographyLink } = Typography;
+
+type Href = string | UrlObject;
+
+type TypographyLinkProps = Omit<
+  ComponentProps<typeof TypographyLink>,
+  "href" | "onClick"
+>;
+
+export interface RouterLinkProps extends TypographyLinkProps {
+  href: Href;
+  children: ReactNode;
+  onClick?: (e: MouseEvent<HTMLElement>) => void;
+  /** Forwarded to next/link when the child is a Button. */
+  replace?: NextLinkProps["replace"];
+  /** Forwarded to next/link when the child is a Button. */
+  scroll?: NextLinkProps["scroll"];
+  /** Forwarded to next/link when the child is a Button. */
+  prefetch?: NextLinkProps["prefetch"];
+}
+
+const isAntButtonChild = (children: ReactNode): boolean => {
+  const arr = Children.toArray(children);
+  if (arr.length !== 1) {
+    return false;
+  }
+  const [only] = arr;
+  return isValidElement(only) && only.type === Button;
+};
+
+/**
+ * Shared internal-navigation link for admin-ui.
+ *
+ * - When the single child is an antd `Button`, wraps it in `next/link` so
+ *   Next renders its own `<a>` around the button. Preserves client-side
+ *   routing, prefetch, and modifier-click handling.
+ * - Otherwise renders a `Typography.Link`-styled anchor that intercepts
+ *   plain left-clicks and uses `router.push` for client-side navigation.
+ *   Modifier, middle, and right clicks fall through to the browser so
+ *   new-tab / copy-link behaviour continues to work.
+ *
+ * Detection is structural (only a single antd `Button` element is detected).
+ * If you need to wrap a custom button-like component, extract its render
+ * and wrap the real antd `Button`, or add a `button` escape-hatch prop.
+ */
+export const RouterLink = ({
+  href,
+  children,
+  onClick,
+  replace,
+  scroll,
+  prefetch,
+  ...typographyProps
+}: RouterLinkProps) => {
+  const router = useRouter();
+
+  if (isAntButtonChild(children)) {
+    return (
+      <NextLink
+        href={href}
+        replace={replace}
+        scroll={scroll}
+        prefetch={prefetch}
+      >
+        {children}
+      </NextLink>
+    );
+  }
+
+  const hrefString = typeof href === "string" ? href : formatUrl(href);
+
+  return (
+    <TypographyLink
+      href={hrefString}
+      onClick={(e) => {
+        onClick?.(e);
+        if (
+          e.defaultPrevented ||
+          e.button !== 0 ||
+          e.metaKey ||
+          e.ctrlKey ||
+          e.shiftKey ||
+          e.altKey
+        ) {
+          // Let the browser handle new-tab / modified clicks natively.
+          return;
+        }
+        e.preventDefault();
+        router.push(href);
+      }}
+      {...typographyProps}
+    >
+      {children}
+    </TypographyLink>
+  );
+};

--- a/clients/admin-ui/src/features/common/table/cells/LinkCell.tsx
+++ b/clients/admin-ui/src/features/common/table/cells/LinkCell.tsx
@@ -1,7 +1,8 @@
 import { Flex, FlexProps, Typography } from "fidesui";
 import { Url } from "next/dist/shared/lib/router/router";
-import NextLink from "next/link";
 import { ComponentProps } from "react";
+
+import { RouterLink } from "~/features/common/nav/RouterLink";
 
 const { Link: LinkText, Text } = Typography;
 
@@ -19,19 +20,18 @@ export const LinkCell = ({
     children && (
       <Flex {...containerProps}>
         {href ? (
-          <NextLink href={href} passHref legacyBehavior>
-            <LinkText
-              strong={strong}
-              ellipsis
-              onClick={(e) => e.stopPropagation()}
-              variant="primary"
-              {...props}
-            >
-              <Text unStyled ellipsis={{ tooltip: children }}>
-                {children}
-              </Text>
-            </LinkText>
-          </NextLink>
+          <RouterLink
+            href={href}
+            strong={strong}
+            ellipsis
+            onClick={(e) => e.stopPropagation()}
+            variant="primary"
+            {...props}
+          >
+            <Text unStyled ellipsis={{ tooltip: children }}>
+              {children}
+            </Text>
+          </RouterLink>
         ) : (
           <Text strong={strong} ellipsis {...props}>
             {children}

--- a/clients/admin-ui/src/features/consent-settings/tcf/PublisherRestrictionsTable.tsx
+++ b/clients/admin-ui/src/features/consent-settings/tcf/PublisherRestrictionsTable.tsx
@@ -1,8 +1,8 @@
 import { Button, ColumnsType, Skeleton, Table, Tag, Typography } from "fidesui";
-import NextLink from "next/link";
 import React, { useMemo } from "react";
 
 import { useAppSelector } from "~/app/hooks";
+import { RouterLink } from "~/features/common/nav/RouterLink";
 import { selectPurposes } from "~/features/common/purpose.slice";
 import { InfoCell } from "~/features/common/table/cells";
 import { MappedPurpose, TCFConfigurationDetail } from "~/types/api";
@@ -102,18 +102,14 @@ export const PublisherRestrictionsTable = ({
         key: "actions",
         width: 100,
         render: (_, record) => (
-          <NextLink
-            href={`/settings/consent/${config?.id}/${record.id}`}
-            passHref
-            legacyBehavior
-          >
+          <RouterLink href={`/settings/consent/${config?.id}/${record.id}`}>
             <Button
               size="small"
               data-testid={`edit-restriction-btn-${record.id}`}
             >
               Edit
             </Button>
-          </NextLink>
+          </RouterLink>
         ),
       },
     ],

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/ConfidenceCard.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/ConfidenceCard.tsx
@@ -1,7 +1,7 @@
 import { Avatar, Button, Card, Icons, Space, SparkleIcon, Text } from "fidesui";
-import NextLink from "next/link";
 import { ReactNode } from "react";
 
+import { RouterLink } from "~/features/common/nav/RouterLink";
 import { SeverityGauge } from "~/features/common/progress/SeverityGauge";
 import { nFormatter, pluralize } from "~/features/common/utils";
 import { ConfidenceBucket } from "~/types/api/models/ConfidenceBucket";
@@ -33,12 +33,11 @@ const getActions = ({
   onConfirmAll,
 }: GetActionsParams): ReactNode[] => {
   const actions: ReactNode[] = [
-    <NextLink
+    <RouterLink
       href={{
         pathname: reviewHref,
         query: { confidence_bucket: item.severity },
       }}
-      passHref
       key={item.label}
     >
       <Button
@@ -49,7 +48,7 @@ const getActions = ({
       >
         Review
       </Button>
-    </NextLink>,
+    </RouterLink>,
   ];
   if (item.severity === ConfidenceBucket.HIGH && onConfirmAll) {
     actions.push(

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/EmptyMonitorsResult.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/EmptyMonitorsResult.tsx
@@ -10,10 +10,10 @@ import {
   Text,
   Title,
 } from "fidesui";
-import NextLink from "next/link";
 import { useSelector } from "react-redux";
 
 import { selectUser } from "~/features/auth";
+import { RouterLink } from "~/features/common/nav/RouterLink";
 import { SYSTEM_ROUTE } from "~/features/common/nav/routes";
 import { useGetSystemsQuery } from "~/features/system";
 
@@ -131,9 +131,9 @@ export const EmptyMonitorsResult = () => {
         </>
       }
     >
-      <NextLink href={SYSTEM_ROUTE} passHref legacyBehavior>
+      <RouterLink href={SYSTEM_ROUTE}>
         <Button type="primary">View inventory</Button>
-      </NextLink>
+      </RouterLink>
     </Empty>
   );
 };

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/MonitorResult.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/MonitorResult.tsx
@@ -17,6 +17,7 @@ import palette from "fidesui/src/palette/palette.module.scss";
 import NextLink from "next/link";
 import { useState } from "react";
 
+import { RouterLink } from "~/features/common/nav/RouterLink";
 import {
   formatDate,
   formatUser,
@@ -151,7 +152,7 @@ export const MonitorResult = ({
               </Button>,
             ]
           : []),
-        <NextLink key="review" href={href} passHref legacyBehavior>
+        <RouterLink key="review" href={href}>
           <Button
             type="link"
             className="p-0"
@@ -159,7 +160,7 @@ export const MonitorResult = ({
           >
             Review
           </Button>
-        </NextLink>,
+        </RouterLink>,
       ]}
     >
       <List.Item.Meta

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/page.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/page.tsx
@@ -13,7 +13,6 @@ import {
   Tooltip,
 } from "fidesui";
 import _ from "lodash";
-import NextLink from "next/link";
 import { useRouter } from "next/router";
 import { Key, useEffect, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
@@ -23,6 +22,7 @@ import {
   getErrorMessage,
   isFetchBaseQueryError,
 } from "~/features/common/helpers";
+import { RouterLink } from "~/features/common/nav/RouterLink";
 import { DATASET_ROUTE } from "~/features/common/nav/routes";
 import { useAntPagination } from "~/features/common/pagination/useAntPagination";
 import {
@@ -456,13 +456,9 @@ const ActionCenterFields = ({
                           }
                         >
                           <Flex gap="medium" justify="center">
-                            <NextLink
-                              href={DATASET_ROUTE}
-                              passHref
-                              legacyBehavior
-                            >
+                            <RouterLink href={DATASET_ROUTE}>
                               <Button>Manage datasets view</Button>
-                            </NextLink>
+                            </RouterLink>
                             <Button
                               type="primary"
                               aria-label="Refresh page"

--- a/clients/admin-ui/src/features/datamap/datamap-drawer/SystemInfo.tsx
+++ b/clients/admin-ui/src/features/datamap/datamap-drawer/SystemInfo.tsx
@@ -1,6 +1,6 @@
-import { Divider, Flex, Form, Input, Title, Typography } from "fidesui";
-import NextLink from "next/link";
+import { Divider, Flex, Form, Input, Title } from "fidesui";
 
+import { RouterLink } from "~/features/common/nav/RouterLink";
 import { SystemInfoFormValues } from "~/features/datamap/datamap-drawer/types";
 import { System } from "~/types/api";
 
@@ -15,9 +15,7 @@ export const SystemInfo = ({ system }: SystemInfoProps) => {
       <Flex align="center">
         <Title level={5}>System details</Title>
         <div className="grow" />
-        <NextLink href={systemHref} passHref legacyBehavior>
-          <Typography.Link>View more</Typography.Link>
-        </NextLink>
+        <RouterLink href={systemHref}>View more</RouterLink>
       </Flex>
       <Divider size="small" className="pb-4" />
       <Form

--- a/clients/admin-ui/src/features/integrations/IntegrationLinkedSystems.tsx
+++ b/clients/admin-ui/src/features/integrations/IntegrationLinkedSystems.tsx
@@ -10,10 +10,10 @@ import {
   useMessage,
   useModal,
 } from "fidesui";
-import NextLink from "next/link";
 import { useCallback, useMemo, useState } from "react";
 
 import { getErrorMessage } from "~/features/common/helpers";
+import { RouterLink } from "~/features/common/nav/RouterLink";
 import { EDIT_SYSTEM_ROUTE } from "~/features/common/nav/routes";
 import { debounce } from "~/features/common/utils";
 import {
@@ -26,7 +26,7 @@ import { useGetSystemsQuery } from "~/features/system/system.slice";
 import { ConnectionConfigurationResponse } from "~/types/api";
 import { isErrorResult } from "~/types/errors";
 
-const { Paragraph, Text, Link: LinkText } = Typography;
+const { Paragraph, Text } = Typography;
 
 const SYSTEMS_PAGE_SIZE = 25;
 
@@ -292,29 +292,24 @@ const IntegrationLinkedSystems = ({
               title={
                 <Flex gap={8} align="center" className="font-normal">
                   <Flex>
-                    <NextLink
+                    <RouterLink
                       href={EDIT_SYSTEM_ROUTE.replace(
                         "[id]",
                         link.system_fides_key,
                       )}
-                      passHref
-                      legacyBehavior
+                      variant="primary"
+                      ellipsis
+                      onClick={(e) => e.stopPropagation()}
                     >
-                      <LinkText
-                        variant="primary"
-                        ellipsis
-                        onClick={(e) => e.stopPropagation()}
+                      <Text
+                        unStyled
+                        ellipsis={{
+                          tooltip: link.system_name || link.system_fides_key,
+                        }}
                       >
-                        <Text
-                          unStyled
-                          ellipsis={{
-                            tooltip: link.system_name || link.system_fides_key,
-                          }}
-                        >
-                          {link.system_name || link.system_fides_key}
-                        </Text>
-                      </LinkText>
-                    </NextLink>
+                        {link.system_name || link.system_fides_key}
+                      </Text>
+                    </RouterLink>
                   </Flex>
                   <Tag>Discovery</Tag>
                 </Flex>

--- a/clients/admin-ui/src/features/privacy-assessments/AssessmentSettingsModal.test.tsx
+++ b/clients/admin-ui/src/features/privacy-assessments/AssessmentSettingsModal.test.tsx
@@ -5,6 +5,16 @@ import { parseCronExpression } from "~/features/digests/helpers/cronHelpers";
 
 import AssessmentSettingsModal from "./AssessmentSettingsModal";
 
+jest.mock("next/router", () => ({
+  useRouter: jest.fn(() => ({
+    push: jest.fn(),
+    pathname: "/",
+    query: {},
+    asPath: "/",
+    isFallback: false,
+  })),
+}));
+
 // Mock fidesui components - only mock Select to make it testable
 jest.mock(
   "fidesui",

--- a/clients/admin-ui/src/features/privacy-assessments/AssessmentSettingsModal.tsx
+++ b/clients/admin-ui/src/features/privacy-assessments/AssessmentSettingsModal.tsx
@@ -9,13 +9,13 @@ import {
   Switch,
   useMessage,
 } from "fidesui";
-import NextLink from "next/link";
 import { useEffect, useMemo } from "react";
 
 import { useGetChatChannelsQuery } from "~/features/chat-provider/chatProvider.slice";
 import { LlmModelSelector } from "~/features/common/form/LlmModelSelector";
 import { getErrorMessage, isErrorResult } from "~/features/common/helpers";
 import ConfirmCloseModal from "~/features/common/modals/ConfirmCloseModal";
+import { RouterLink } from "~/features/common/nav/RouterLink";
 import { CHAT_PROVIDERS_ROUTE } from "~/features/common/nav/routes";
 import { parseCronExpression } from "~/features/digests/helpers/cronHelpers";
 
@@ -191,11 +191,15 @@ const AssessmentSettingsModal = ({
               type="info"
               title="Configure Slack to enable channel notifications."
               action={
-                <NextLink href={CHAT_PROVIDERS_ROUTE} target="_blank" passHref>
+                <RouterLink
+                  href={CHAT_PROVIDERS_ROUTE}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
                   <Button size="small" type="link">
                     Configure Slack
                   </Button>
-                </NextLink>
+                </RouterLink>
               }
               className="mb-4"
             />

--- a/clients/admin-ui/src/features/privacy-requests/dashboard/DuplicateRequestsButton.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/dashboard/DuplicateRequestsButton.tsx
@@ -1,7 +1,7 @@
 import { Button } from "fidesui";
-import Link from "next/link";
 import { useRouter } from "next/router";
 
+import { RouterLink } from "~/features/common/nav/RouterLink";
 import { pluralize } from "~/features/common/utils";
 import { useSearchPrivacyRequestsQuery } from "~/features/privacy-requests/privacy-requests.slice";
 import { PrivacyRequestStatus } from "~/types/api";
@@ -44,13 +44,11 @@ export const DuplicateRequestsButton = ({
   }
 
   return (
-    <Link
+    <RouterLink
       href={{
         pathname: router.pathname,
         query: { status: PrivacyRequestStatus.DUPLICATE },
       }}
-      passHref
-      legacyBehavior
     >
       <Button
         type="text"
@@ -60,6 +58,6 @@ export const DuplicateRequestsButton = ({
         {duplicateCount} duplicate{" "}
         {pluralize(duplicateCount, "request", "requests")}
       </Button>
-    </Link>
+    </RouterLink>
   );
 };

--- a/clients/admin-ui/src/features/user-management/RolesForm.tsx
+++ b/clients/admin-ui/src/features/user-management/RolesForm.tsx
@@ -16,12 +16,12 @@ import {
   Typography,
   useMessage,
 } from "fidesui";
-import NextLink from "next/link";
 import React, { useEffect, useMemo, useState } from "react";
 
 import { useAppSelector } from "~/app/hooks";
 import { getErrorMessage, isErrorResult } from "~/features/common/helpers";
 import { InfoTooltip } from "~/features/common/InfoTooltip";
+import { RouterLink } from "~/features/common/nav/RouterLink";
 import { USER_MANAGEMENT_ROUTE } from "~/features/common/nav/routes";
 import {
   useAssignUserRoleMutation,
@@ -445,9 +445,9 @@ const RolesForm = () => {
       )}
 
       <Flex gap={12}>
-        <NextLink href={USER_MANAGEMENT_ROUTE} passHref>
+        <RouterLink href={USER_MANAGEMENT_ROUTE}>
           <Button>Cancel</Button>
-        </NextLink>
+        </RouterLink>
         <Button
           type="primary"
           onClick={handleSave}

--- a/clients/admin-ui/src/features/user-management/UserManagementTable.tsx
+++ b/clients/admin-ui/src/features/user-management/UserManagementTable.tsx
@@ -1,9 +1,9 @@
 import { Button, Flex, Table } from "fidesui";
-import NextLink from "next/link";
 import React, { useEffect } from "react";
 
 import { useAppDispatch } from "~/app/hooks";
 import { DebouncedSearchInput } from "~/features/common/DebouncedSearchInput";
+import { RouterLink } from "~/features/common/nav/RouterLink";
 import { USER_MANAGEMENT_ROUTE } from "~/features/common/nav/routes";
 import Restrict from "~/features/common/Restrict";
 import { ScopeRegistryEnum } from "~/types/api";
@@ -30,15 +30,11 @@ const UserManagementTable = () => {
           data-testid="user-search"
         />
         <Restrict scopes={[ScopeRegistryEnum.USER_CREATE]}>
-          <NextLink
-            href={`${USER_MANAGEMENT_ROUTE}/new`}
-            passHref
-            legacyBehavior
-          >
+          <RouterLink href={`${USER_MANAGEMENT_ROUTE}/new`}>
             <Button type="primary" data-testid="add-new-user-btn">
               Add new user
             </Button>
-          </NextLink>
+          </RouterLink>
         </Restrict>
       </Flex>
       <Table

--- a/clients/admin-ui/src/home/SystemCoverageCard.tsx
+++ b/clients/admin-ui/src/home/SystemCoverageCard.tsx
@@ -9,8 +9,8 @@ import {
   Text,
   Tooltip,
 } from "fidesui";
-import NextLink from "next/link";
 
+import { RouterLink } from "~/features/common/nav/RouterLink";
 import { ADD_SYSTEMS_MANUAL_ROUTE } from "~/features/common/nav/routes";
 import { useGetSystemCoverageQuery } from "~/features/dashboard/dashboard.slice";
 import type { SystemCoverageResponse } from "~/features/dashboard/types";
@@ -61,9 +61,9 @@ export const SystemCoverageCard = () => {
       loading={isLoading}
       className="h-full"
       extra={
-        <NextLink href={ADD_SYSTEMS_MANUAL_ROUTE} passHref>
+        <RouterLink href={ADD_SYSTEMS_MANUAL_ROUTE}>
           Connect more systems
-        </NextLink>
+        </RouterLink>
       }
     >
       <Flex vertical gap="large" className="h-full">

--- a/clients/admin-ui/src/pages/access-policies/controls/index.tsx
+++ b/clients/admin-ui/src/pages/access-policies/controls/index.tsx
@@ -1,6 +1,5 @@
 import { Button, List, Text, Typography, useMessage, useModal } from "fidesui";
 import type { NextPage } from "next";
-import NextLink from "next/link";
 
 import {
   Control,
@@ -9,6 +8,7 @@ import {
 } from "~/features/access-policies/access-policies.slice";
 import { getErrorMessage } from "~/features/common/helpers";
 import Layout from "~/features/common/Layout";
+import { RouterLink } from "~/features/common/nav/RouterLink";
 import {
   ACCESS_POLICIES_ROUTE,
   CONTROLS_EDIT_ROUTE,
@@ -55,9 +55,9 @@ const ControlsPage: NextPage = () => {
           { title: "Controls" },
         ]}
         rightContent={
-          <NextLink href={CONTROLS_NEW_ROUTE} passHref>
+          <RouterLink href={CONTROLS_NEW_ROUTE}>
             <Button type="primary">New control</Button>
-          </NextLink>
+          </RouterLink>
         }
       >
         <div className="max-w-3xl">
@@ -94,13 +94,12 @@ const ControlsPage: NextPage = () => {
               >
                 Delete
               </Button>,
-              <NextLink
+              <RouterLink
                 key="edit"
                 href={{
                   pathname: CONTROLS_EDIT_ROUTE,
                   query: { controlKey: control.key },
                 }}
-                passHref
               >
                 <Button
                   type="link"
@@ -109,7 +108,7 @@ const ControlsPage: NextPage = () => {
                 >
                   Edit
                 </Button>
-              </NextLink>,
+              </RouterLink>,
             ]}
           >
             <List.Item.Meta

--- a/clients/admin-ui/src/pages/access-policies/index.tsx
+++ b/clients/admin-ui/src/pages/access-policies/index.tsx
@@ -1,6 +1,5 @@
 import { Button, Flex, Icons, Text } from "fidesui";
 import type { NextPage } from "next";
-import NextLink from "next/link";
 import { useState } from "react";
 
 import { useGetAccessPoliciesQuery } from "~/features/access-policies/access-policies.slice";
@@ -8,6 +7,7 @@ import PoliciesContainer from "~/features/access-policies/PoliciesContainer";
 import PolicySettingsModal from "~/features/access-policies/PolicySettingsModal";
 import { useFlags } from "~/features/common/features";
 import Layout from "~/features/common/Layout";
+import { RouterLink } from "~/features/common/nav/RouterLink";
 import {
   ACCESS_POLICIES_NEW_ROUTE,
   CONTROLS_ROUTE,
@@ -37,9 +37,9 @@ const AccessPoliciesPage: NextPage = () => {
                   onClick={() => setSettingsOpen(true)}
                 />
               )}
-              <NextLink href={ACCESS_POLICIES_NEW_ROUTE} passHref>
+              <RouterLink href={ACCESS_POLICIES_NEW_ROUTE}>
                 <Button type="primary">New policy</Button>
-              </NextLink>
+              </RouterLink>
             </Flex>
           ) : undefined
         }

--- a/clients/admin-ui/src/pages/access-policies/index.tsx
+++ b/clients/admin-ui/src/pages/access-policies/index.tsx
@@ -27,9 +27,9 @@ const AccessPoliciesPage: NextPage = () => {
         rightContent={
           hasPolicies ? (
             <Flex gap={8}>
-              <NextLink href={CONTROLS_ROUTE} passHref>
+              <RouterLink href={CONTROLS_ROUTE}>
                 <Button>Manage controls</Button>
-              </NextLink>
+              </RouterLink>
               {flags.alphaPrivacyDocUpload && (
                 <Button
                   aria-label="Policy settings"

--- a/clients/admin-ui/src/pages/add-systems/multiple.tsx
+++ b/clients/admin-ui/src/pages/add-systems/multiple.tsx
@@ -1,12 +1,8 @@
-import {
-  ChakraBox as Box,
-  ChakraText as Text,
-  Link as LinkText,
-} from "fidesui";
+import { ChakraBox as Box, ChakraText as Text } from "fidesui";
 import type { NextPage } from "next";
-import NextLink from "next/link";
 
 import Layout from "~/features/common/Layout";
+import { RouterLink } from "~/features/common/nav/RouterLink";
 import {
   ADD_SYSTEMS_MANUAL_ROUTE,
   ADD_SYSTEMS_ROUTE,
@@ -33,9 +29,9 @@ const AddMultipleSystemsPage: NextPage = () => (
     <Box w={{ base: "100%", md: "75%" }}>
       <Text fontSize="sm" mb={8}>
         {DESCRIBE_SYSTEM_COPY}
-        <NextLink href={ADD_SYSTEMS_MANUAL_ROUTE} passHref legacyBehavior>
-          <LinkText>Add a system</LinkText>
-        </NextLink>{" "}
+        <RouterLink href={ADD_SYSTEMS_MANUAL_ROUTE}>
+          Add a system
+        </RouterLink>{" "}
         page.
       </Text>
     </Box>

--- a/clients/admin-ui/src/pages/dataset/index.tsx
+++ b/clients/admin-ui/src/pages/dataset/index.tsx
@@ -17,7 +17,6 @@ import {
   Icons,
 } from "fidesui";
 import type { NextPage } from "next";
-import NextLink from "next/link";
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useDispatch } from "react-redux";
@@ -26,6 +25,7 @@ import { usePollForClassifications } from "~/features/common/classifications";
 import ErrorPage from "~/features/common/errors/ErrorPage";
 import { useFeatures } from "~/features/common/features";
 import Layout from "~/features/common/Layout";
+import { RouterLink } from "~/features/common/nav/RouterLink";
 import { DATASET_DETAIL_ROUTE } from "~/features/common/nav/routes";
 import PageHeader from "~/features/common/PageHeader";
 import {
@@ -219,9 +219,9 @@ const DataSets: NextPage = () => {
             },
           ]}
           rightContent={
-            <NextLink href="/dataset/new" passHref legacyBehavior>
+            <RouterLink href="/dataset/new">
               <Button data-testid="create-dataset-btn">+ Add dataset</Button>
-            </NextLink>
+            </RouterLink>
           }
         />
 

--- a/clients/admin-ui/src/pages/privacy-assessments/[id].tsx
+++ b/clients/admin-ui/src/pages/privacy-assessments/[id].tsx
@@ -10,12 +10,12 @@ import {
   useModal,
 } from "fidesui";
 import type { NextPage } from "next";
-import NextLink from "next/link";
 import { useRouter } from "next/router";
 
 import { useFeatures } from "~/features/common/features";
 import { getErrorMessage } from "~/features/common/helpers";
 import Layout from "~/features/common/Layout";
+import { RouterLink } from "~/features/common/nav/RouterLink";
 import { PRIVACY_ASSESSMENTS_ROUTE } from "~/features/common/nav/routes";
 import PageHeader from "~/features/common/PageHeader";
 import {
@@ -129,9 +129,9 @@ const PrivacyAssessmentDetailPage: NextPage = () => {
           subTitle="There was an error loading this privacy assessment. Please try again."
           extra={
             <Space>
-              <NextLink href={PRIVACY_ASSESSMENTS_ROUTE} passHref>
+              <RouterLink href={PRIVACY_ASSESSMENTS_ROUTE}>
                 <Button>Back to list</Button>
-              </NextLink>
+              </RouterLink>
               <Button type="primary" onClick={() => refetch()}>
                 Retry
               </Button>

--- a/clients/admin-ui/src/pages/settings/rbac/index.tsx
+++ b/clients/admin-ui/src/pages/settings/rbac/index.tsx
@@ -1,10 +1,10 @@
 import Layout from "common/Layout";
 import { Button, Flex, Space, Table, Tag, Typography } from "fidesui";
 import type { NextPage } from "next";
-import NextLink from "next/link";
 import React from "react";
 
 import ErrorPage from "~/features/common/errors/ErrorPage";
+import { RouterLink } from "~/features/common/nav/RouterLink";
 import { RBAC_ROLE_NEW_ROUTE } from "~/features/common/nav/routes";
 import PageHeader from "~/features/common/PageHeader";
 import { LinkCell } from "~/features/common/table/cells/LinkCell";
@@ -85,9 +85,9 @@ const RBACPage: NextPage = () => {
         isSticky={false}
         className="pb-0"
         rightContent={
-          <NextLink href={RBAC_ROLE_NEW_ROUTE} passHref>
+          <RouterLink href={RBAC_ROLE_NEW_ROUTE}>
             <Button type="primary">Create role</Button>
-          </NextLink>
+          </RouterLink>
         }
       >
         <Typography.Paragraph className="max-w-screen-sm">

--- a/clients/admin-ui/src/pages/settings/rbac/roles/new.tsx
+++ b/clients/admin-ui/src/pages/settings/rbac/roles/new.tsx
@@ -10,11 +10,11 @@ import {
   useMessage,
 } from "fidesui";
 import type { NextPage } from "next";
-import NextLink from "next/link";
 import { useRouter } from "next/router";
 import React, { useMemo } from "react";
 
 import { getErrorMessage } from "~/features/common/helpers";
+import { RouterLink } from "~/features/common/nav/RouterLink";
 import { RBAC_ROUTE } from "~/features/common/nav/routes";
 import PageHeader from "~/features/common/PageHeader";
 import { useCreateRoleMutation, useGetRolesQuery } from "~/features/rbac";
@@ -144,9 +144,9 @@ const NewRolePage: NextPage = () => {
               <Button type="primary" htmlType="submit" loading={isLoading}>
                 Create role
               </Button>
-              <NextLink href={RBAC_ROUTE} passHref>
+              <RouterLink href={RBAC_ROUTE}>
                 <Button>Cancel</Button>
-              </NextLink>
+              </RouterLink>
             </Space>
           </Form.Item>
         </Form>


### PR DESCRIPTION
Ticket [ENG-3461]

### Description Of Changes

Next.js 16 dropped `passHref` and `legacyBehavior` from the public `<Link>` API, and Next.js 15 emits a runtime deprecation warning for `legacyBehavior`. The Admin UI still relied on that pattern in **20 places** to wrap a `Typography.Link` or `Button` inside a `next/link`.

This PR introduces a shared `RouterLink` component (`clients/admin-ui/src/features/common/nav/RouterLink.tsx`) that replaces every `<Link passHref legacyBehavior>` call site in admin-ui. It detects whether its only child is an antd `Button` and either:

- wraps the button in `next/link` so Next renders its own `<a>` around the button (preserves prefetch + modifier-click handling), or
- renders a `Typography.Link`-styled anchor that intercepts plain left-clicks and calls `router.push` for SPA navigation, while letting modifier / middle / right clicks fall through to the browser for new-tab / copy-link behaviour.

Also forwards `target` and `rel` to both paths so callers can still open a link in a new tab (bypassing SPA interception when `target="_blank"`).

The result is a single anchor per link (no more nested `<a>` hack), no deprecation warnings, and consistent SPA navigation across the app. Unit tests cover both branches of the component.

After this PR, `git grep 'passHref\|legacyBehavior'` in `clients/admin-ui` returns zero hits. Privacy Center, fides-js, and fidesui already had zero deprecated Link usages and did not need changes.

### Code Changes

* Added `clients/admin-ui/src/features/common/nav/RouterLink.tsx` + jest coverage in `RouterLink.test.tsx` (10 tests: Button-wrap path, text path, URL-object serialisation, modifier-click pass-through, `target="_blank"` pass-through, `target`/`rel` forwarding, custom `onClick` + `preventDefault`, fragment fall-through).
* Migrated **20** call sites off `<Link passHref legacyBehavior>`:
  * `features/access-policies/PolicyCard.tsx`
  * `features/common/table/cells/LinkCell.tsx`
  * `features/consent-settings/tcf/PublisherRestrictionsTable.tsx`
  * `features/data-discovery-and-detection/action-center/ConfidenceCard.tsx`
  * `features/data-discovery-and-detection/action-center/EmptyMonitorsResult.tsx`
  * `features/data-discovery-and-detection/action-center/MonitorResult.tsx`
  * `features/data-discovery-and-detection/action-center/fields/page.tsx`
  * `features/datamap/datamap-drawer/SystemInfo.tsx`
  * `features/integrations/IntegrationLinkedSystems.tsx`
  * `features/privacy-assessments/AssessmentSettingsModal.tsx` (uses `target="_blank"`)
  * `features/privacy-requests/dashboard/DuplicateRequestsButton.tsx`
  * `features/user-management/RolesForm.tsx`
  * `features/user-management/UserManagementTable.tsx`
  * `home/SystemCoverageCard.tsx` (text-mode link)
  * `pages/access-policies/index.tsx`
  * `pages/add-systems/multiple.tsx`
  * `pages/dataset/index.tsx`
  * `pages/privacy-assessments/[id].tsx`
  * `pages/settings/rbac/index.tsx`
  * `pages/settings/rbac/roles/new.tsx`

### Steps to Confirm

All of the below were verified manually against a local `npm run dev` admin-ui. After each, confirm the URL changes to the expected destination and no `validateDOMNesting` / nested-anchor / `legacyBehavior` / `passHref` warnings appear in the console.

1. Go to `/dataset` → click the **+ Add dataset** button (top right) → lands on `/dataset/new`.
2. Go to `/add-systems/multiple` → click the inline **Add a system** link in the description → lands on `/add-systems/manual`.
3. Go to `/data-discovery/action-center` → on any monitor card click **Review** → lands on `/data-discovery/action-center/{website|datastore|infrastructure}/{monitorId}`.
4. Go to `/user-management` → click **Add new user** (top right) → lands on `/user-management/new`.
5. Go to `/integrations` → on any row, click the integration name in the first column (should be a single blue link, ellipsis-truncated, and the row itself should NOT also navigate) → lands on `/integrations/{id}`.
6. On an integration detail page that has a linked system (e.g. the BigQuery Connection seed data), open the **Linked system** tab → click the system name in the list → lands on `/systems/configure/{systemKey}`.
7. Go to `/reporting/datamap` → click a system cell in the table to open the drawer → click **View more** in the drawer header → lands on `/systems/configure/{systemKey}`.
8. Go to `/settings/consent` on a TCF config with restrictions → click any **Edit** button in the restrictions table → lands on `/settings/consent/{configId}/{restrictionId}`.
9. Go to `/` (home dashboard) → on the **System Coverage** card, click **Connect more systems** in the card header (text link, Typography.Link style) → lands on `/add-systems/manual`.

Modifier-click check (optional but worth it): on any of the above links, Cmd/Ctrl-click should open the target in a new tab (not SPA-navigate in place).

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-3461]: https://ethyca.atlassian.net/browse/ENG-3461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ