### PR TITLE
ENG-3461: add unstyled mode to RouterLink, replace all remaining NextLink usages

### DIFF
--- a/changelog/7946-routerlink-unstyled-mode.yaml
+++ b/changelog/7946-routerlink-unstyled-mode.yaml
@@ -1,0 +1,4 @@
+type: Changed
+description: Added unstyled mode to RouterLink and migrated all remaining NextLink usages
+pr: 7946
+labels: []

--- a/clients/admin-ui/__tests__/features/common/nav/NavSearch.collapsed.test.tsx
+++ b/clients/admin-ui/__tests__/features/common/nav/NavSearch.collapsed.test.tsx
@@ -49,6 +49,12 @@ jest.mock("fidesui", () => {
     Icons: {
       Search: () => MockReact.createElement("span", null, "search-icon"),
     },
+    Typography: {
+      Link: MockReact.forwardRef((props: any, ref: any) =>
+        MockReact.createElement("a", { ...props, ref }),
+      ),
+    },
+    Button: "button",
   };
 });
 

--- a/clients/admin-ui/__tests__/features/common/nav/NavSearch.test.tsx
+++ b/clients/admin-ui/__tests__/features/common/nav/NavSearch.test.tsx
@@ -87,6 +87,12 @@ jest.mock("fidesui", () => {
     Icons: {
       Search: () => MockReact.createElement("span", null, "search-icon"),
     },
+    Typography: {
+      Link: MockReact.forwardRef((props: any, ref: any) =>
+        MockReact.createElement("a", { ...props, ref }),
+      ),
+    },
+    Button: "button",
   };
 });
 

--- a/clients/admin-ui/src/features/common/nav/AccountDropdownMenu.tsx
+++ b/clients/admin-ui/src/features/common/nav/AccountDropdownMenu.tsx
@@ -1,9 +1,9 @@
 import { Button, Dropdown, Icons, Typography } from "fidesui";
-import NextLink from "next/link";
 
 import { useAppSelector } from "~/app/hooks";
 import { selectUser } from "~/features/auth/auth.slice";
 
+import { RouterLink } from "./RouterLink";
 import { USER_DETAIL_ROUTE } from "./routes";
 
 interface AccountDropdownMenuProps {
@@ -31,11 +31,12 @@ const AccountDropdownMenu = ({
                 {username}
               </Typography.Text>
             ) : (
-              <NextLink href={USER_DETAIL_ROUTE.replace("[id]", userId!)}>
-                <Typography.Link data-testid="header-menu-username">
-                  {username}
-                </Typography.Link>
-              </NextLink>
+              <RouterLink
+                href={USER_DETAIL_ROUTE.replace("[id]", userId!)}
+                data-testid="header-menu-username"
+              >
+                {username}
+              </RouterLink>
             ),
             type: "group",
           },

--- a/clients/admin-ui/src/features/common/nav/MainSideNav.tsx
+++ b/clients/admin-ui/src/features/common/nav/MainSideNav.tsx
@@ -5,7 +5,6 @@ import {
   Icons,
 } from "fidesui";
 import palette from "fidesui/src/palette/palette.module.scss";
-import NextLink from "next/link";
 import { useRouter } from "next/router";
 import React from "react";
 
@@ -23,6 +22,7 @@ import { ActiveNav, NavGroup } from "./nav-config";
 import { NavMenu } from "./NavMenu";
 import styles from "./NavMenu.module.scss";
 import NavSearch from "./NavSearch";
+import { RouterLink } from "./RouterLink";
 
 const NAV_BACKGROUND_COLOR = palette.FIDESUI_MINOS;
 const NAV_WIDTH = "240px";
@@ -77,13 +77,14 @@ export const UnconnectedMainSideNav = ({
           .map((child) => ({
             key: child.path,
             label: (
-              <NextLink
+              <RouterLink
+                unstyled
                 href={child.path}
                 data-testid={`${child.title}-nav-link`}
                 className="ml-4 pl-0.5"
               >
                 {child.title}
-              </NextLink>
+              </RouterLink>
             ),
           })),
       ],

--- a/clients/admin-ui/src/features/common/nav/NavSearchModal.tsx
+++ b/clients/admin-ui/src/features/common/nav/NavSearchModal.tsx
@@ -1,6 +1,5 @@
 import { Icons, Input, InputRef, Modal } from "fidesui";
 import palette from "fidesui/src/palette/palette.module.scss";
-import NextLink from "next/link";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 
@@ -8,6 +7,7 @@ import { pluralize } from "~/features/common/utils";
 
 import { NavGroup } from "./nav-config";
 import styles from "./NavSearch.module.scss";
+import { RouterLink } from "./RouterLink";
 import useNavSearchItems, { FlatNavItem } from "./useNavSearchItems";
 
 const SEARCH_ICON_STYLE = {
@@ -49,7 +49,8 @@ const NavSearchResultItem = ({
   onClose,
   onMouseEnter,
 }: NavSearchResultItemProps) => (
-  <NextLink
+  <RouterLink
+    unstyled
     href={item.path}
     id={`nav-search-result-${item.idx}`}
     role="option"
@@ -63,7 +64,7 @@ const NavSearchResultItem = ({
     {item.parentTitle && (
       <span className={styles.resultItemParent}>{item.parentTitle}</span>
     )}
-  </NextLink>
+  </RouterLink>
 );
 
 interface NavSearchModalProps {

--- a/clients/admin-ui/src/features/common/nav/NextBreadcrumb.tsx
+++ b/clients/admin-ui/src/features/common/nav/NextBreadcrumb.tsx
@@ -7,8 +7,9 @@ import {
   Typography,
 } from "fidesui";
 import { Url } from "next/dist/shared/lib/router/router";
-import NextLink from "next/link";
 import { ReactNode, useMemo } from "react";
+
+import { RouterLink } from "./RouterLink";
 
 const { Text } = Typography;
 
@@ -80,9 +81,13 @@ export const NextBreadcrumb = ({ items, ...props }: NextBreadcrumbProps) => {
         if (modifiedItem.href && modifiedItem.title) {
           // repeat the ant breadcrumb link class to match the style and margin of the ant breadcrumb item
           modifiedItem.title = (
-            <NextLink href={modifiedItem.href} className="ant-breadcrumb-link">
+            <RouterLink
+              unstyled
+              href={modifiedItem.href}
+              className="ant-breadcrumb-link"
+            >
               {modifiedItem.title}
-            </NextLink>
+            </RouterLink>
           );
           delete modifiedItem.href;
         }

--- a/clients/admin-ui/src/features/common/nav/RouterLink.test.tsx
+++ b/clients/admin-ui/src/features/common/nav/RouterLink.test.tsx
@@ -138,6 +138,17 @@ describe("RouterLink", () => {
       expect(anchor).toHaveAttribute("rel", "noopener noreferrer");
     });
 
+    it("forwards className to the next/link anchor", () => {
+      render(
+        <RouterLink href="/dashboard" className="mb-4">
+          <Button>Go</Button>
+        </RouterLink>,
+      );
+
+      const anchor = screen.getByRole("link", { name: "Go" });
+      expect(anchor).toHaveClass("mb-4");
+    });
+
     it("does not call router.push on click (next/link handles it)", () => {
       render(
         <RouterLink href="/dashboard">
@@ -293,6 +304,96 @@ describe("RouterLink", () => {
       // jest runs with NODE_ENV=test, so default prefetch behaviour is a no-op
       render(<RouterLink href="/details">Details</RouterLink>);
       expect(mockPrefetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("with unstyled mode", () => {
+    it("renders a plain <a> via NextLink with the correct href", () => {
+      render(
+        <RouterLink unstyled href="/dashboard">
+          <div>Card content</div>
+        </RouterLink>,
+      );
+
+      const anchor = screen.getByRole("link");
+      expect(anchor).toHaveAttribute("href", "/dashboard");
+      expect(anchor.tagName).toBe("A");
+      // Should NOT have Typography.Link's ant-typography class
+      expect(anchor).not.toHaveClass("ant-typography");
+    });
+
+    it("forwards className, id, role, data-testid, and aria-selected", () => {
+      render(
+        <RouterLink
+          unstyled
+          href="/item"
+          className="pt-4"
+          id="result-0"
+          role="option"
+          aria-selected
+          data-testid="search-result"
+        >
+          Result
+        </RouterLink>,
+      );
+
+      const anchor = screen.getByRole("option");
+      expect(anchor).toHaveClass("pt-4");
+      expect(anchor).toHaveAttribute("id", "result-0");
+      expect(anchor).toHaveAttribute("aria-selected", "true");
+      expect(anchor).toHaveAttribute("data-testid", "search-result");
+    });
+
+    it("does not call router.push on click (NextLink handles it)", () => {
+      render(
+        <RouterLink unstyled href="/dashboard">
+          <div>Card</div>
+        </RouterLink>,
+      );
+
+      fireEvent.click(screen.getByRole("link"), { button: 0 });
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+
+    it("forwards onClick to NextLink", () => {
+      const onClick = jest.fn();
+      render(
+        <RouterLink unstyled href="/dashboard" onClick={onClick}>
+          <div>Card</div>
+        </RouterLink>,
+      );
+
+      fireEvent.click(screen.getByRole("link"));
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it("forwards onMouseEnter", () => {
+      const onMouseEnter = jest.fn();
+      render(
+        <RouterLink unstyled href="/dashboard" onMouseEnter={onMouseEnter}>
+          <div>Card</div>
+        </RouterLink>,
+      );
+
+      fireEvent.mouseEnter(screen.getByRole("link"));
+      expect(onMouseEnter).toHaveBeenCalledTimes(1);
+    });
+
+    it("forwards target and rel", () => {
+      render(
+        <RouterLink
+          unstyled
+          href="/external"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          External
+        </RouterLink>,
+      );
+
+      const anchor = screen.getByRole("link", { name: "External" });
+      expect(anchor).toHaveAttribute("target", "_blank");
+      expect(anchor).toHaveAttribute("rel", "noopener noreferrer");
     });
   });
 });

--- a/clients/admin-ui/src/features/common/nav/RouterLink.tsx
+++ b/clients/admin-ui/src/features/common/nav/RouterLink.tsx
@@ -2,6 +2,7 @@ import { Button, Typography } from "fidesui";
 import NextLink, { LinkProps as NextLinkProps } from "next/link";
 import { useRouter } from "next/router";
 import {
+  AnchorHTMLAttributes,
   Children,
   ComponentProps,
   isValidElement,
@@ -11,6 +12,11 @@ import {
   useEffect,
 } from "react";
 import type { UrlObject } from "url";
+
+type AnchorProps = Omit<
+  AnchorHTMLAttributes<HTMLAnchorElement>,
+  "href" | "onClick"
+>;
 
 const { Link: TypographyLink } = Typography;
 
@@ -51,14 +57,19 @@ type TypographyLinkProps = Omit<
   "href" | "onClick"
 >;
 
-export interface RouterLinkProps extends TypographyLinkProps {
+interface BaseRouterLinkProps {
   href: Href;
   children: ReactNode;
   onClick?: (e: MouseEvent<HTMLElement>) => void;
   replace?: NextLinkProps["replace"];
   scroll?: NextLinkProps["scroll"];
   prefetch?: NextLinkProps["prefetch"];
+  className?: string;
 }
+
+export type RouterLinkProps =
+  | (BaseRouterLinkProps & { unstyled: true } & AnchorProps)
+  | (BaseRouterLinkProps & { unstyled?: false } & TypographyLinkProps);
 
 const isAntButtonChild = (children: ReactNode): boolean => {
   const arr = Children.toArray(children);
@@ -72,33 +83,49 @@ const isAntButtonChild = (children: ReactNode): boolean => {
 /**
  * Shared internal-navigation link for admin-ui.
  *
- * - When the single child is an antd `Button`, wraps it in `next/link` so
- *   Next renders its own `<a>` around the button. Preserves client-side
- *   routing, prefetch, and modifier-click handling.
- * - Otherwise renders a `Typography.Link`-styled anchor that intercepts
- *   plain left-clicks and uses `router.push` for client-side navigation.
- *   Modifier, middle, and right clicks fall through to the browser so
- *   new-tab / copy-link behaviour continues to work.
+ * Three rendering modes:
  *
- * Detection is structural (only a single antd `Button` element is detected).
- * If you need to wrap a custom button-like component, extract its render
- * and wrap the real antd `Button`, or add a `button` escape-hatch prop.
+ * 1. **Button child** - When the single child is an antd `Button`, wraps it
+ *    in `next/link` so Next renders its own `<a>` around the button.
+ *    Preserves client-side routing, prefetch, and modifier-click handling.
+ *
+ * 2. **Unstyled** (`unstyled` prop) - Delegates to `next/link` directly,
+ *    rendering a plain `<a>` with no Typography.Link styling. Use this
+ *    when wrapping cards, list items, or other non-text content that
+ *    shouldn't inherit link colors/underlines. All standard anchor
+ *    attributes (className, id, role, aria-*, data-*) are forwarded.
+ *
+ * 3. **Text mode** (default) - Renders a `Typography.Link`-styled anchor
+ *    that intercepts plain left-clicks and uses `router.push` for
+ *    client-side navigation. Modifier, middle, and right clicks fall
+ *    through to the browser so new-tab / copy-link behaviour continues
+ *    to work.
+ *
+ * Button detection is structural (only a single antd `Button` element is
+ * detected). If you need to wrap a custom button-like component, use
+ * `unstyled` instead.
  */
-export const RouterLink = ({
-  href,
-  children,
-  onClick,
-  replace,
-  scroll,
-  prefetch,
-  target,
-  rel,
-  ...typographyProps
-}: RouterLinkProps) => {
+export const RouterLink = (props: RouterLinkProps) => {
+  const {
+    href,
+    children,
+    onClick,
+    replace,
+    scroll,
+    prefetch,
+    unstyled,
+    className,
+    ...rest
+  } = props;
+
   const router = useRouter();
   const isButtonChild = isAntButtonChild(children);
+  const useNextLink = isButtonChild || unstyled;
   const hrefString = typeof href === "string" ? href : formatHref(href);
+  const { target } = rest;
+  const { rel } = rest;
 
+  // Text-mode prefetch (hooks must be called unconditionally)
   const prefetchHref = useCallback(() => {
     router.prefetch(hrefString).catch(() => {
       // prefetch is best-effort; ignore failures
@@ -107,7 +134,7 @@ export const RouterLink = ({
 
   useEffect(() => {
     if (
-      isButtonChild ||
+      useNextLink ||
       process.env.NODE_ENV !== "production" ||
       prefetch === false ||
       prefetch === null ||
@@ -116,9 +143,16 @@ export const RouterLink = ({
       return;
     }
     prefetchHref();
-  }, [isButtonChild, prefetch, prefetchHref, target]);
+  }, [useNextLink, prefetch, prefetchHref, target]);
 
-  if (isButtonChild) {
+  // Modes 1 & 2: delegate to NextLink (button child or unstyled)
+  if (useNextLink) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- destructure to exclude from spread
+    const {
+      target: anchorTarget,
+      rel: anchorRel,
+      ...anchorProps
+    } = rest as AnchorProps;
     return (
       <NextLink
         href={href}
@@ -127,17 +161,27 @@ export const RouterLink = ({
         prefetch={prefetch}
         target={target}
         rel={rel}
+        className={className}
+        onClick={onClick as NextLinkProps["onClick"]}
+        {...anchorProps}
       >
         {children}
       </NextLink>
     );
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- destructure to exclude from spread
+  const {
+    target: typTarget,
+    rel: typRel,
+    ...typographyProps
+  } = rest as TypographyLinkProps;
   return (
     <TypographyLink
       href={hrefString}
       target={target}
       rel={rel}
+      className={className}
       onMouseEnter={prefetch === null ? prefetchHref : undefined}
       onClick={(e) => {
         onClick?.(e);

--- a/clients/admin-ui/src/features/common/nav/RouterLink.tsx
+++ b/clients/admin-ui/src/features/common/nav/RouterLink.tsx
@@ -60,7 +60,7 @@ type TypographyLinkProps = Omit<
 interface BaseRouterLinkProps {
   href: Href;
   children: ReactNode;
-  onClick?: (e: MouseEvent<HTMLElement>) => void;
+  onClick?: NextLinkProps["onClick"];
   replace?: NextLinkProps["replace"];
   scroll?: NextLinkProps["scroll"];
   prefetch?: NextLinkProps["prefetch"];
@@ -162,7 +162,7 @@ export const RouterLink = (props: RouterLinkProps) => {
         target={target}
         rel={rel}
         className={className}
-        onClick={onClick as NextLinkProps["onClick"]}
+        onClick={onClick}
         {...anchorProps}
       >
         {children}
@@ -183,7 +183,7 @@ export const RouterLink = (props: RouterLinkProps) => {
       rel={rel}
       className={className}
       onMouseEnter={prefetch === null ? prefetchHref : undefined}
-      onClick={(e) => {
+      onClick={(e: MouseEvent<HTMLAnchorElement>) => {
         onClick?.(e);
         if (
           e.defaultPrevented ||

--- a/clients/admin-ui/src/features/common/nav/RouterLink.tsx
+++ b/clients/admin-ui/src/features/common/nav/RouterLink.tsx
@@ -115,6 +115,8 @@ export const RouterLink = (props: RouterLinkProps) => {
     prefetch,
     unstyled,
     className,
+    target,
+    rel,
     ...rest
   } = props;
 
@@ -122,8 +124,6 @@ export const RouterLink = (props: RouterLinkProps) => {
   const isButtonChild = isAntButtonChild(children);
   const useNextLink = isButtonChild || unstyled;
   const hrefString = typeof href === "string" ? href : formatHref(href);
-  const { target } = rest;
-  const { rel } = rest;
 
   // Text-mode prefetch (hooks must be called unconditionally)
   const prefetchHref = useCallback(() => {
@@ -147,12 +147,6 @@ export const RouterLink = (props: RouterLinkProps) => {
 
   // Modes 1 & 2: delegate to NextLink (button child or unstyled)
   if (useNextLink) {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- destructure to exclude from spread
-    const {
-      target: anchorTarget,
-      rel: anchorRel,
-      ...anchorProps
-    } = rest as AnchorProps;
     return (
       <NextLink
         href={href}
@@ -163,19 +157,13 @@ export const RouterLink = (props: RouterLinkProps) => {
         rel={rel}
         className={className}
         onClick={onClick}
-        {...anchorProps}
+        {...(rest as AnchorProps)}
       >
         {children}
       </NextLink>
     );
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- destructure to exclude from spread
-  const {
-    target: typTarget,
-    rel: typRel,
-    ...typographyProps
-  } = rest as TypographyLinkProps;
   return (
     <TypographyLink
       href={hrefString}
@@ -205,7 +193,7 @@ export const RouterLink = (props: RouterLinkProps) => {
           // navigation errors are surfaced by Next's own error handling
         });
       }}
-      {...typographyProps}
+      {...(rest as TypographyLinkProps)}
     >
       {children}
     </TypographyLink>

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/MonitorDetailsWidget.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/MonitorDetailsWidget.tsx
@@ -1,8 +1,8 @@
 import { skipToken } from "@reduxjs/toolkit/query";
 import { Descriptions, Flex, Paragraph, Text } from "fidesui";
-import Link from "next/link";
 
 import { useFlags } from "~/features/common/features";
+import { RouterLink } from "~/features/common/nav/RouterLink";
 import {
   EDIT_SYSTEM_ROUTE,
   INTEGRATION_DETAIL_ROUTE,
@@ -53,7 +53,7 @@ const MonitorDetailsWidget = ({ monitorId }: MonitorDetailsWidgetProps) => {
                     }}
                   >
                     {connectionData?.linked_systems?.map((linkedSystem) => (
-                      <Link
+                      <RouterLink
                         key={linkedSystem.fides_key}
                         href={EDIT_SYSTEM_ROUTE.replace(
                           "[id]",
@@ -62,7 +62,7 @@ const MonitorDetailsWidget = ({ monitorId }: MonitorDetailsWidgetProps) => {
                       >
                         {" "}
                         {linkedSystem.name}
-                      </Link>
+                      </RouterLink>
                     ))}
                   </Paragraph>
                 ) : (
@@ -79,14 +79,14 @@ const MonitorDetailsWidget = ({ monitorId }: MonitorDetailsWidgetProps) => {
                     tooltip: { title: connectionData?.key },
                   }}
                 >
-                  <Link
+                  <RouterLink
                     href={INTEGRATION_DETAIL_ROUTE.replace(
                       "[id]",
                       connectionData?.key ?? "",
                     )}
                   >
                     {connectionData?.key}
-                  </Link>
+                  </RouterLink>
                 </Paragraph>
               ),
               span: "filled",

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/MonitorProgressWidget.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/MonitorProgressWidget.tsx
@@ -1,8 +1,8 @@
 import { Button, Flex, Icons, Text, Title } from "fidesui";
-import Link from "next/link";
 import { useQueryStates } from "nuqs";
 
 import { useFlags } from "~/features/common/features";
+import { RouterLink } from "~/features/common/nav/RouterLink";
 import { INTEGRATION_MANAGEMENT_ROUTE } from "~/features/common/nav/routes";
 import { APIMonitorType } from "~/types/api/models/APIMonitorType";
 
@@ -76,9 +76,9 @@ const MonitorProgressWidget = ({
               <Text type="secondary">
                 {MONITOR_TYPE_TO_EMPTY_TEXT[monitorType]}
               </Text>
-              <Link href={INTEGRATION_MANAGEMENT_ROUTE}>
+              <RouterLink href={INTEGRATION_MANAGEMENT_ROUTE}>
                 <Button type="primary">Create</Button>
-              </Link>
+              </RouterLink>
             </Flex>
           </div>
         )}

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/MonitorResult.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/MonitorResult.tsx
@@ -14,7 +14,6 @@ import {
   Typography,
 } from "fidesui";
 import palette from "fidesui/src/palette/palette.module.scss";
-import NextLink from "next/link";
 import { useState } from "react";
 
 import { RouterLink } from "~/features/common/nav/RouterLink";
@@ -182,13 +181,14 @@ export const MonitorResult = ({
             gap={4}
             className="flex-wrap overflow-hidden whitespace-nowrap font-normal"
           >
-            <NextLink
+            <RouterLink
+              unstyled
               href={href}
               data-testid="monitor-link"
               className="overflow-hidden font-semibold"
             >
               <Text ellipsis>{name}</Text>
-            </NextLink>
+            </RouterLink>
             <Text type="secondary">
               {nFormatter(totalUpdates ?? 0)} {monitorResultCountType}
             </Text>

--- a/clients/admin-ui/src/features/integrations/configure-tasks/CreateExternalUserModal.tsx
+++ b/clients/admin-ui/src/features/integrations/configure-tasks/CreateExternalUserModal.tsx
@@ -1,9 +1,9 @@
 import { Button, Form, Input, Typography, useMessage } from "fidesui";
-import Link from "next/link";
 import { useState } from "react";
 
 import { getErrorMessage, isErrorResult } from "~/features/common/helpers";
 import ConfirmCloseModal from "~/features/common/modals/ConfirmCloseModal";
+import { RouterLink } from "~/features/common/nav/RouterLink";
 import { USER_MANAGEMENT_ROUTE } from "~/features/common/nav/routes";
 
 import { useCreateExternalUserMutation } from "./external-user.slice";
@@ -92,7 +92,8 @@ const CreateExternalUserModal = ({
         <Paragraph type="secondary">
           If you need to create an internal user that can log in to the Fides
           admin interface, please use the{" "}
-          <Link href={USER_MANAGEMENT_ROUTE}>Users page</Link> instead.
+          <RouterLink href={USER_MANAGEMENT_ROUTE}>Users page</RouterLink>{" "}
+          instead.
         </Paragraph>
       </div>
 

--- a/clients/admin-ui/src/features/privacy-assessments/AssessmentCard.tsx
+++ b/clients/admin-ui/src/features/privacy-assessments/AssessmentCard.tsx
@@ -14,9 +14,9 @@ import {
   Text,
   Typography,
 } from "fidesui";
-import NextLink from "next/link";
 
 import useTaxonomies from "~/features/common/hooks/useTaxonomies";
+import { RouterLink } from "~/features/common/nav/RouterLink";
 import { PRIVACY_ASSESSMENTS_ROUTE } from "~/features/common/nav/routes";
 import { formatDate } from "~/features/common/utils";
 
@@ -75,9 +75,12 @@ export const AssessmentCard = ({
       <Flex vertical gap="small" justify="space-between" className="flex-1">
         <div>
           <Title level={3} className={`!mb-1 ${styles.titleLink}`}>
-            <NextLink href={`${PRIVACY_ASSESSMENTS_ROUTE}/${assessment.id}`}>
+            <RouterLink
+              unstyled
+              href={`${PRIVACY_ASSESSMENTS_ROUTE}/${assessment.id}`}
+            >
               {assessment.template_name ?? assessment.name}
-            </NextLink>
+            </RouterLink>
           </Title>
           {assessment.system_name && (
             <Text type="secondary" size="sm" className="block">

--- a/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
@@ -15,7 +15,6 @@ import {
   useMessage,
 } from "fidesui";
 import { Form, Formik } from "formik";
-import NextLink from "next/link";
 import { useRouter } from "next/router";
 import { useMemo } from "react";
 
@@ -24,6 +23,7 @@ import FormSection from "~/features/common/form/FormSection";
 import { CustomSwitch, CustomTextInput } from "~/features/common/form/inputs";
 import { getErrorMessage, isErrorResult } from "~/features/common/helpers";
 import { InfoTooltip } from "~/features/common/InfoTooltip";
+import { RouterLink } from "~/features/common/nav/RouterLink";
 import { PRIVACY_NOTICES_ROUTE } from "~/features/common/nav/routes";
 import * as routes from "~/features/common/nav/routes";
 import { PRIVACY_NOTICE_REGION_RECORD } from "~/features/common/privacy-notice-regions";
@@ -95,9 +95,9 @@ const PrivacyNoticeLocationDisplay = ({
         {!regions?.length && (
           <Text italic>
             No locations assigned. Navigate to the{" "}
-            <NextLink href={routes.PRIVACY_EXPERIENCE_ROUTE}>
+            <RouterLink href={routes.PRIVACY_EXPERIENCE_ROUTE}>
               experiences view
-            </NextLink>{" "}
+            </RouterLink>{" "}
             configure.
           </Text>
         )}

--- a/clients/admin-ui/src/features/system/hooks/useSystemFormTabs.tsx
+++ b/clients/admin-ui/src/features/system/hooks/useSystemFormTabs.tsx
@@ -6,7 +6,6 @@ import {
   TabsProps,
   useNotification,
 } from "fidesui";
-import NextLink from "next/link";
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useState } from "react";
 
@@ -14,6 +13,7 @@ import { useAppDispatch, useAppSelector } from "~/app/hooks";
 import { useFeatures } from "~/features/common/features";
 import { useIsAnyFormDirty } from "~/features/common/hooks/useIsAnyFormDirty";
 import { useSystemOrDatamapRoute } from "~/features/common/hooks/useSystemOrDatamapRoute";
+import { RouterLink } from "~/features/common/nav/RouterLink";
 import {
   EDIT_SYSTEM_ROUTE,
   INTEGRATION_MANAGEMENT_ROUTE,
@@ -180,13 +180,9 @@ const useSystemFormTabs = ({
                 data-testid="save-help-message"
               >
                 Now that you have saved this new system it is{" "}
-                <Link
-                  as={NextLink}
-                  href={systemOrDatamapRoute}
-                  textDecor="underline"
-                >
+                <RouterLink href={systemOrDatamapRoute}>
                   ready to view in your data map
-                </Link>
+                </RouterLink>
                 . You can return to this setup at any time to add privacy
                 declarations to this system.
               </Text>

--- a/clients/admin-ui/src/features/system/privacy-declarations/PrivacyDeclarationStep.tsx
+++ b/clients/admin-ui/src/features/system/privacy-declarations/PrivacyDeclarationStep.tsx
@@ -1,12 +1,11 @@
 import {
   ChakraHeading as Heading,
-  ChakraLink as Link,
   ChakraStack as Stack,
   ChakraText as Text,
   Spin,
 } from "fidesui";
-import NextLink from "next/link";
 
+import { RouterLink } from "~/features/common/nav/RouterLink";
 import { usePrivacyDeclarationData } from "~/features/system/privacy-declarations/hooks";
 import PrivacyDeclarationFormTab from "~/features/system/system-form-declaration-tab/PrivacyDeclarationFormTab";
 import { SystemResponse } from "~/types/api";
@@ -49,10 +48,7 @@ const PrivacyDeclarationStep = ({ system }: Props) => {
         of personal information are collected for this purpose and for which
         categories of data subjects. To update the available categories and
         uses, please visit{" "}
-        <Link as={NextLink} href="/taxonomy" color="link.900">
-          Manage taxonomy
-        </Link>
-        .
+        <RouterLink href="/taxonomy">Manage taxonomy</RouterLink>.
       </Text>
       {isLoading ? (
         <Spin />

--- a/clients/admin-ui/src/home/ActivityFeedCard.tsx
+++ b/clients/admin-ui/src/home/ActivityFeedCard.tsx
@@ -2,9 +2,9 @@ import classNames from "classnames";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import { Avatar, Card, Flex, Icons, Spin, Text } from "fidesui";
-import NextLink from "next/link";
 import { useEffect, useRef, useState } from "react";
 
+import { RouterLink } from "~/features/common/nav/RouterLink";
 import {
   ACTION_CTA,
   ACTIVITY_FILTER_OPTIONS,
@@ -117,12 +117,13 @@ export const ActivityFeedCard = () => {
           return (
             <div key={item.id}>
               {href ? (
-                <NextLink
+                <RouterLink
+                  unstyled
                   href={href}
                   className={classNames(styles.feedItem, styles.clickable)}
                 >
                   <FeedItemContent item={item} />
-                </NextLink>
+                </RouterLink>
               ) : (
                 <div
                   className={classNames(styles.feedItem, styles.nonClickable)}

--- a/clients/admin-ui/src/home/AgentBriefingBanner.tsx
+++ b/clients/admin-ui/src/home/AgentBriefingBanner.tsx
@@ -7,10 +7,10 @@ import {
   useThemeMode,
 } from "fidesui";
 import palette from "fidesui/src/palette/palette.module.scss";
-import NextLink from "next/link";
 import { useMemo } from "react";
 
 import { useFlags } from "~/features/common/features";
+import { RouterLink } from "~/features/common/nav/RouterLink";
 import { ACTION_CTA } from "~/features/dashboard/constants";
 import { useGetAgentBriefingQuery } from "~/features/dashboard/dashboard.slice";
 import { ActionSeverity } from "~/features/dashboard/types";
@@ -75,7 +75,7 @@ export const AgentBriefingBanner = () => {
                   const severityClass =
                     SEVERITY_STYLE[action.severity] ?? styles.info;
                   return (
-                    <NextLink
+                    <RouterLink
                       key={`${action.action_type}-${action.label}`}
                       href={cta.route(action.action_data)}
                       className={styles.quickActionTile}
@@ -86,7 +86,7 @@ export const AgentBriefingBanner = () => {
                       >
                         {action.label}
                       </Button>
-                    </NextLink>
+                    </RouterLink>
                   );
                 })}
               </Flex>

--- a/clients/admin-ui/src/home/DSRStatusCard.tsx
+++ b/clients/admin-ui/src/home/DSRStatusCard.tsx
@@ -9,10 +9,10 @@ import {
   Text,
   Tooltip,
 } from "fidesui";
-import NextLink from "next/link";
 import { useRouter } from "next/router";
 import { useCallback } from "react";
 
+import { RouterLink } from "~/features/common/nav/RouterLink";
 import { PRIVACY_REQUESTS_ROUTE } from "~/features/common/nav/routes";
 import { useGetPrivacyRequestsQuery } from "~/features/dashboard/dashboard.slice";
 
@@ -81,12 +81,16 @@ export const DSRStatusCard = () => {
       }
       loading={isLoading}
       extra={
-        <NextLink href={PRIVACY_REQUESTS_ROUTE} className={styles.viewAllLink}>
+        <RouterLink
+          unstyled
+          href={PRIVACY_REQUESTS_ROUTE}
+          className={styles.viewAllLink}
+        >
           <Flex align="center" gap={4}>
             View all requests
             <Icons.ArrowRight size={14} />
           </Flex>
-        </NextLink>
+        </RouterLink>
       }
       variant="borderless"
       className={styles.cardContainer}
@@ -123,7 +127,8 @@ export const DSRStatusCard = () => {
                 ))}
               </Flex>
               {(data?.overdue_count ?? 0) > 0 && (
-                <NextLink
+                <RouterLink
+                  unstyled
                   href={`${PRIVACY_REQUESTS_ROUTE}?is_overdue=true`}
                   className={styles.overdueBadge}
                 >
@@ -136,7 +141,7 @@ export const DSRStatusCard = () => {
                     overdue
                   </Text>
                   <Icons.ArrowRight size={12} color={token.colorError} />
-                </NextLink>
+                </RouterLink>
               )}
             </div>
           </Flex>

--- a/clients/admin-ui/src/home/HomeContent.tsx
+++ b/clients/admin-ui/src/home/HomeContent.tsx
@@ -1,11 +1,11 @@
 import { Col, Flex, Row } from "fidesui";
-import NextLink from "next/link";
 import * as React from "react";
 import { useMemo } from "react";
 
 import { useAppSelector } from "~/app/hooks";
 import CalloutNavCard from "~/features/common/CalloutNavCard";
 import { useFeatures } from "~/features/common/features";
+import { RouterLink } from "~/features/common/nav/RouterLink";
 import { selectThisUsersScopes } from "~/features/user-management";
 
 import { MODULE_CARD_ITEMS } from "./constants";
@@ -33,13 +33,13 @@ const HomeContent = () => {
           .sort((a, b) => (a.sortOrder > b.sortOrder ? 1 : -1))
           .map((item) => (
             <Col key={item.key} xs={24} md={12} xl={8}>
-              <NextLink href={item.href} className="flex h-full">
+              <RouterLink unstyled href={item.href} className="flex h-full">
                 <CalloutNavCard
                   title={item.name}
                   description={item.description}
                   color={item.color}
                 />
-              </NextLink>
+              </RouterLink>
             </Col>
           ))}
       </Row>

--- a/clients/admin-ui/src/home/PostureBreakdownContent.tsx
+++ b/clients/admin-ui/src/home/PostureBreakdownContent.tsx
@@ -8,8 +8,8 @@ import {
   Tag,
   Text,
 } from "fidesui";
-import NextLink from "next/link";
 
+import { RouterLink } from "~/features/common/nav/RouterLink";
 import {
   BAND_CONFIG,
   DIMENSION_DESCRIPTIONS,
@@ -116,13 +116,14 @@ export const PostureBreakdownContent = () => {
 
         if (route) {
           return (
-            <NextLink
+            <RouterLink
+              unstyled
               key={dim.dimension}
               href={route.route}
               className={styles.dimensionLink}
             >
               {card}
-            </NextLink>
+            </RouterLink>
           );
         }
         return card;

--- a/clients/admin-ui/src/home/PriorityActionsCard.tsx
+++ b/clients/admin-ui/src/home/PriorityActionsCard.tsx
@@ -10,9 +10,9 @@ import {
   Tag,
   Text,
 } from "fidesui";
-import NextLink from "next/link";
 import { useMemo, useState } from "react";
 
+import { RouterLink } from "~/features/common/nav/RouterLink";
 import { capitalize } from "~/features/common/utils";
 import {
   ACTION_CTA,
@@ -166,7 +166,12 @@ export const PriorityActionsCard = () => {
           const href = cta.route(action.action_data);
           const daysInfo = getDaysRemaining(action.due_date);
           return (
-            <NextLink key={action.id} href={href} className={styles.actionRow}>
+            <RouterLink
+              unstyled
+              key={action.id}
+              href={href}
+              className={styles.actionRow}
+            >
               <List.Item>
                 <List.Item.Meta
                   title={
@@ -188,7 +193,7 @@ export const PriorityActionsCard = () => {
                 />
                 <Icons.Launch size={14} className={styles.launchIcon} />
               </List.Item>
-            </NextLink>
+            </RouterLink>
           );
         }}
       />

--- a/clients/admin-ui/src/pages/forgot-password.tsx
+++ b/clients/admin-ui/src/pages/forgot-password.tsx
@@ -10,11 +10,11 @@ import {
   useMessage,
 } from "fidesui";
 import type { NextPage } from "next";
-import Link from "next/link";
 import { useState } from "react";
 
 import { useForgotPasswordMutation } from "~/features/auth";
 import { getErrorMessage } from "~/features/common/helpers";
+import { RouterLink } from "~/features/common/nav/RouterLink";
 import { RTKErrorResult } from "~/types/errors/api";
 
 interface ForgotPasswordFormValues {
@@ -70,11 +70,11 @@ const ForgotPassword: NextPage = () => {
                       If an account with that email exists, we&apos;ve sent a
                       password reset link. Please check your inbox.
                     </Typography.Text>
-                    <Link href="/login">
+                    <RouterLink href="/login">
                       <Button type="link" data-testid="back-to-login-btn">
                         Back to sign in
                       </Button>
-                    </Link>
+                    </RouterLink>
                   </Flex>
                 ) : (
                   <Form
@@ -123,11 +123,11 @@ const ForgotPassword: NextPage = () => {
                         Send reset link
                       </Button>
                       <Flex justify="center" className="mt-4">
-                        <Link href="/login">
+                        <RouterLink href="/login">
                           <Button type="link" data-testid="back-to-login-btn">
                             Back to sign in
                           </Button>
-                        </Link>
+                        </RouterLink>
                       </Flex>
                     </Flex>
                   </Form>

--- a/clients/admin-ui/src/pages/login.tsx
+++ b/clients/admin-ui/src/pages/login.tsx
@@ -12,7 +12,6 @@ import {
 } from "fidesui";
 import { motion } from "motion/react";
 import type { NextPage } from "next";
-import Link from "next/link";
 import { useRouter } from "next/router";
 import { ParsedUrlQuery } from "querystring";
 import { useEffect, useMemo, useState } from "react";
@@ -29,6 +28,7 @@ import {
 import { passwordRules as strongPasswordRules } from "~/features/common/form/validation";
 import { getErrorMessage } from "~/features/common/helpers";
 import { usePrefersReducedMotion } from "~/features/common/hooks";
+import { RouterLink } from "~/features/common/nav/RouterLink";
 import { useGetAllOpenIDProvidersSimpleQuery } from "~/features/openid-authentication/openprovider.slice";
 import { RTKErrorResult } from "~/types/errors/api";
 
@@ -408,14 +408,14 @@ const Login: NextPage = () => {
                         </Flex>
                         {!isFromInvite && !isResetPassword && (
                           <Flex justify="center" className="mt-4">
-                            <Link href="/forgot-password">
+                            <RouterLink href="/forgot-password">
                               <Button
                                 type="link"
                                 data-testid="forgot-password-btn"
                               >
                                 Forgot password?
                               </Button>
-                            </Link>
+                            </RouterLink>
                           </Flex>
                         )}
                       </>

--- a/clients/admin-ui/src/pages/privacy-requests/configure.tsx
+++ b/clients/admin-ui/src/pages/privacy-requests/configure.tsx
@@ -1,14 +1,12 @@
 import {
   ChakraBox as Box,
   ChakraHeading as Heading,
-  ChakraLinkBox as LinkBox,
-  ChakraLinkOverlay as LinkOverlay,
   Typography,
 } from "fidesui";
 import type { NextPage } from "next";
-import NextLink from "next/link";
 
 import Layout from "~/features/common/Layout";
+import { RouterLink } from "~/features/common/nav/RouterLink";
 import { PRIVACY_REQUESTS_ROUTE } from "~/features/common/nav/routes";
 import PageHeader from "~/features/common/PageHeader";
 
@@ -32,45 +30,31 @@ const ConfigurePrivacyRequests: NextPage = () => (
       my={5}
       data-testid="privacy-requests-configure"
     >
-      <LinkBox
-        p="5"
-        borderWidth="1px"
-        rounded="md"
-        borderColor="gray.300"
-        _hover={{ borderColor: "complimentary.500", cursor: "pointer" }}
-        mr={5}
-        minHeight="100%"
+      <RouterLink
+        unstyled
+        href="/privacy-requests/configure/messaging"
+        className="mr-5 block min-h-full rounded-md border border-gray-300 p-5 hover:cursor-pointer hover:border-[var(--fidesui-complimentary-500)]"
       >
         <Heading mb={2} size="sm">
-          <LinkOverlay
-            as={NextLink}
-            href="/privacy-requests/configure/messaging"
-          >
-            Configure messaging provider
-          </LinkOverlay>
+          Configure messaging provider
         </Heading>
         Fides supports email (Mailgun & Twilio) and SMS (Twilio) server
         configurations for sending processing notices to privacy request
         subjects. Configure your settings here.
-      </LinkBox>
-      <LinkBox
-        p="5"
-        borderWidth="1px"
-        rounded="md"
-        borderColor="gray.300"
-        _hover={{ borderColor: "complimentary.500", cursor: "pointer" }}
-        minHeight="100%"
+      </RouterLink>
+      <RouterLink
+        unstyled
+        href="/privacy-requests/configure/storage"
+        className="block min-h-full rounded-md border border-gray-300 p-5 hover:cursor-pointer hover:border-[var(--fidesui-complimentary-500)]"
       >
         <Heading mb={2} size="sm">
-          <LinkOverlay as={NextLink} href="/privacy-requests/configure/storage">
-            Configure storage
-          </LinkOverlay>
+          Configure storage
         </Heading>
         The data produced by an access request will need to be uploaded to a
         storage destination (e.g. an S3 bucket) in order to be returned to the
         user. At least one storage destination must be configured to process
         access requests. Configure your settings here.
-      </LinkBox>
+      </RouterLink>
     </Box>
   </Layout>
 );

--- a/clients/admin-ui/src/pages/settings/regulations.tsx
+++ b/clients/admin-ui/src/pages/settings/regulations.tsx
@@ -1,10 +1,10 @@
-import { ChakraLink as Link, ChakraText as Text, Spin } from "fidesui";
+import { ChakraText as Text, Spin } from "fidesui";
 import type { NextPage } from "next";
-import NextLink from "next/link";
 
 import { useAppSelector } from "~/app/hooks";
 import ErrorPage from "~/features/common/errors/ErrorPage";
 import Layout from "~/features/common/Layout";
+import { RouterLink } from "~/features/common/nav/RouterLink";
 import { LOCATIONS_ROUTE } from "~/features/common/nav/routes";
 import PageHeader from "~/features/common/PageHeader";
 import {
@@ -35,9 +35,9 @@ const RegulationsPage: NextPage = () => {
         Select the regulations that apply to your organizations compliance
         requirements. The selections you make here will automatically update
         your location selections.{" "}
-        <Link as={NextLink} href={LOCATIONS_ROUTE} color="complimentary.500">
+        <RouterLink href={LOCATIONS_ROUTE}>
           You can view your location settings here.
-        </Link>
+        </RouterLink>
       </Text>
       {isLoading ? (
         <Spin />

--- a/clients/admin-ui/src/pages/settings/regulations.tsx
+++ b/clients/admin-ui/src/pages/settings/regulations.tsx
@@ -1,4 +1,4 @@
-import { ChakraText as Text, Spin } from "fidesui";
+import { Spin, Typography } from "fidesui";
 import type { NextPage } from "next";
 
 import { useAppSelector } from "~/app/hooks";
@@ -31,14 +31,15 @@ const RegulationsPage: NextPage = () => {
   return (
     <Layout title="Regulations">
       <PageHeader heading="Regulations" />
-      <Text pb={6} fontSize="sm" maxWidth="600px">
+      <Typography.Paragraph className="max-w-xl pb-4">
         Select the regulations that apply to your organizations compliance
         requirements. The selections you make here will automatically update
-        your location selections.{" "}
+        your location selections.
+        <br />
         <RouterLink href={LOCATIONS_ROUTE}>
-          You can view your location settings here.
+          View your location settings
         </RouterLink>
-      </Text>
+      </Typography.Paragraph>
       {isLoading ? (
         <Spin />
       ) : (


### PR DESCRIPTION
Ticket [ENG-3461]

### Description Of Changes

Followup to #7942. Extends `RouterLink` with an `unstyled` prop and migrates all 22 remaining files that imported `next/link` directly, so `RouterLink.tsx` is now the sole file importing from `next/link`.

The `unstyled` prop delegates to `NextLink` directly, rendering a plain `<a>` without Typography.Link styling. This covers wrapping cards, list items, nav links, search results, breadcrumbs, and other non-text content that shouldn't inherit link colors/underlines.

Also forwards `className` in button mode (previously dropped).

### Code Changes

* **RouterLink.tsx**: Added `unstyled` boolean prop with discriminated union types (`AnchorProps` when unstyled, `TypographyLinkProps` otherwise). Both button mode and unstyled mode now delegate to `NextLink`. Added `className` forwarding in button mode.
* **22 consumer files**: Replaced `NextLink`, `Link from "next/link"`, `<Link as={NextLink}>` (Chakra), and `<LinkOverlay as={NextLink}>` (Chakra) patterns with `RouterLink`
* **NavSearch test mocks**: Added `Typography` and `Button` to fidesui mock since NavSearchModal now imports RouterLink
* **configure.tsx**: Replaced Chakra `LinkBox`/`LinkOverlay` pattern with `RouterLink unstyled` + Tailwind classes

### Steps to Confirm

1. Verify home page module cards navigate correctly (HomeContent)
2. Verify sidebar nav links work (MainSideNav)
3. Verify Cmd+K search modal navigates on result click (NavSearchModal)
4. Verify breadcrumb links work (NextBreadcrumb)
5. Verify login page "Forgot password?" link works
6. Verify DSR Status card "View all requests" and overdue links work
7. Verify Priority Actions card action rows navigate correctly
8. Verify account dropdown username link works
9. Verify configure privacy requests page cards are clickable with hover styling

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required

[ENG-3461]: https://ethyca.atlassian.net/browse/ENG-3461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ