### PR TITLE
ENG-3174: Migrate privacy notice forms to Ant Design

### DIFF
--- a/changelog/7950-privacy-notice-forms-ant.yaml
+++ b/changelog/7950-privacy-notice-forms-ant.yaml
@@ -1,0 +1,4 @@
+type: Changed
+description: Migrated privacy notice forms from Formik/Chakra to Ant Design
+pr: 7950
+labels: []

--- a/clients/admin-ui/cypress/e2e/privacy-notices.cy.ts
+++ b/clients/admin-ui/cypress/e2e/privacy-notices.cy.ts
@@ -218,9 +218,7 @@ describe("Privacy notices", () => {
         cy.getByTestId("input-name").should("have.value", notice.name);
 
         // consent mechanism section
-        cy.getByTestId("controlled-select-consent_mechanism").contains(
-          "Notice only",
-        );
+        cy.getByTestId("select-consent_mechanism").contains("Notice only");
 
         cy.getByTestId("notice-locations").should("contain", "United States");
 
@@ -229,14 +227,12 @@ describe("Privacy notices", () => {
         });
 
         // configuration section
-        notice.data_uses.forEach((dataUse) => {
-          cy.getByTestId("controlled-select-data_uses").contains(dataUse);
+        notice.data_uses.forEach((dataUse: string) => {
+          cy.getByTestId("select-data_uses").contains(dataUse);
         });
 
         // enforcement level
-        cy.getByTestId("controlled-select-enforcement_level").contains(
-          "Not applicable",
-        );
+        cy.getByTestId("select-enforcement_level").contains("Not applicable");
 
         // translations
         cy.getByTestId("input-translations.0.title").should(
@@ -347,13 +343,11 @@ describe("Privacy notices", () => {
       cy.getByTestId("input-name").type(notice.name);
 
       // consent mechanism section
-      cy.getByTestId("controlled-select-consent_mechanism").antSelect("Opt in");
+      cy.getByTestId("select-consent_mechanism").antSelect("Opt in");
       cy.getByTestId("input-has_gpc_flag").click();
 
       // configuration section
-      cy.getByTestId("controlled-select-data_uses").antSelect(
-        notice.data_uses[0],
-      );
+      cy.getByTestId("select-data_uses").antSelect(notice.data_uses[0]);
 
       // translations
       cy.getByTestId("input-translations.0.title").type("Title");

--- a/clients/admin-ui/src/features/privacy-notices/NoticeKeyField.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/NoticeKeyField.tsx
@@ -1,27 +1,22 @@
-import { useFormikContext } from "formik";
+import { Form, Input } from "fidesui";
 import snakeCase from "lodash.snakecase";
 import { useEffect } from "react";
 
-import { CustomTextInput } from "~/features/common/form/inputs";
-import { PrivacyNoticeResponse } from "~/types/api";
-
 const NoticeKeyField = ({ isEditing }: { isEditing: boolean }) => {
-  const { values, setFieldValue } = useFormikContext<PrivacyNoticeResponse>();
+  const form = Form.useFormInstance();
+  const name = Form.useWatch("name", form);
 
   useEffect(() => {
-    if (!isEditing) {
-      const noticeKey = snakeCase(values.name);
-      setFieldValue("notice_key", noticeKey);
+    if (!isEditing && name !== undefined && name !== null) {
+      form.setFieldsValue({ notice_key: snakeCase(name) });
     }
-  }, [values.name, isEditing, setFieldValue]);
+  }, [name, isEditing, form]);
 
   return (
-    <CustomTextInput
-      name="notice_key"
-      label="Key used in Fides cookie"
-      variant="stacked"
-    />
+    <Form.Item name="notice_key" label="Key used in Fides cookie">
+      <Input data-testid="input-notice_key" />
+    </Form.Item>
   );
 };
 
-export default NoticeKeyField;
+export { NoticeKeyField };

--- a/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
@@ -20,7 +20,7 @@ import { useRouter } from "next/router";
 import { useEffect, useMemo, useState } from "react";
 
 import { useAppSelector } from "~/app/hooks";
-import { getErrorMessage, isErrorResult } from "~/features/common/helpers";
+import { getErrorMessage } from "~/features/common/helpers";
 import { InfoTooltip } from "~/features/common/InfoTooltip";
 import { RouterLink } from "~/features/common/nav/RouterLink";
 import { PRIVACY_NOTICES_ROUTE } from "~/features/common/nav/routes";
@@ -39,6 +39,7 @@ import {
   PrivacyNoticeResponseWithRegions,
 } from "~/types/api";
 import type { MinimalPrivacyNotice } from "~/types/api/models/MinimalPrivacyNotice";
+import type { RTKErrorResult } from "~/types/errors/api";
 
 import {
   CONSENT_MECHANISM_OPTIONS,
@@ -147,26 +148,24 @@ const PrivacyNoticeForm = ({
   const isEditing = !!passedInPrivacyNotice;
 
   const handleSubmit = async (values: PrivacyNoticeCreation) => {
-    let result;
-    if (isEditing) {
-      const valuesToSubmit = {
-        ...values,
-        id: passedInPrivacyNotice!.id,
-        translations: values.translations ?? [],
-        children: values.children ?? [],
-      };
-      result = await patchNoticesMutationTrigger(valuesToSubmit);
-    } else {
-      result = await postNoticesMutationTrigger(values);
-    }
-
-    if (isErrorResult(result)) {
-      message.error(getErrorMessage(result.error));
-    } else {
+    try {
+      if (isEditing) {
+        const valuesToSubmit = {
+          ...values,
+          id: passedInPrivacyNotice!.id,
+          translations: values.translations ?? [],
+          children: values.children ?? [],
+        };
+        await patchNoticesMutationTrigger(valuesToSubmit).unwrap();
+      } else {
+        await postNoticesMutationTrigger(values).unwrap();
+      }
       message.success(`Privacy notice ${isEditing ? "updated" : "created"}`);
       if (!isEditing) {
         router.push(PRIVACY_NOTICES_ROUTE);
       }
+    } catch (error: unknown) {
+      message.error(getErrorMessage(error as RTKErrorResult["error"]));
     }
   };
 
@@ -175,15 +174,19 @@ const PrivacyNoticeForm = ({
   const allValues = Form.useWatch([], form);
   const [submittable, setSubmittable] = useState(false);
   useEffect(() => {
-    form
-      .validateFields({ validateOnly: true })
-      .then(() => setSubmittable(true))
-      .catch(() => setSubmittable(false));
+    const check = async () => {
+      try {
+        await form.validateFields({ validateOnly: true });
+        setSubmittable(true);
+      } catch {
+        setSubmittable(false);
+      }
+    };
+    check();
   }, [form, allValues]);
 
   const isDirty = useMemo(
-    () =>
-      !allValues ? false : !isEqual(form.getFieldsValue(true), initialValues),
+    () => (!allValues ? false : !isEqual(allValues, initialValues)),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- allValues triggers re-eval
     [allValues, initialValues],
   );

--- a/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
@@ -215,6 +215,12 @@ const PrivacyNoticeForm = ({
       <Form.Item name="translations" hidden noStyle>
         <Input />
       </Form.Item>
+      <Form.Item name="disabled" hidden noStyle>
+        <Input />
+      </Form.Item>
+      <Form.Item name="internal_description" hidden noStyle>
+        <Input />
+      </Form.Item>
       <Flex vertical gap="large">
         <Flex vertical gap="middle">
           <Card title="Privacy notice details">

--- a/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
@@ -1,26 +1,25 @@
 import ScrollableList from "common/ScrollableList";
 import {
   Button,
-  ChakraBox as Box,
-  ChakraDivider as Divider,
-  ChakraFlex as Flex,
-  ChakraFormLabel as FormLabel,
-  ChakraStack as Stack,
-  ChakraVStack as VStack,
+  Card,
+  Divider,
+  Flex,
+  Form,
   formatIsoLocation,
+  Input,
   isoStringToEntry,
+  Select,
   Space,
+  Switch,
   Tag,
   Typography,
   useMessage,
 } from "fidesui";
-import { Form, Formik } from "formik";
+import { isEqual } from "lodash";
 import { useRouter } from "next/router";
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { useAppSelector } from "~/app/hooks";
-import FormSection from "~/features/common/form/FormSection";
-import { CustomSwitch, CustomTextInput } from "~/features/common/form/inputs";
 import { getErrorMessage, isErrorResult } from "~/features/common/helpers";
 import { InfoTooltip } from "~/features/common/InfoTooltip";
 import { RouterLink } from "~/features/common/nav/RouterLink";
@@ -31,7 +30,7 @@ import {
   selectEnabledDataUseOptions,
   useGetAllDataUsesQuery,
 } from "~/features/data-use/data-use.slice";
-import PrivacyNoticeTranslationForm from "~/features/privacy-notices/PrivacyNoticeTranslationForm";
+import { PrivacyNoticeTranslationForm } from "~/features/privacy-notices/PrivacyNoticeTranslationForm";
 import {
   LimitedPrivacyNoticeResponseSchema,
   NoticeTranslation,
@@ -41,15 +40,13 @@ import {
 } from "~/types/api";
 import type { MinimalPrivacyNotice } from "~/types/api/models/MinimalPrivacyNotice";
 
-import { ControlledSelect } from "../common/form/ControlledSelect";
 import {
   CONSENT_MECHANISM_OPTIONS,
   defaultInitialValues,
   ENFORCEMENT_LEVEL_OPTIONS,
   transformPrivacyNoticeResponseToCreation,
-  ValidationSchema,
 } from "./form";
-import NoticeKeyField from "./NoticeKeyField";
+import { NoticeKeyField } from "./NoticeKeyField";
 import {
   selectAllPrivacyNotices,
   selectPage as selectNoticePage,
@@ -70,17 +67,13 @@ const PrivacyNoticeLocationDisplay = ({
   label: string;
   tooltip: string;
 }) => (
-  <VStack align="start">
+  <Flex vertical align="start" gap="small">
     <Flex align="start">
-      {label ? (
-        <FormLabel htmlFor="regions" fontSize="xs" my={0} mr={1}>
-          {label}
-        </FormLabel>
-      ) : null}
+      {label ? <label className="mr-1 text-xs">{label}</label> : null}
       <InfoTooltip label={tooltip} />
     </Flex>
-    <Box w="100%" data-testid="notice-locations">
-      <Space size={[0, 2]} wrap>
+    <div className="w-full" data-testid="notice-locations">
+      <Space size={[4, 6]} wrap>
         {regions?.map((region) => {
           const isoEntry = isoStringToEntry(region);
 
@@ -102,8 +95,8 @@ const PrivacyNoticeLocationDisplay = ({
           </Text>
         )}
       </Space>
-    </Box>
-  </VStack>
+    </div>
+  </Flex>
 );
 
 const PrivacyNoticeForm = ({
@@ -115,9 +108,15 @@ const PrivacyNoticeForm = ({
 }) => {
   const router = useRouter();
   const message = useMessage();
-  const initialValues = passedInPrivacyNotice
-    ? transformPrivacyNoticeResponseToCreation(passedInPrivacyNotice)
-    : defaultInitialValues;
+  const [form] = Form.useForm<PrivacyNoticeCreation>();
+
+  const initialValues = useMemo(
+    () =>
+      passedInPrivacyNotice
+        ? transformPrivacyNoticeResponseToCreation(passedInPrivacyNotice)
+        : defaultInitialValues,
+    [passedInPrivacyNotice],
+  );
 
   // Query for data uses
   useGetAllDataUsesQuery();
@@ -139,13 +138,13 @@ const PrivacyNoticeForm = ({
     p.children?.some((c) => c.id === passedInPrivacyNotice?.id),
   );
 
-  const [patchNoticesMutationTrigger] = usePatchPrivacyNoticesMutation();
-  const [postNoticesMutationTrigger] = usePostPrivacyNoticeMutation();
+  const [patchNoticesMutationTrigger, { isLoading: isPatching }] =
+    usePatchPrivacyNoticesMutation();
+  const [postNoticesMutationTrigger, { isLoading: isPosting }] =
+    usePostPrivacyNoticeMutation();
+  const isSubmitting = isPatching || isPosting;
 
-  const isEditing = useMemo(
-    () => !!passedInPrivacyNotice,
-    [passedInPrivacyNotice],
-  );
+  const isEditing = !!passedInPrivacyNotice;
 
   const handleSubmit = async (values: PrivacyNoticeCreation) => {
     let result;
@@ -171,108 +170,160 @@ const PrivacyNoticeForm = ({
     }
   };
 
+  // Watch all registered fields (including hidden Form.Items below) to drive
+  // dirty/submittable re-computation.
+  const allValues = Form.useWatch([], form);
+  const [submittable, setSubmittable] = useState(false);
+  useEffect(() => {
+    form
+      .validateFields({ validateOnly: true })
+      .then(() => setSubmittable(true))
+      .catch(() => setSubmittable(false));
+  }, [form, allValues]);
+
+  const isDirty = useMemo(
+    () =>
+      !allValues ? false : !isEqual(form.getFieldsValue(true), initialValues),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- allValues triggers re-eval
+    [allValues, initialValues],
+  );
+
+  // Read children and translations reactively via useWatch so ScrollableList
+  // and the translation form stay in sync with the hidden Form.Items below.
+  const children =
+    (Form.useWatch("children", form) as MinimalPrivacyNotice[] | undefined) ??
+    [];
+
   return (
-    <Formik
+    <Form
+      form={form}
+      layout="vertical"
+      onFinish={handleSubmit}
       initialValues={initialValues}
-      enableReinitialize
-      onSubmit={handleSubmit}
-      validationSchema={ValidationSchema}
+      key={passedInPrivacyNotice?.id ?? "create"}
+      data-testid="privacy-notice-form"
     >
-      {({ values, setFieldValue, dirty, isValid, isSubmitting }) => (
-        <Form>
-          <Stack spacing={10}>
-            <Stack spacing={6}>
-              <FormSection title="Privacy notice details">
-                <CustomTextInput
-                  label="Notice title"
-                  name="name"
-                  isRequired
-                  variant="stacked"
-                />
-                <ControlledSelect
-                  name="consent_mechanism"
-                  label="Consent mechanism"
-                  options={CONSENT_MECHANISM_OPTIONS}
-                  isRequired
-                  layout="stacked"
-                />
-                <NoticeKeyField isEditing={isEditing} />
-                <CustomSwitch
-                  name="has_gpc_flag"
-                  label="Configure whether this notice conforms to the Global Privacy Control"
-                  variant="stacked"
-                />
-                <PrivacyNoticeLocationDisplay
-                  regions={passedInPrivacyNotice?.configured_regions}
-                  label="Locations where privacy notice is shown to visitors"
-                  tooltip="To configure locations, change the privacy experiences where this notice is shown"
-                />
-                <Divider />
-                {!isChildNotice && (
-                  <ScrollableList<MinimalPrivacyNotice>
-                    label="Child notices"
-                    addButtonLabel="Add notice children"
-                    allItems={allPrivacyNotices.map((n) => ({
-                      id: n.id,
-                      name: n.name,
-                    }))}
-                    values={
-                      values.children?.map((n) => ({
-                        id: n.id,
-                        name: n.name,
-                      })) ?? []
-                    }
-                    setValues={(newValue) =>
-                      setFieldValue("children", newValue)
-                    }
-                    idField="id"
-                    getItemLabel={getPrivacyNoticeName}
-                    draggable
-                    baseTestId="children"
-                  />
-                )}
-                <ControlledSelect
-                  name="data_uses"
-                  label="Data use"
-                  options={dataUseOptions}
-                  mode="multiple"
-                  layout="stacked"
-                />
-                <ControlledSelect
-                  name="enforcement_level"
-                  label="Enforcement level"
-                  options={ENFORCEMENT_LEVEL_OPTIONS}
-                  isRequired
-                  layout="stacked"
-                />
-              </FormSection>
-              <PrivacyNoticeTranslationForm
-                availableTranslations={availableTranslations}
+      {/* Register fields managed outside of Form.Item (ScrollableList, the
+          translations tab form) so Form.useWatch and getFieldsValue track them
+          reactively. */}
+      <Form.Item name="children" hidden noStyle>
+        <Input />
+      </Form.Item>
+      <Form.Item name="translations" hidden noStyle>
+        <Input />
+      </Form.Item>
+      <Flex vertical gap="large">
+        <Flex vertical gap="middle">
+          <Card title="Privacy notice details">
+            <Form.Item
+              name="name"
+              label="Notice title"
+              rules={[{ required: true, message: "Title is required" }]}
+            >
+              <Input data-testid="input-name" />
+            </Form.Item>
+            <Form.Item
+              name="consent_mechanism"
+              label="Consent mechanism"
+              rules={[
+                {
+                  required: true,
+                  message: "Consent mechanism is required",
+                },
+              ]}
+            >
+              <Select
+                options={CONSENT_MECHANISM_OPTIONS}
+                aria-label="Consent mechanism"
+                data-testid="select-consent_mechanism"
               />
-            </Stack>
-            <div className="flex gap-2">
-              <Button
-                onClick={() => {
-                  router.back();
-                }}
-              >
-                Cancel
-              </Button>
-              <Button
-                htmlType="submit"
-                type="primary"
-                disabled={isSubmitting || !dirty || !isValid}
-                loading={isSubmitting}
-                data-testid="save-btn"
-              >
-                Save
-              </Button>
-            </div>
-          </Stack>
-        </Form>
-      )}
-    </Formik>
+            </Form.Item>
+            <NoticeKeyField isEditing={isEditing} />
+            <Form.Item
+              name="has_gpc_flag"
+              label="Conforms to Global Privacy Control (GPC)"
+              valuePropName="checked"
+            >
+              <Switch data-testid="input-has_gpc_flag" />
+            </Form.Item>
+            <PrivacyNoticeLocationDisplay
+              regions={passedInPrivacyNotice?.configured_regions}
+              label="Locations where privacy notice is shown to visitors"
+              tooltip="To configure locations, change the privacy experiences where this notice is shown"
+            />
+            <Divider />
+            {!isChildNotice && (
+              <div className="mb-4">
+                <ScrollableList<MinimalPrivacyNotice>
+                  label="Child notices"
+                  addButtonLabel="Add notice children"
+                  allItems={allPrivacyNotices.map((n) => ({
+                    id: n.id,
+                    name: n.name,
+                  }))}
+                  values={children}
+                  setValues={(newValue) =>
+                    form.setFieldValue("children", newValue)
+                  }
+                  idField="id"
+                  getItemLabel={getPrivacyNoticeName}
+                  draggable
+                  baseTestId="children"
+                />
+              </div>
+            )}
+            <Form.Item name="data_uses" label="Data use">
+              <Select
+                options={dataUseOptions}
+                mode="multiple"
+                aria-label="Data use"
+                data-testid="select-data_uses"
+              />
+            </Form.Item>
+            <Form.Item
+              name="enforcement_level"
+              label="Enforcement level"
+              rules={[
+                {
+                  required: true,
+                  message: "Enforcement level is required",
+                },
+              ]}
+            >
+              <Select
+                options={ENFORCEMENT_LEVEL_OPTIONS}
+                aria-label="Enforcement level"
+                data-testid="select-enforcement_level"
+              />
+            </Form.Item>
+          </Card>
+          <PrivacyNoticeTranslationForm
+            availableTranslations={availableTranslations}
+            initialTranslations={initialValues.translations ?? []}
+            form={form}
+          />
+        </Flex>
+        <Flex gap="small">
+          <Button
+            onClick={() => {
+              router.back();
+            }}
+          >
+            Cancel
+          </Button>
+          <Button
+            htmlType="submit"
+            type="primary"
+            disabled={isSubmitting || !isDirty || !submittable}
+            loading={isSubmitting}
+            data-testid="save-btn"
+          >
+            Save
+          </Button>
+        </Flex>
+      </Flex>
+    </Form>
   );
 };
 
-export default PrivacyNoticeForm;
+export { PrivacyNoticeForm };

--- a/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeTranslationForm.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeTranslationForm.tsx
@@ -1,17 +1,18 @@
 import {
   Button,
-  ChakraFlex as Flex,
-  ChakraHeading as Heading,
+  Card,
+  Flex,
+  Form,
+  FormInstance,
   Icons,
+  Input,
   Select,
   Tabs,
+  Typography,
 } from "fidesui";
-import { FieldArray, useFormikContext } from "formik";
 import { useState } from "react";
 
 import { useAppSelector } from "~/app/hooks";
-import FormSection from "~/features/common/form/FormSection";
-import { CustomTextArea, CustomTextInput } from "~/features/common/form/inputs";
 import { useGetConfigurationSettingsQuery } from "~/features/config-settings/config-settings.slice";
 import {
   selectAllLanguages,
@@ -22,23 +23,30 @@ import {
 import { OOBTranslationNotice } from "~/features/privacy-experience/PrivacyExperienceTranslationForm";
 import {
   NoticeTranslation,
+  NoticeTranslationCreate,
   PrivacyNoticeCreation,
   SupportedLanguage,
 } from "~/types/api";
 
+const { Title } = Typography;
+
 const NoticeFormFields = ({ index }: { index: number }) => (
   <>
-    <CustomTextInput
-      autoFocus={index !== 0}
-      name={`translations.${index}.title`}
+    <Form.Item
+      name={["translations", index, "title"]}
       label="Title of privacy notice as displayed to user"
-      variant="stacked"
-    />
-    <CustomTextArea
-      name={`translations.${index}.description`}
+    >
+      <Input
+        autoFocus={index !== 0}
+        data-testid={`input-translations.${index}.title`}
+      />
+    </Form.Item>
+    <Form.Item
+      name={["translations", index, "description"]}
       label="Privacy notice displayed to the user"
-      variant="stacked"
-    />
+    >
+      <Input.TextArea data-testid={`input-translations.${index}.description`} />
+    </Form.Item>
   </>
 );
 
@@ -96,8 +104,8 @@ const TranslationFormBlock = ({
   name: string;
   isOOB?: boolean;
 }) => (
-  <Flex direction="column" gap={6}>
-    <Heading size="sm">Edit {name} translation</Heading>
+  <Flex vertical gap="middle">
+    <Title level={5}>Edit {name} translation</Title>
     {isOOB ? <OOBTranslationNotice languageName={name} /> : null}
     <NoticeFormFields index={index} />
   </Flex>
@@ -105,14 +113,24 @@ const TranslationFormBlock = ({
 
 const PrivacyNoticeTranslationForm = ({
   availableTranslations,
+  initialTranslations,
+  form,
 }: {
   availableTranslations?: NoticeTranslation[];
+  initialTranslations: NoticeTranslationCreate[];
+  form: FormInstance<PrivacyNoticeCreation>;
 }) => {
-  const { values, setFieldValue } = useFormikContext<PrivacyNoticeCreation>();
+  // Read translations reactively from the form store. The parent registers
+  // `translations` via a hidden Form.Item so useWatch tracks changes even
+  // when they're applied via setFieldValue (no direct Form.Item for the array).
+  const translations =
+    (Form.useWatch("translations", form) as
+      | NoticeTranslationCreate[]
+      | undefined) ?? [];
 
   const [translationIsOOB, setTranslationIsOOB] = useState<boolean>(false);
   const [activeLanguage, setActiveLanguage] = useState<string>(
-    values.translations?.[0]?.language ?? "",
+    initialTranslations[0]?.language ?? "",
   );
 
   const { data: appConfig } = useGetConfigurationSettingsQuery({
@@ -130,9 +148,7 @@ const PrivacyNoticeTranslationForm = ({
 
   const languageOptions = allLanguages
     .filter((lang) =>
-      values.translations?.every(
-        (translation) => translation.language !== lang.id,
-      ),
+      translations.every((translation) => translation.language !== lang.id),
     )
     .map((lang) => ({ label: lang.name, value: lang.id as SupportedLanguage }));
 
@@ -146,24 +162,27 @@ const PrivacyNoticeTranslationForm = ({
       (translation) => translation.language === language,
     );
     setTranslationIsOOB(!!availableTranslation);
-    const newTranslation = availableTranslation ?? {
-      language: language as SupportedLanguage,
-      title: "",
-      description: "",
-    };
+    const newTranslation: NoticeTranslationCreate = availableTranslation
+      ? {
+          ...availableTranslation,
+          title: availableTranslation.title ?? "",
+        }
+      : {
+          language: language as SupportedLanguage,
+          title: "",
+          description: "",
+        };
     setActiveLanguage(language);
-    setFieldValue("translations", [...values.translations!, newTranslation]);
+    form.setFieldValue("translations", [...translations, newTranslation]);
   };
 
   const handleLanguageDeleted = (language: string) => {
-    const newTranslations = values.translations
-      ? values.translations.slice().filter((lang) => lang.language !== language)
-      : [];
+    const updated = translations.filter((lang) => lang.language !== language);
     const newActiveLanguage =
       activeLanguage === language
-        ? (newTranslations[newTranslations.length - 1]?.language ?? "")
+        ? (updated[updated.length - 1]?.language ?? "")
         : activeLanguage;
-    setFieldValue("translations", newTranslations);
+    form.setFieldValue("translations", updated);
     setActiveLanguage(newActiveLanguage);
   };
 
@@ -172,54 +191,49 @@ const PrivacyNoticeTranslationForm = ({
 
   if (!translationsEnabled) {
     return (
-      <FormSection title="Notice text">
+      <Card title="Notice text">
         <NoticeFormFields index={0} />
-      </FormSection>
+      </Card>
     );
   }
 
   return (
-    <FormSection title="Localizations">
-      <FieldArray
-        name="translations"
-        render={() => (
-          <Tabs
-            activeKey={activeLanguage}
-            onChange={handleTabSelected}
-            type="editable-card"
-            tabBarExtraContent={
-              !!languageOptions.length && (
-                <AddTranslationMenu
-                  languageOptions={languageOptions}
-                  handleCreateLanguage={handleCreateLanguage}
-                />
-              )
-            }
-            hideAdd
-            onEdit={(e, action) => {
-              if (action === "remove") {
-                handleLanguageDeleted(e as SupportedLanguage);
-              }
-            }}
-            items={values.translations!.map((translation) => ({
-              key: translation.language,
-              label: getLanguageDisplayName(translation.language),
-              children: (
-                <TranslationFormBlock
-                  index={values.translations!.findIndex(
-                    (t) => t.language === translation.language,
-                  )}
-                  name={getLanguageDisplayName(translation.language)}
-                  isOOB={translationIsOOB}
-                />
-              ),
-              closable: values.translations!.length > 1,
-            }))}
-          />
-        )}
+    <Card title="Localizations">
+      <Tabs
+        activeKey={activeLanguage}
+        onChange={handleTabSelected}
+        type="editable-card"
+        tabBarExtraContent={
+          !!languageOptions.length && (
+            <AddTranslationMenu
+              languageOptions={languageOptions}
+              handleCreateLanguage={handleCreateLanguage}
+            />
+          )
+        }
+        hideAdd
+        onEdit={(e, action) => {
+          if (action === "remove") {
+            handleLanguageDeleted(e as SupportedLanguage);
+          }
+        }}
+        items={translations.map((translation) => ({
+          key: translation.language,
+          label: getLanguageDisplayName(translation.language),
+          children: (
+            <TranslationFormBlock
+              index={translations.findIndex(
+                (t) => t.language === translation.language,
+              )}
+              name={getLanguageDisplayName(translation.language)}
+              isOOB={translationIsOOB}
+            />
+          ),
+          closable: translations.length > 1,
+        }))}
       />
-    </FormSection>
+    </Card>
   );
 };
 
-export default PrivacyNoticeTranslationForm;
+export { PrivacyNoticeTranslationForm };

--- a/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeTranslationForm.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeTranslationForm.tsx
@@ -60,7 +60,7 @@ const AddTranslationMenu = ({
   const [isSelectingLanguage, setIsSelectingLanguage] = useState(false);
 
   const handleSelect = (language: SupportedLanguage) => {
-    handleCreateLanguage(language as SupportedLanguage);
+    handleCreateLanguage(language);
     setIsSelectingLanguage(false);
   };
 
@@ -128,7 +128,6 @@ const PrivacyNoticeTranslationForm = ({
       | NoticeTranslationCreate[]
       | undefined) ?? [];
 
-  const [translationIsOOB, setTranslationIsOOB] = useState<boolean>(false);
   const [activeLanguage, setActiveLanguage] = useState<string>(
     initialTranslations[0]?.language ?? "",
   );
@@ -152,23 +151,25 @@ const PrivacyNoticeTranslationForm = ({
     )
     .map((lang) => ({ label: lang.name, value: lang.id as SupportedLanguage }));
 
+  const isActiveTabOOB = !!availableTranslations?.some(
+    (t) => t.language === activeLanguage,
+  );
+
   const handleTabSelected = (language: string) => {
     setActiveLanguage(language);
-    setTranslationIsOOB(false);
   };
 
   const handleCreateLanguage = (language: SupportedLanguage) => {
     const availableTranslation = availableTranslations?.find(
       (translation) => translation.language === language,
     );
-    setTranslationIsOOB(!!availableTranslation);
     const newTranslation: NoticeTranslationCreate = availableTranslation
       ? {
           ...availableTranslation,
           title: availableTranslation.title ?? "",
         }
       : {
-          language: language as SupportedLanguage,
+          language,
           title: "",
           description: "",
         };
@@ -226,7 +227,7 @@ const PrivacyNoticeTranslationForm = ({
                 (t) => t.language === translation.language,
               )}
               name={getLanguageDisplayName(translation.language)}
-              isOOB={translationIsOOB}
+              isOOB={isActiveTabOOB}
             />
           ),
           closable: translations.length > 1,

--- a/clients/admin-ui/src/features/privacy-notices/form.ts
+++ b/clients/admin-ui/src/features/privacy-notices/form.ts
@@ -1,5 +1,3 @@
-import * as Yup from "yup";
-
 import { getOptionsFromMap } from "~/features/common/utils";
 import {
   ENFORCEMENT_LEVEL_MAP,
@@ -68,9 +66,4 @@ export const transformPrivacyNoticeResponseToCreation = (
       })
     : defaultInitialTranslations,
   children: notice.children,
-});
-
-export const ValidationSchema = Yup.object().shape({
-  name: Yup.string().required().label("Title"),
-  consent_mechanism: Yup.string().required().label("Consent mechanism"),
 });

--- a/clients/admin-ui/src/pages/consent/privacy-notices/[id].tsx
+++ b/clients/admin-ui/src/pages/consent/privacy-notices/[id].tsx
@@ -1,4 +1,4 @@
-import { ChakraBox as Box, ChakraText as Text, Spin } from "fidesui";
+import { Spin, Typography } from "fidesui";
 import { useRouter } from "next/router";
 
 import Layout from "~/features/common/Layout";
@@ -8,7 +8,9 @@ import {
   useGetAvailableNoticeTranslationsQuery,
   useGetPrivacyNoticeByIdQuery,
 } from "~/features/privacy-notices/privacy-notices.slice";
-import PrivacyNoticeForm from "~/features/privacy-notices/PrivacyNoticeForm";
+import { PrivacyNoticeForm } from "~/features/privacy-notices/PrivacyNoticeForm";
+
+const { Paragraph, Text } = Typography;
 
 const PrivacyNoticeDetailPage = () => {
   const router = useRouter();
@@ -49,20 +51,20 @@ const PrivacyNoticeDetailPage = () => {
           { title: data.name },
         ]}
       />
-      <Box
-        width={{ base: "100%", lg: "70%" }}
+      <div
+        className="w-full lg:w-[70%]"
         data-testid="privacy-notice-detail-page"
       >
-        <Text fontSize="sm" mb={8}>
+        <Paragraph className="mb-8">
           Configure your privacy notice including consent mechanism, associated
           data uses and the locations in which this should be displayed to
           users.
-        </Text>
+        </Paragraph>
         <PrivacyNoticeForm
           privacyNotice={data}
           availableTranslations={availableTranslations}
         />
-      </Box>
+      </div>
     </Layout>
   );
 };

--- a/clients/admin-ui/src/pages/consent/privacy-notices/[id].tsx
+++ b/clients/admin-ui/src/pages/consent/privacy-notices/[id].tsx
@@ -51,10 +51,7 @@ const PrivacyNoticeDetailPage = () => {
           { title: data.name },
         ]}
       />
-      <div
-        className="w-full lg:w-[70%]"
-        data-testid="privacy-notice-detail-page"
-      >
+      <div className="w-[70%]" data-testid="privacy-notice-detail-page">
         <Paragraph className="mb-8">
           Configure your privacy notice including consent mechanism, associated
           data uses and the locations in which this should be displayed to

--- a/clients/admin-ui/src/pages/consent/privacy-notices/new.tsx
+++ b/clients/admin-ui/src/pages/consent/privacy-notices/new.tsx
@@ -16,7 +16,7 @@ const NewPrivacyNoticePage = () => (
         { title: "New privacy notice" },
       ]}
     />
-    <div className="w-full lg:w-[70%]">
+    <div className="w-[70%]">
       <Paragraph className="mb-8">
         Configure your privacy notice including consent mechanism, associated
         data uses and the locations in which this should be displayed to users.

--- a/clients/admin-ui/src/pages/consent/privacy-notices/new.tsx
+++ b/clients/admin-ui/src/pages/consent/privacy-notices/new.tsx
@@ -1,9 +1,11 @@
-import { ChakraBox as Box, ChakraText as Text } from "fidesui";
+import { Typography } from "fidesui";
 
 import Layout from "~/features/common/Layout";
 import { PRIVACY_NOTICES_ROUTE } from "~/features/common/nav/routes";
 import PageHeader from "~/features/common/PageHeader";
-import PrivacyNoticeForm from "~/features/privacy-notices/PrivacyNoticeForm";
+import { PrivacyNoticeForm } from "~/features/privacy-notices/PrivacyNoticeForm";
+
+const { Paragraph } = Typography;
 
 const NewPrivacyNoticePage = () => (
   <Layout title="New privacy notice">
@@ -14,15 +16,15 @@ const NewPrivacyNoticePage = () => (
         { title: "New privacy notice" },
       ]}
     />
-    <Box width={{ base: "100%", lg: "70%" }}>
-      <Text fontSize="sm" mb={8}>
+    <div className="w-full lg:w-[70%]">
+      <Paragraph className="mb-8">
         Configure your privacy notice including consent mechanism, associated
         data uses and the locations in which this should be displayed to users.
-      </Text>
-      <Box data-testid="new-privacy-notice-page">
+      </Paragraph>
+      <div data-testid="new-privacy-notice-page">
         <PrivacyNoticeForm />
-      </Box>
-    </Box>
+      </div>
+    </div>
   </Layout>
 );
 


### PR DESCRIPTION
Ticket [ENG-3174]

### Description Of Changes

Migrates privacy notice create/edit forms from Formik + Chakra to Ant Design Form. This replaces `Formik`, `Yup`, `ControlledSelect`, `CustomTextInput`, `CustomSwitch`, `CustomTextArea`, and `FormSection` with native Ant Design `Form`, `Form.Item`, `Select`, `Input`, `Switch`, and `Card` components.

Key patterns used:
- Hidden `Form.Item` elements for externally managed fields (`children`, `translations`) so `useWatch` and `getFieldsValue` track them reactively
- `Form.useWatch` for derived state (dirty checking, submittable validation)
- Inline `rules` on `Form.Item` instead of Yup validation schema
- `key` prop on `Form` to remount cleanly when switching between notices
- RTK Query `isLoading` for submit state instead of manual `useState`

### Code Changes

* Replaced `Formik`/`Form` with Ant Design `Form` and `Form.useForm` in `PrivacyNoticeForm.tsx`
* Replaced `FieldArray`/`useFormikContext` with `Form.useWatch` and `form.setFieldValue` in `PrivacyNoticeTranslationForm.tsx`
* Migrated `NoticeKeyField` from `useFormikContext` to `Form.useFormInstance` and `Form.useWatch`
* Removed Yup `ValidationSchema` from `form.ts`, replaced with inline `rules` on `Form.Item`
* Replaced Chakra layout components (`Box`, `Flex`, `VStack`, `Stack`, `FormLabel`, `Heading`) with Ant `Flex`, `Card`, `Typography`, `Divider`, and Tailwind utilities
* Switched from default exports to named exports for all components
* Updated Cypress tests to use new `data-testid` values (`select-*` instead of `controlled-select-*`)
* Updated page shells (`[id].tsx`, `new.tsx`) to use Ant `Typography` and Tailwind layout

### Steps to Confirm

1. Navigate to Privacy Notices list page
2. Click into an existing notice, verify all fields load correctly (name, consent mechanism, notice key, GPC flag, locations, child notices, data uses, enforcement level, translations)
3. Edit a field, verify Save button enables (dirty + valid)
4. Save changes, verify success toast
5. Create a new privacy notice, fill all fields, save, verify redirect to list
6. Verify notice key auto-generates from name on create (not on edit)
7. If translations enabled: add/remove translation tabs, verify fields persist

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required

[ENG-3174]: https://ethyca.atlassian.net/browse/ENG-3174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ