### PR TITLE
fix: datastore integration text taxonomy [ENG-3209]

### DIFF
--- a/changelog/7943-datastore-integration-text-taxonomy.yaml
+++ b/changelog/7943-datastore-integration-text-taxonomy.yaml
@@ -1,0 +1,4 @@
+type: Fixed # One of: Added, Changed, Developer Experience, Deprecated, Docs, Fixed, Removed, Security
+description: datastore integration text changes based on taxonomy of integration
+pr: 7943 # PR number
+labels: [] # Optional: ["high-risk", "db-migration"]

--- a/clients/admin-ui/src/features/integrations/configure-monitor/ConfigureMonitorDatabasesForm.tsx
+++ b/clients/admin-ui/src/features/integrations/configure-monitor/ConfigureMonitorDatabasesForm.tsx
@@ -13,8 +13,6 @@ import MonitorDatabasePicker from "~/features/integrations/configure-monitor/Mon
 import useCumulativeGetDatabases from "~/features/integrations/configure-monitor/useCumulativeGetDatabases";
 import { EditableMonitorConfig } from "~/types/api";
 
-const TOOLTIP_COPY =
-  "Selecting a project will monitor all current and future datasets within that project.";
 const TIMEOUT_COPY =
   "Loading resources is taking longer than expected. The monitor has been saved and is tracking all available resources. You can return later to limit its scope if needed";
 
@@ -25,6 +23,7 @@ const ConfigureMonitorDatabasesForm = ({
   integrationKey,
   onSubmit,
   onClose,
+  contentTaxonomy = ["project", "projects"],
 }: {
   monitor: EditableMonitorConfig;
   isEditing?: boolean;
@@ -32,6 +31,7 @@ const ConfigureMonitorDatabasesForm = ({
   integrationKey: string;
   onSubmit: (monitor: EditableMonitorConfig) => void;
   onClose: () => void;
+  contentTaxonomy?: readonly [string, string];
 }) => {
   const message = useMessage();
 
@@ -85,8 +85,10 @@ const ConfigureMonitorDatabasesForm = ({
     <>
       <Flex p={4} direction="column">
         <Flex direction="row" mb={4} gap={1} align="center">
-          <Text fontSize="sm">Select projects to monitor</Text>
-          <InfoTooltip label={TOOLTIP_COPY} />
+          <Text fontSize="sm">{`Select ${contentTaxonomy[1]} to monitor`}</Text>
+          <InfoTooltip
+            label={`Selecting a ${contentTaxonomy[0]} will monitor all current and future datasets within that ${contentTaxonomy[0]}.`}
+          />
         </Flex>
         <MonitorDatabasePicker
           items={databases}
@@ -105,7 +107,9 @@ const ConfigureMonitorDatabasesForm = ({
         <Button onClick={onClose}>Cancel</Button>
         <Tooltip
           title={
-            saveIsDisabled ? "Select one or more projects to save" : undefined
+            saveIsDisabled
+              ? `Select one or more ${contentTaxonomy[1]} to save`
+              : undefined
           }
         >
           <Button

--- a/clients/admin-ui/src/features/integrations/configure-monitor/ConfigureMonitorDatabasesForm.tsx
+++ b/clients/admin-ui/src/features/integrations/configure-monitor/ConfigureMonitorDatabasesForm.tsx
@@ -23,7 +23,7 @@ const ConfigureMonitorDatabasesForm = ({
   integrationKey,
   onSubmit,
   onClose,
-  contentTaxonomy = ["project", "projects"],
+  contentTaxonomy = ["database", "databases"],
 }: {
   monitor: EditableMonitorConfig;
   isEditing?: boolean;

--- a/clients/admin-ui/src/features/integrations/configure-monitor/ConfigureMonitorModal.tsx
+++ b/clients/admin-ui/src/features/integrations/configure-monitor/ConfigureMonitorModal.tsx
@@ -17,6 +17,7 @@ import ConfigureWebsiteMonitorForm from "~/features/integrations/configure-monit
 import {
   ConnectionConfigurationResponseWithSystemKey,
   ConnectionSystemTypeMap,
+  ConnectionType,
   EditableMonitorConfig,
   MonitorFrequency,
 } from "~/types/api";
@@ -30,6 +31,11 @@ const WEBSITE_MONITOR_NOW_SCANNING_MESSAGE =
   "Your monitor has been created and is now scanning your website. Once the monitor is finished scanning, results can be found in the action center.";
 
 const WEBSITE_MONITOR_NOT_SCHEDULED_MESSAGE = `Your monitor has been created with no schedule.  Select "Scan" in the table below to begin scanning your website.`;
+
+const DATASTORE_CONTENT_TAXONOMY = {
+  project: ["project", "projects"],
+  database: ["database", "databases"],
+} as const;
 
 const ConfigureMonitorModal = ({
   isOpen,
@@ -171,6 +177,11 @@ const ConfigureMonitorModal = ({
             onSubmit={handleSubmit}
             onClose={onClose}
             integrationKey={integration.key}
+            contentTaxonomy={
+              integration.connection_type === ConnectionType.BIGQUERY
+                ? DATASTORE_CONTENT_TAXONOMY.project
+                : DATASTORE_CONTENT_TAXONOMY.database
+            }
           />
         ) : (
           <Spin />


### PR DESCRIPTION
Ticket [ENG-3209] <!-- simply paste the ticket number between the brackets and it will auto-convert to a link -->

### Description Of Changes

Changes the taxonomy of the datastore monitor content based on the type of monitor being created/edited.

### Code Changes

* <!-- list your code changes -->

### Steps to Confirm

1. Add a bigquery integration
2. Add a monitor to that integration and confirm that the second modal refers to the selectable content as `projects`
3. Add any other type of datastore integration
4. Add a monitor to that integration and confirm that the second modal refers to the selectable content as `databases`


### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-3209]: https://ethyca.atlassian.net/browse/ENG-3209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ