### PR TITLE
Replace palette JS imports with CSS variables in Admin UI

### DIFF
--- a/changelog/7954-replace-palette-imports-with-css-vars.yaml
+++ b/changelog/7954-replace-palette-imports-with-css-vars.yaml
@@ -1,0 +1,4 @@
+type: Changed
+description: Replace palette JS imports with CSS variables across admin-ui and privacy-center
+pr: 7954
+labels: []

--- a/clients/admin-ui/__tests__/features/common/nav/NavSearch.collapsed.test.tsx
+++ b/clients/admin-ui/__tests__/features/common/nav/NavSearch.collapsed.test.tsx
@@ -58,11 +58,6 @@ jest.mock("fidesui", () => {
   };
 });
 
-jest.mock("fidesui/src/palette/palette.module.scss", () => ({
-  FIDESUI_CORINTH: "#fafafa",
-  FIDESUI_NEUTRAL_400: "#a8aaad",
-}));
-
 // Mock react-hotkeys-hook so fireEvent.keyDown works in tests
 jest.mock("react-hotkeys-hook", () => {
   // eslint-disable-next-line global-require

--- a/clients/admin-ui/__tests__/features/common/nav/NavSearch.test.tsx
+++ b/clients/admin-ui/__tests__/features/common/nav/NavSearch.test.tsx
@@ -96,12 +96,6 @@ jest.mock("fidesui", () => {
   };
 });
 
-// Mock palette to avoid SCSS import issues
-jest.mock("fidesui/src/palette/palette.module.scss", () => ({
-  FIDESUI_CORINTH: "#fafafa",
-  FIDESUI_NEUTRAL_400: "#a8aaad",
-}));
-
 // Mock react-hotkeys-hook so fireEvent.keyDown works in tests
 jest.mock("react-hotkeys-hook", () => {
   // eslint-disable-next-line global-require

--- a/clients/admin-ui/src/features/chat-provider/components/AuthorizationStatus.tsx
+++ b/clients/admin-ui/src/features/chat-provider/components/AuthorizationStatus.tsx
@@ -1,5 +1,4 @@
 import { Icons, Space, Tag, Typography } from "fidesui";
-import palette from "fidesui/src/palette/palette.module.scss";
 
 const { Text } = Typography;
 
@@ -15,7 +14,7 @@ const AuthorizationStatus = ({ authorized }: AuthorizationStatusProps) => {
   if (authorized) {
     return (
       <Space data-testid="authorize-status">
-        <Icons.CheckmarkFilled color={palette.FIDESUI_SUCCESS} />
+        <Icons.CheckmarkFilled color="var(--fidesui-success)" />
         <Text type="success" strong>
           Authorized
         </Text>

--- a/clients/admin-ui/src/features/common/SearchInput.tsx
+++ b/clients/admin-ui/src/features/common/SearchInput.tsx
@@ -1,7 +1,6 @@
 import classNames from "classnames";
 import { Icons, Input, InputRef } from "fidesui";
 import { CustomInputProps } from "fidesui/src/hoc";
-import palette from "fidesui/src/palette/palette.module.scss";
 import { useRef } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 
@@ -50,7 +49,7 @@ const SearchInput = ({
       aria-label="Search"
       prefix={
         withIcon ? (
-          <Icons.Search color={palette.FIDESUI_NEUTRAL_200} />
+          <Icons.Search color="var(--fidesui-neutral-200)" />
         ) : undefined
       }
       allowClear

--- a/clients/admin-ui/src/features/common/nav/MainSideNav.tsx
+++ b/clients/admin-ui/src/features/common/nav/MainSideNav.tsx
@@ -4,7 +4,6 @@ import {
   ChakraVStack as VStack,
   Icons,
 } from "fidesui";
-import palette from "fidesui/src/palette/palette.module.scss";
 import { useRouter } from "next/router";
 import React from "react";
 
@@ -24,7 +23,7 @@ import styles from "./NavMenu.module.scss";
 import NavSearch from "./NavSearch";
 import { RouterLink } from "./RouterLink";
 
-const NAV_BACKGROUND_COLOR = palette.FIDESUI_MINOS;
+const NAV_BACKGROUND_COLOR = "var(--fidesui-minos)";
 const NAV_WIDTH = "240px";
 const COLLAPSED_WIDTH = "80px";
 const OPENED_TOGGLES_LOCAL_STORAGE_KEY = "mainSideNavOpenKeys";

--- a/clients/admin-ui/src/features/common/nav/NavSearch.tsx
+++ b/clients/admin-ui/src/features/common/nav/NavSearch.tsx
@@ -1,5 +1,4 @@
 import { AutoComplete, Icons, Input, InputRef } from "fidesui";
-import palette from "fidesui/src/palette/palette.module.scss";
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
@@ -16,7 +15,7 @@ const isMac =
 const SHORTCUT_LABEL = isMac ? "⌘K" : "Ctrl+K";
 
 const SEARCH_ICON_STYLE = {
-  color: palette.FIDESUI_NEUTRAL_400,
+  color: "var(--fidesui-neutral-400)",
   fontSize: 14,
 };
 const DEBOUNCE_MS = 200;

--- a/clients/admin-ui/src/features/common/nav/NavSearchModal.tsx
+++ b/clients/admin-ui/src/features/common/nav/NavSearchModal.tsx
@@ -1,5 +1,4 @@
 import { Icons, Input, InputRef, Modal } from "fidesui";
-import palette from "fidesui/src/palette/palette.module.scss";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 
@@ -11,12 +10,12 @@ import { RouterLink } from "./RouterLink";
 import useNavSearchItems, { FlatNavItem } from "./useNavSearchItems";
 
 const SEARCH_ICON_STYLE = {
-  color: palette.FIDESUI_NEUTRAL_400,
+  color: "var(--fidesui-neutral-400)",
   fontSize: 16,
 };
 const COLLAPSED_ICON_STYLE = {
   fontSize: 16,
-  color: palette.FIDESUI_CORINTH,
+  color: "var(--fidesui-corinth)",
 };
 const isMac =
   typeof navigator !== "undefined" &&

--- a/clients/admin-ui/src/features/common/table/v2/RowSelectionBar.tsx
+++ b/clients/admin-ui/src/features/common/table/v2/RowSelectionBar.tsx
@@ -6,7 +6,6 @@ import {
   ChakraText as Text,
   ChakraTr as Tr,
 } from "fidesui";
-import palette from "fidesui/src/palette/palette.module.scss";
 
 type RowSelectionBarProps<T> = {
   tableInstance: TableInstance<T>;
@@ -41,7 +40,7 @@ export const RowSelectionBar = <T,>({
         pr={2}
         py={0}
         colSpan={tableInstance.getAllColumns().length}
-        bgColor={palette.FIDESUI_FULL_WHITE}
+        bgColor="var(--fidesui-full-white)"
       >
         <HStack>
           <Text data-testid="selected-row-count" fontSize="xs">

--- a/clients/admin-ui/src/features/config-wizard/AddSystem.tsx
+++ b/clients/admin-ui/src/features/config-wizard/AddSystem.tsx
@@ -7,7 +7,6 @@ import {
   ManualSetupIcon,
   useModal,
 } from "fidesui";
-import palette from "fidesui/src/palette/palette.module.scss";
 import { useRouter } from "next/router";
 
 import { useAppDispatch } from "~/app/hooks";
@@ -76,7 +75,7 @@ const AddSystem = () => {
           >
             <CalloutNavCard
               title="Add a system"
-              color={palette.FIDESUI_SANDSTONE}
+              color="var(--fidesui-sandstone)"
               icon={<ManualSetupIcon size={24} />}
               description="Manually add a system for services not covered by AWS or Okta discovery"
             />
@@ -111,7 +110,7 @@ const AddSystem = () => {
           >
             <CalloutNavCard
               title="Add multiple systems"
-              color={palette.FIDESUI_OLIVE}
+              color="var(--fidesui-olive)"
               icon={<ManualSetupIcon size={24} />}
               description="Choose vendors and automatically populate system details"
             />
@@ -134,7 +133,7 @@ const AddSystem = () => {
           >
             <CalloutNavCard
               title="Scan your infrastructure (AWS)"
-              color={palette.FIDESUI_TERRACOTTA}
+              color="var(--fidesui-terracotta)"
               description="Automatically discover new systems in your AWS infrastructure"
               icon={<AWSLogo size={24} />}
             />
@@ -151,7 +150,7 @@ const AddSystem = () => {
           >
             <CalloutNavCard
               title="Scan your Sign On Provider (Okta)"
-              color={palette.FIDESUI_MINOS}
+              color="var(--fidesui-minos)"
               description="Automatically discover new systems in your Okta infrastructure"
               icon={<OktaLogo size={24} />}
             />

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/MonitorResult.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/MonitorResult.tsx
@@ -13,7 +13,6 @@ import {
   Tooltip,
   Typography,
 } from "fidesui";
-import palette from "fidesui/src/palette/palette.module.scss";
 import { useState } from "react";
 
 import { RouterLink } from "~/features/common/nav/RouterLink";
@@ -211,7 +210,7 @@ export const MonitorResult = ({
         <Avatar.Group
           max={{
             count: 5,
-            style: { background: palette.FIDESUI_NEUTRAL_700 },
+            style: { background: "var(--fidesui-neutral-700)" },
           }}
           className="hidden flex-[6.5rem] grow-0 justify-end lg:flex"
           size="small"

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/components/InfrastructureSystemListItem.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/components/InfrastructureSystemListItem.tsx
@@ -10,7 +10,6 @@ import {
   Tooltip,
   useMessage,
 } from "fidesui";
-import palette from "fidesui/src/palette/palette.module.scss";
 
 import { getErrorMessage } from "~/features/common/helpers";
 import { getBrandIconUrl, getDomain } from "~/features/common/utils";
@@ -128,7 +127,7 @@ export const InfrastructureSystemListItem = ({
                 shape="square"
                 icon={
                   <Icons.TransformInstructions
-                    style={{ color: palette.FIDESUI_MINOS }}
+                    style={{ color: "var(--fidesui-minos)" }}
                     className="m-1 size-full"
                   />
                 }

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorFields.const.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorFields.const.ts
@@ -1,6 +1,4 @@
 import { CUSTOM_TAG_COLOR, Icons } from "fidesui";
-// TODO: fix this export to be better encapsulated in fidesui
-import palette from "fidesui/src/palette/palette.module.scss";
 
 import { DiffStatus, StagedResourceTypeValue, StatusCounts } from "~/types/api";
 
@@ -147,11 +145,11 @@ export const MAP_DIFF_STATUS_TO_STATUS_INFO: Partial<
   >
 > = {
   [DiffStatus.ADDITION]: {
-    color: palette.FIDESUI_SUCCESS,
+    color: "var(--fidesui-success)",
     tooltip: "This resource was added in the latest scan",
   },
   [DiffStatus.REMOVAL]: {
-    color: palette.FIDESUI_ERROR,
+    color: "var(--fidesui-error)",
     tooltip: "This resource was removed in the latest scan",
   },
 } as const;

--- a/clients/admin-ui/src/features/data-discovery-and-detection/statusIndicators.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/statusIndicators.tsx
@@ -1,11 +1,10 @@
 import { Icons } from "fidesui";
-import palette from "fidesui/src/palette/palette.module.scss";
 
 import { ResourceChangeType } from "~/features/data-discovery-and-detection/types/ResourceChangeType";
 
 export const AdditionIndicator = () => (
   <Icons.ArrowUpRight
-    style={{ color: palette.FIDESUI_SUCCESS }}
+    style={{ color: "var(--fidesui-success)" }}
     className="size-2"
     data-testid="add-icon"
   />
@@ -13,7 +12,7 @@ export const AdditionIndicator = () => (
 
 export const RemovalIndicator = () => (
   <Icons.ArrowDownRight
-    style={{ color: palette.FIDESUI_ERROR }}
+    style={{ color: "var(--fidesui-error)" }}
     className="size-2"
     data-testid="remove-icon"
   />
@@ -21,7 +20,7 @@ export const RemovalIndicator = () => (
 
 export const ClassificationIndicator = () => (
   <Icons.Tag
-    style={{ color: palette.FIDESUI_WARNING }}
+    style={{ color: "var(--fidesui-warning)" }}
     className="size-3"
     data-testid="classify-icon"
   />
@@ -32,23 +31,23 @@ const CircleIndicator = ({ color, ...props }: { color: string }) => (
 );
 
 export const ChangeIndicator = () => (
-  <CircleIndicator color={palette.FIDESUI_INFO} data-testid="change-icon" />
+  <CircleIndicator color={"var(--fidesui-info)"} data-testid="change-icon" />
 );
 
 export const MonitoredIndicator = () => (
   <CircleIndicator
-    color={palette.FIDESUI_SUCCESS}
+    color={"var(--fidesui-success)"}
     data-testid="monitored-icon"
   />
 );
 
 export const MutedIndicator = () => (
-  <CircleIndicator color={palette.FIDESUI_ERROR} data-testid="muted-icon" />
+  <CircleIndicator color={"var(--fidesui-error)"} data-testid="muted-icon" />
 );
 
 export const InProgressIndicator = () => (
   <CircleIndicator
-    color={palette.FIDESUI_WARNING}
+    color={"var(--fidesui-warning)"}
     data-testid="in-progress-icon"
   />
 );

--- a/clients/admin-ui/src/features/data-discovery-and-detection/statusIndicators.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/statusIndicators.tsx
@@ -31,23 +31,23 @@ const CircleIndicator = ({ color, ...props }: { color: string }) => (
 );
 
 export const ChangeIndicator = () => (
-  <CircleIndicator color={"var(--fidesui-info)"} data-testid="change-icon" />
+  <CircleIndicator color="var(--fidesui-info)" data-testid="change-icon" />
 );
 
 export const MonitoredIndicator = () => (
   <CircleIndicator
-    color={"var(--fidesui-success)"}
+    color="var(--fidesui-success)"
     data-testid="monitored-icon"
   />
 );
 
 export const MutedIndicator = () => (
-  <CircleIndicator color={"var(--fidesui-error)"} data-testid="muted-icon" />
+  <CircleIndicator color="var(--fidesui-error)" data-testid="muted-icon" />
 );
 
 export const InProgressIndicator = () => (
   <CircleIndicator
-    color={"var(--fidesui-warning)"}
+    color="var(--fidesui-warning)"
     data-testid="in-progress-icon"
   />
 );

--- a/clients/admin-ui/src/features/datamap/DatamapGraph.tsx
+++ b/clients/admin-ui/src/features/datamap/DatamapGraph.tsx
@@ -11,7 +11,6 @@ import {
   ReactFlowProvider,
   useReactFlow,
 } from "@xyflow/react";
-import palette from "fidesui/src/palette/palette.module.scss";
 import React, { useCallback, useEffect, useMemo, useRef } from "react";
 
 import DatamapSystemNode from "~/features/datamap/DatamapSystemNode";
@@ -203,7 +202,7 @@ const DatamapGraph = ({
     >
       <div
         className="size-full"
-        style={{ backgroundColor: palette.FIDESUI_BG_CORINTH }}
+        style={{ backgroundColor: "var(--fidesui-bg-corinth)" }}
       >
         <ReactFlow
           nodes={nodes}
@@ -221,7 +220,7 @@ const DatamapGraph = ({
           proOptions={{ hideAttribution: true }}
         >
           <Background
-            color={palette.FIDESUI_NEUTRAL_100}
+            color="var(--fidesui-neutral-100)"
             variant={BackgroundVariant.Dots}
             size={3}
           />

--- a/clients/admin-ui/src/features/datamap/DatamapSystemNode.module.scss
+++ b/clients/admin-ui/src/features/datamap/DatamapSystemNode.module.scss
@@ -1,5 +1,3 @@
-@import "fidesui/src/palette/palette.module.scss";
-
 .container {
   position: relative;
   display: flex;
@@ -17,39 +15,39 @@
     box-shadow 300ms ease 0s;
 
   // Default state
-  color: map-get($colors, "neutral-800");
-  background-color: map-get($colors, "neutral-100");
-  border: 1px solid map-get($colors, "neutral-200");
+  color: var(--fidesui-neutral-800);
+  background-color: var(--fidesui-neutral-100);
+  border: 1px solid var(--fidesui-neutral-200);
   box-shadow: none;
 
   // Hover state
   &:hover {
     color: white !important;
-    background-color: map-get($colors, "neutral-700") !important;
-    border: 1px solid map-get($colors, "neutral-600") !important;
+    background-color: var(--fidesui-neutral-700) !important;
+    border: 1px solid var(--fidesui-neutral-600) !important;
   }
 
   // Focus state for accessibility
   &:focus,
   &:focus-visible {
     color: white !important;
-    background-color: map-get($colors, "minos") !important;
-    border: 1px solid map-get($colors, "minos") !important;
+    background-color: var(--fidesui-minos) !important;
+    border: 1px solid var(--fidesui-minos) !important;
   }
 
   // Active/selected state
   &--selected {
     color: white !important;
-    background-color: map-get($colors, "minos") !important;
-    border: 1px solid map-get($colors, "minos") !important;
+    background-color: var(--fidesui-minos) !important;
+    border: 1px solid var(--fidesui-minos) !important;
   }
 }
 
 .handle {
   width: 10px;
   height: 10px;
-  background: map-get($colors, "neutral-200");
-  border: 1px solid map-get($colors, "neutral-300");
+  background: var(--fidesui-neutral-200);
+  border: 1px solid var(--fidesui-neutral-300);
   opacity: 0;
   pointer-events: none;
 }

--- a/clients/admin-ui/src/features/datamap/hooks/useDatamapGraph.ts
+++ b/clients/admin-ui/src/features/datamap/hooks/useDatamapGraph.ts
@@ -1,5 +1,4 @@
 import { Edge, MarkerType, Node } from "@xyflow/react";
-import palette from "fidesui/src/palette/palette.module.scss";
 import { useMemo } from "react";
 
 import { getLayoutedElements } from "~/features/datamap/layout-utils";
@@ -45,12 +44,12 @@ export const useDatamapGraph = ({ data }: UseDatamapGraphProps) => {
         target: link.target,
         markerEnd: {
           type: MarkerType.ArrowClosed,
-          color: palette.FIDESUI_NEUTRAL_300,
+          color: "var(--fidesui-neutral-300)",
           width: 15,
           height: 15,
         },
         style: {
-          stroke: palette.FIDESUI_NEUTRAL_300,
+          stroke: "var(--fidesui-neutral-300)",
           strokeWidth: 1.5,
           strokeOpacity: 0.8,
         },

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/ConnectionListDropdown.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/ConnectionListDropdown.tsx
@@ -11,7 +11,6 @@ import {
   Popover,
   Tooltip,
 } from "fidesui";
-import palette from "fidesui/src/palette/palette.module.scss";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { useAppSelector } from "~/app/hooks";
@@ -219,7 +218,7 @@ const ConnectionListDropdown = ({
       <Box px="8px" mt={2}>
         <InputGroup size="sm">
           <InputLeftElement pointerEvents="none">
-            <Icons.Search color={palette.FIDESUI_NEUTRAL_500} />
+            <Icons.Search color="var(--fidesui-neutral-500)" />
           </InputLeftElement>
           <Input
             data-testid="input-search-integrations"

--- a/clients/admin-ui/src/features/integrations/configure-tasks/AddManualTaskForm.tsx
+++ b/clients/admin-ui/src/features/integrations/configure-tasks/AddManualTaskForm.tsx
@@ -8,7 +8,6 @@ import {
   Select,
   Tooltip,
 } from "fidesui";
-import palette from "fidesui/src/palette/palette.module.scss";
 import React, { useEffect } from "react";
 
 import { ManualFieldRequestType, ManualTaskFieldType } from "~/types/api";
@@ -36,7 +35,7 @@ const HelpIcon = ({ text }: { text: string }) => (
   <Tooltip title={text}>
     <Icons.Information
       style={{
-        color: palette.FIDESUI_NEUTRAL_500,
+        color: "var(--fidesui-neutral-500)",
         marginLeft: 4,
         cursor: "help",
       }}

--- a/clients/admin-ui/src/features/messaging/forms/AwsSesMessagingForm.tsx
+++ b/clients/admin-ui/src/features/messaging/forms/AwsSesMessagingForm.tsx
@@ -563,9 +563,7 @@ const AwsSesMessagingForm = ({ configKey }: AwsSesMessagingFormProps) => {
                     loading={isVerifying}
                     icon={
                       verificationStatus.isVerified && !isVerifying ? (
-                        <Icons.CheckmarkFilled
-                          color="var(--fidesui-success)"
-                        />
+                        <Icons.CheckmarkFilled color="var(--fidesui-success)" />
                       ) : undefined
                     }
                   >

--- a/clients/admin-ui/src/features/messaging/forms/AwsSesMessagingForm.tsx
+++ b/clients/admin-ui/src/features/messaging/forms/AwsSesMessagingForm.tsx
@@ -10,7 +10,6 @@ import {
   Select,
   useMessage,
 } from "fidesui";
-import palette from "fidesui/src/palette/palette.module.scss";
 import { isEmpty, isEqual, isUndefined, mapValues, omitBy } from "lodash";
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useState } from "react";
@@ -565,7 +564,7 @@ const AwsSesMessagingForm = ({ configKey }: AwsSesMessagingFormProps) => {
                     icon={
                       verificationStatus.isVerified && !isVerifying ? (
                         <Icons.CheckmarkFilled
-                          color={palette.FIDESUI_SUCCESS}
+                          color="var(--fidesui-success)"
                         />
                       ) : undefined
                     }

--- a/clients/admin-ui/src/features/messaging/forms/MailgunMessagingForm.tsx
+++ b/clients/admin-ui/src/features/messaging/forms/MailgunMessagingForm.tsx
@@ -368,9 +368,7 @@ const MailgunMessagingForm = ({ configKey }: MailgunMessagingFormProps) => {
                     loading={isVerifying}
                     icon={
                       verificationStatus.isVerified && !isVerifying ? (
-                        <Icons.CheckmarkFilled
-                          color="var(--fidesui-success)"
-                        />
+                        <Icons.CheckmarkFilled color="var(--fidesui-success)" />
                       ) : undefined
                     }
                   >

--- a/clients/admin-ui/src/features/messaging/forms/MailgunMessagingForm.tsx
+++ b/clients/admin-ui/src/features/messaging/forms/MailgunMessagingForm.tsx
@@ -9,7 +9,6 @@ import {
   Input,
   useMessage,
 } from "fidesui";
-import palette from "fidesui/src/palette/palette.module.scss";
 import { isEmpty, isEqual, isUndefined, mapValues, omitBy } from "lodash";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
@@ -370,7 +369,7 @@ const MailgunMessagingForm = ({ configKey }: MailgunMessagingFormProps) => {
                     icon={
                       verificationStatus.isVerified && !isVerifying ? (
                         <Icons.CheckmarkFilled
-                          color={palette.FIDESUI_SUCCESS}
+                          color="var(--fidesui-success)"
                         />
                       ) : undefined
                     }

--- a/clients/admin-ui/src/features/messaging/forms/TwilioEmailMessagingForm.tsx
+++ b/clients/admin-ui/src/features/messaging/forms/TwilioEmailMessagingForm.tsx
@@ -373,9 +373,7 @@ const TwilioEmailMessagingForm = ({
                     loading={isVerifying}
                     icon={
                       verificationStatus.isVerified && !isVerifying ? (
-                        <Icons.CheckmarkFilled
-                          color="var(--fidesui-success)"
-                        />
+                        <Icons.CheckmarkFilled color="var(--fidesui-success)" />
                       ) : undefined
                     }
                   >

--- a/clients/admin-ui/src/features/messaging/forms/TwilioEmailMessagingForm.tsx
+++ b/clients/admin-ui/src/features/messaging/forms/TwilioEmailMessagingForm.tsx
@@ -9,7 +9,6 @@ import {
   Input,
   useMessage,
 } from "fidesui";
-import palette from "fidesui/src/palette/palette.module.scss";
 import { isEmpty, isEqual, isUndefined, mapValues, omitBy } from "lodash";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
@@ -375,7 +374,7 @@ const TwilioEmailMessagingForm = ({
                     icon={
                       verificationStatus.isVerified && !isVerifying ? (
                         <Icons.CheckmarkFilled
-                          color={palette.FIDESUI_SUCCESS}
+                          color="var(--fidesui-success)"
                         />
                       ) : undefined
                     }

--- a/clients/admin-ui/src/features/messaging/forms/TwilioSMSMessagingForm.tsx
+++ b/clients/admin-ui/src/features/messaging/forms/TwilioSMSMessagingForm.tsx
@@ -9,7 +9,6 @@ import {
   Input,
   useMessage,
 } from "fidesui";
-import palette from "fidesui/src/palette/palette.module.scss";
 import { isEmpty, isEqual, isUndefined, mapValues, omitBy } from "lodash";
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useState } from "react";
@@ -436,7 +435,7 @@ const TwilioSMSMessagingForm = ({ configKey }: TwilioSMSMessagingFormProps) => {
                     icon={
                       verificationStatus.isVerified && !isVerifying ? (
                         <Icons.CheckmarkFilled
-                          color={palette.FIDESUI_SUCCESS}
+                          color="var(--fidesui-success)"
                         />
                       ) : undefined
                     }

--- a/clients/admin-ui/src/features/messaging/forms/TwilioSMSMessagingForm.tsx
+++ b/clients/admin-ui/src/features/messaging/forms/TwilioSMSMessagingForm.tsx
@@ -434,9 +434,7 @@ const TwilioSMSMessagingForm = ({ configKey }: TwilioSMSMessagingFormProps) => {
                     loading={isVerifying}
                     icon={
                       verificationStatus.isVerified && !isVerifying ? (
-                        <Icons.CheckmarkFilled
-                          color="var(--fidesui-success)"
-                        />
+                        <Icons.CheckmarkFilled color="var(--fidesui-success)" />
                       ) : undefined
                     }
                   >

--- a/clients/admin-ui/src/features/poc/privacy-notices-sandbox/components/ExperienceConfigSection.tsx
+++ b/clients/admin-ui/src/features/poc/privacy-notices-sandbox/components/ExperienceConfigSection.tsx
@@ -1,5 +1,4 @@
 import { Button, Flex, Input, Typography } from "fidesui";
-import palette from "fidesui/src/palette/palette.module.scss";
 
 import type { PrivacyNoticeResponse } from "~/types/api";
 
@@ -114,7 +113,7 @@ const ExperienceConfigSection = ({
           <PreviewCard
             title="Available notices"
             height="200px"
-            headerColor={palette.FIDESUI_MINOS}
+            headerColor="var(--fidesui-minos)"
             emptyMessage="Available notices will appear here after fetching experience"
           >
             {privacyNotices.length > 0 ? (

--- a/clients/admin-ui/src/features/poc/privacy-notices-sandbox/components/FetchPreferencesSection.tsx
+++ b/clients/admin-ui/src/features/poc/privacy-notices-sandbox/components/FetchPreferencesSection.tsx
@@ -1,5 +1,4 @@
 import { Button, Flex, Input, Select, Typography } from "fidesui";
-import palette from "fidesui/src/palette/palette.module.scss";
 
 import type { ConsentPreferenceResponse } from "~/types/api/models/ConsentPreferenceResponse";
 
@@ -90,7 +89,7 @@ const FetchPreferencesSection = ({
                 }`
               : null
           }
-          headerColor={palette.FIDESUI_SUCCESS}
+          headerColor="var(--fidesui-success)"
           body={getCurrentResponse}
           emptyMessage="GET response will appear here after fetching preferences"
         />

--- a/clients/admin-ui/src/features/poc/privacy-notices-sandbox/components/SavePreferencesSection.tsx
+++ b/clients/admin-ui/src/features/poc/privacy-notices-sandbox/components/SavePreferencesSection.tsx
@@ -1,6 +1,5 @@
 import type { Key } from "antd/es/table/interface";
 import { Button, Empty, Flex, Typography } from "fidesui";
-import palette from "fidesui/src/palette/palette.module.scss";
 import { useCallback, useMemo, useState } from "react";
 
 import { getErrorMessage } from "~/features/common/helpers";
@@ -234,7 +233,7 @@ const SavePreferencesSection = ({
                 }`
               : null
           }
-          headerColor={palette.FIDESUI_ALERT}
+          headerColor="var(--fidesui-alert)"
           body={postResponse}
           emptyMessage="POST response will appear here after saving preferences"
         />

--- a/clients/admin-ui/src/features/privacy-assessments/EvidenceSection.tsx
+++ b/clients/admin-ui/src/features/privacy-assessments/EvidenceSection.tsx
@@ -1,5 +1,4 @@
 import { Badge, Collapse, Flex, Text } from "fidesui";
-import palette from "fidesui/src/palette/palette.module.scss";
 
 import { EvidenceCardGroup } from "./EvidenceCardGroup";
 import styles from "./EvidenceSection.module.scss";
@@ -58,7 +57,7 @@ export const EvidenceSection = ({
                   <Text strong>System-derived data</Text>
                   <Badge
                     count={systemItems.length}
-                    color={palette.FIDESUI_MINOS}
+                    color="var(--fidesui-minos)"
                   />
                 </Flex>
                 <Text type="secondary" size="sm">
@@ -81,7 +80,7 @@ export const EvidenceSection = ({
                   <Text strong>Human input</Text>
                   <Badge
                     count={humanItems.length}
-                    color={palette.FIDESUI_MINOS}
+                    color="var(--fidesui-minos)"
                   />
                 </Flex>
                 <Text type="secondary" size="sm">

--- a/clients/admin-ui/src/features/privacy-requests/events-and-logs/EventLog.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/events-and-logs/EventLog.tsx
@@ -13,7 +13,6 @@ import {
   Tag,
   Tooltip,
 } from "fidesui";
-import palette from "fidesui/src/palette/palette.module.scss";
 import {
   ExecutionLog,
   ExecutionLogStatus,
@@ -261,7 +260,7 @@ const EventLog = ({
       <Tr
         key={detail.updated_at}
         backgroundColor={
-          hasExpandableDetails ? palette.FIDESUI_NEUTRAL_50 : "unset"
+          hasExpandableDetails ? "var(--fidesui-neutral-50)" : "unset"
         }
         onClick={() => {
           if (hasExpandableDetails) {
@@ -271,7 +270,7 @@ const EventLog = ({
         style={{
           cursor: hasExpandableDetails ? "pointer" : "unset",
         }}
-        _hover={{ backgroundColor: palette.FIDESUI_NEUTRAL_50 }}
+        _hover={{ backgroundColor: "var(--fidesui-neutral-50)" }}
       >
         <Td>
           <Text

--- a/clients/admin-ui/src/features/system/history/SystemHistoryTable.tsx
+++ b/clients/admin-ui/src/features/system/history/SystemHistoryTable.tsx
@@ -10,7 +10,6 @@ import {
   ChakraTr as Tr,
   Icons,
 } from "fidesui";
-import palette from "fidesui/src/palette/palette.module.scss";
 import React, { useState } from "react";
 
 import { useAppSelector } from "~/app/hooks";
@@ -100,7 +99,7 @@ const SystemHistoryTable = ({ system }: Props) => {
               p="16px"
               fontSize="12px"
               border="1px solid #E2E8F0"
-              background={palette.FIDESUI_NEUTRAL_50}
+              background="var(--fidesui-neutral-50)"
             >
               System created on {formattedDate} at {formattedTime}
             </Td>

--- a/clients/admin-ui/src/features/system/privacy-declarations/PrivacyDeclarationForm.tsx
+++ b/clients/admin-ui/src/features/system/privacy-declarations/PrivacyDeclarationForm.tsx
@@ -15,7 +15,6 @@ import {
   ChakraText as Text,
   Icons,
 } from "fidesui";
-import palette from "fidesui/src/palette/palette.module.scss";
 import { Form, Formik, FormikHelpers } from "formik";
 import { useMemo, useState } from "react";
 import * as Yup from "yup";
@@ -260,7 +259,7 @@ export const usePrivacyDeclarationForm = ({
       ) : null}
       {!hideSaved && showSaved && !dirty && initialValues.data_use ? (
         <Text fontSize="sm" data-testid="saved-indicator">
-          <Icons.CheckmarkFilled color={palette.FIDESUI_SUCCESS} /> Saved
+          <Icons.CheckmarkFilled color="var(--fidesui-success)" /> Saved
         </Text>
       ) : null}
     </Box>

--- a/clients/admin-ui/src/features/taxonomy/components/TaxonomyInteractiveTree.tsx
+++ b/clients/admin-ui/src/features/taxonomy/components/TaxonomyInteractiveTree.tsx
@@ -13,7 +13,6 @@ import {
   ReactFlowProvider,
   useReactFlow,
 } from "@xyflow/react";
-import palette from "fidesui/src/palette/palette.module.scss";
 import { useEffect, useMemo } from "react";
 
 import { TAXONOMY_ROOT_NODE_ID } from "~/features/taxonomy/constants";
@@ -204,7 +203,7 @@ const TaxonomyInteractiveTree = ({
   return (
     <div
       className="size-full"
-      style={{ backgroundColor: palette.FIDESUI_BG_CORINTH }}
+      style={{ backgroundColor: "var(--fidesui-bg-corinth)" }}
       data-testid="taxonomy-interactive-tree"
     >
       <TaxonomyTreeHoverProvider>
@@ -221,7 +220,7 @@ const TaxonomyInteractiveTree = ({
           proOptions={{ hideAttribution: true }}
         >
           <Background
-            color={palette.FIDESUI_NEUTRAL_100}
+            color="var(--fidesui-neutral-100)"
             variant={BackgroundVariant.Dots}
             size={3}
           />

--- a/clients/admin-ui/src/features/taxonomy/components/TaxonomyTreeEdge.tsx
+++ b/clients/admin-ui/src/features/taxonomy/components/TaxonomyTreeEdge.tsx
@@ -1,5 +1,4 @@
 import { BezierEdge, BezierEdgeProps } from "@xyflow/react";
-import palette from "fidesui/src/palette/palette.module.scss";
 import { useCallback, useContext } from "react";
 
 import {
@@ -22,11 +21,11 @@ const TaxonomyTreeEdge = (props: TaxonomyTreeEdgeProps) => {
     switch (targetNodeHoverStatus) {
       case TreeNodeHoverStatus.ACTIVE_HOVER:
       case TreeNodeHoverStatus.PARENT_OF_HOVER:
-        return palette.FIDESUI_MINOS;
+        return "var(--fidesui-minos)";
       case TreeNodeHoverStatus.INACTIVE:
-        return palette.NEUTRAL_400;
+        return "var(--fidesui-neutral-400)";
       default:
-        return palette.FIDESUI_SANDSTONE;
+        return "var(--fidesui-sandstone)";
     }
   }, [targetNodeHoverStatus]);
 

--- a/clients/admin-ui/src/features/taxonomy/components/TaxonomyTreeNodeHandle.tsx
+++ b/clients/admin-ui/src/features/taxonomy/components/TaxonomyTreeNodeHandle.tsx
@@ -1,5 +1,4 @@
 import { Handle, HandleType, Position } from "@xyflow/react";
-import palette from "fidesui/src/palette/palette.module.scss";
 
 interface TaxonomyTreeNodeHandleProps {
   type: HandleType;
@@ -20,8 +19,8 @@ const TaxonomyTreeNodeHandle = ({
         width: handleRadius,
         height: handleRadius,
         backgroundColor: inactive
-          ? palette.FIDESUI_NEUTRAL_400
-          : palette.FIDESUI_MINOS,
+          ? "var(--fidesui-neutral-400)"
+          : "var(--fidesui-minos)",
       }}
       className="transition-colors duration-300 ease-in"
     />

--- a/clients/admin-ui/src/home/AgentBriefingBanner.tsx
+++ b/clients/admin-ui/src/home/AgentBriefingBanner.tsx
@@ -6,7 +6,6 @@ import {
   SparkleIcon,
   useThemeMode,
 } from "fidesui";
-import palette from "fidesui/src/palette/palette.module.scss";
 import { useMemo } from "react";
 
 import { useFlags } from "~/features/common/features";
@@ -37,12 +36,12 @@ export const AgentBriefingBanner = () => {
         Alert: {
           colorInfoBg:
             resolvedMode === "dark"
-              ? palette.FIDESUI_MINOS
-              : palette.FIDESUI_LIMESTONE,
+              ? "var(--fidesui-minos)"
+              : "var(--fidesui-limestone)",
           colorInfoBorder:
             resolvedMode === "dark"
-              ? palette.FIDESUI_MINOS
-              : palette.FIDESUI_LIMESTONE,
+              ? "var(--fidesui-minos)"
+              : "var(--fidesui-limestone)",
         },
       },
     }),

--- a/clients/admin-ui/src/home/HomeBanner.tsx
+++ b/clients/admin-ui/src/home/HomeBanner.tsx
@@ -1,5 +1,4 @@
 import { Flex, Text, Title, useThemeMode } from "fidesui";
-import palette from "fidesui/src/palette/palette.module.scss";
 import * as React from "react";
 
 import { useFeatures } from "~/features/common/features";
@@ -13,8 +12,8 @@ const HomeBanner = () => {
   // Once we're using ant Layout globally, we won't need to hard-code the colors.
   const bgColor =
     resolvedMode === "dark"
-      ? palette.FIDESUI_BG_MINOS
-      : palette.FIDESUI_CORINTH;
+      ? "var(--fidesui-bg-minos)"
+      : "var(--fidesui-corinth)";
 
   const hasSystems = systemsCount > 0;
 

--- a/clients/admin-ui/src/home/HomeContainer.tsx
+++ b/clients/admin-ui/src/home/HomeContainer.tsx
@@ -7,7 +7,6 @@ import {
   ThemeModeProvider,
   useThemeMode,
 } from "fidesui";
-import palette from "fidesui/src/palette/palette.module.scss";
 import * as React from "react";
 
 import { useFlags } from "~/features/common/features";
@@ -26,8 +25,8 @@ const HomeContainerInner = () => {
   const activeTheme = resolvedMode === "dark" ? darkAntTheme : defaultAntTheme;
   const bgColor =
     resolvedMode === "dark"
-      ? palette.FIDESUI_BG_MINOS
-      : palette.FIDESUI_FULL_WHITE;
+      ? "var(--fidesui-bg-minos)"
+      : "var(--fidesui-full-white)";
 
   if (alphaDashboard) {
     return (

--- a/clients/admin-ui/src/home/PostureCard.tsx
+++ b/clients/admin-ui/src/home/PostureCard.tsx
@@ -11,7 +11,6 @@ import {
   Tooltip,
   useThemeMode,
 } from "fidesui";
-import palette from "fidesui/src/palette/palette.module.scss";
 import { useCallback, useMemo } from "react";
 
 import {
@@ -40,12 +39,12 @@ export const PostureCard = () => {
         Alert: {
           colorInfoBg:
             resolvedMode === "dark"
-              ? palette.FIDESUI_BG_MINOS
-              : palette.FIDESUI_LIMESTONE,
+              ? "var(--fidesui-bg-minos)"
+              : "var(--fidesui-limestone)",
           colorInfoBorder:
             resolvedMode === "dark"
-              ? palette.FIDESUI_MINOS
-              : palette.FIDESUI_LIMESTONE,
+              ? "var(--fidesui-minos)"
+              : "var(--fidesui-limestone)",
         },
       },
     }),

--- a/clients/admin-ui/src/home/constants.ts
+++ b/clients/admin-ui/src/home/constants.ts
@@ -1,5 +1,3 @@
-import palette from "fidesui/src/palette/palette.module.scss";
-
 import {
   ADD_SYSTEMS_ROUTE,
   CONFIGURE_CONSENT_ROUTE,
@@ -24,7 +22,7 @@ export enum ModuleCardKeys {
 
 export const MODULE_CARD_ITEMS: ModuleCardConfig[] = [
   {
-    color: palette.FIDESUI_SANDSTONE,
+    color: "var(--fidesui-sandstone)",
     description:
       "Explore the systems and data flow across your organization and create custom reports.",
     href: `${DATAMAP_ROUTE}`,
@@ -37,7 +35,7 @@ export const MODULE_CARD_ITEMS: ModuleCardConfig[] = [
     scopes: [ScopeRegistryEnum.DATAMAP_READ],
   },
   {
-    color: palette.FIDESUI_OLIVE,
+    color: "var(--fidesui-olive)",
     description: "Add third party applications and databases to your data map.",
     href: `${ADD_SYSTEMS_ROUTE}`,
     key: ModuleCardKeys.ADD_SYSTEMS,
@@ -47,7 +45,7 @@ export const MODULE_CARD_ITEMS: ModuleCardConfig[] = [
     scopes: [ScopeRegistryEnum.SYSTEM_CREATE],
   },
   {
-    color: palette.FIDESUI_TERRACOTTA,
+    color: "var(--fidesui-terracotta)",
     description:
       "Review system information for all systems in your organization.",
     href: `${SYSTEM_ROUTE}`,
@@ -59,7 +57,7 @@ export const MODULE_CARD_ITEMS: ModuleCardConfig[] = [
     requiresSystems: true,
   },
   {
-    color: palette.FIDESUI_MINOS,
+    color: "var(--fidesui-minos)",
     description:
       "Review, approve and process privacy requests across your systems on behalf of your users.",
     href: `${PRIVACY_REQUESTS_ROUTE}`,
@@ -71,7 +69,7 @@ export const MODULE_CARD_ITEMS: ModuleCardConfig[] = [
     requiresConnections: true,
   },
   {
-    color: palette.FIDESUI_NECTAR,
+    color: "var(--fidesui-nectar)",
     description:
       "Manage privacy notices and experiences for all domains in your organization.",
     href: `${CONFIGURE_CONSENT_ROUTE}`,

--- a/clients/admin-ui/src/pages/poc/form-experiments/AntForm.tsx
+++ b/clients/admin-ui/src/pages/poc/form-experiments/AntForm.tsx
@@ -13,7 +13,6 @@ import {
   Tag,
   Typography,
 } from "fidesui";
-import palette from "fidesui/src/palette/palette.module.scss";
 import { useState } from "react";
 
 import { initialValues } from "../../../features/poc/constants";
@@ -104,8 +103,8 @@ export const AntFormPOC = () => {
         <Title level={4}>Controlled Values</Title>
         <Card
           style={{
-            backgroundColor: palette.FIDESUI_MINOS,
-            color: palette.FIDESUI_CORINTH,
+            backgroundColor: "var(--fidesui-minos)",
+            color: "var(--fidesui-corinth)",
           }}
         >
           <pre>

--- a/clients/admin-ui/src/pages/poc/form-experiments/FormikAntFormItem.tsx
+++ b/clients/admin-ui/src/pages/poc/form-experiments/FormikAntFormItem.tsx
@@ -16,7 +16,6 @@ import {
   Tag,
   Typography,
 } from "fidesui";
-import palette from "fidesui/src/palette/palette.module.scss";
 import { Form, Formik } from "formik";
 
 import { initialValues } from "../../../features/poc/constants";
@@ -127,8 +126,8 @@ export const FormikAntFormItemPOC = () => (
           <Title level={4}>Controlled Values</Title>
           <Card
             style={{
-              backgroundColor: palette.FIDESUI_MINOS,
-              color: palette.FIDESUI_CORINTH,
+              backgroundColor: "var(--fidesui-minos)",
+              color: "var(--fidesui-corinth)",
             }}
           >
             <pre>

--- a/clients/admin-ui/src/pages/poc/form-experiments/FormikControlled.tsx
+++ b/clients/admin-ui/src/pages/poc/form-experiments/FormikControlled.tsx
@@ -15,7 +15,6 @@ import {
   Tag,
   Typography,
 } from "fidesui";
-import palette from "fidesui/src/palette/palette.module.scss";
 import { Form, Formik } from "formik";
 
 import { initialValues } from "../../../features/poc/constants";
@@ -150,8 +149,8 @@ export const FormikControlledPOC = () => (
           <Title level={4}>Controlled Values</Title>
           <Card
             style={{
-              backgroundColor: palette.FIDESUI_MINOS,
-              color: palette.FIDESUI_CORINTH,
+              backgroundColor: "var(--fidesui-minos)",
+              color: "var(--fidesui-corinth)",
             }}
           >
             <pre>

--- a/clients/admin-ui/src/pages/poc/form-experiments/FormikField.tsx
+++ b/clients/admin-ui/src/pages/poc/form-experiments/FormikField.tsx
@@ -14,7 +14,6 @@ import {
   Tag,
   Typography,
 } from "fidesui";
-import palette from "fidesui/src/palette/palette.module.scss";
 import { Field, Form, Formik } from "formik";
 
 import { initialValues } from "../../../features/poc/constants";
@@ -170,8 +169,8 @@ export const FormikFieldPOC = () => (
           <Title level={4}>Controlled Values</Title>
           <Card
             style={{
-              backgroundColor: palette.FIDESUI_MINOS,
-              color: palette.FIDESUI_CORINTH,
+              backgroundColor: "var(--fidesui-minos)",
+              color: "var(--fidesui-corinth)",
             }}
           >
             <pre>

--- a/clients/admin-ui/src/pages/poc/form-experiments/FormikSpreadField.tsx
+++ b/clients/admin-ui/src/pages/poc/form-experiments/FormikSpreadField.tsx
@@ -14,7 +14,6 @@ import {
   Tag,
   Typography,
 } from "fidesui";
-import palette from "fidesui/src/palette/palette.module.scss";
 import { Field, Form, Formik } from "formik";
 
 import { initialValues } from "../../../features/poc/constants";
@@ -194,8 +193,8 @@ export const FormikSpreadFieldPOC = () => (
           <Title level={4}>Controlled Values</Title>
           <Card
             style={{
-              backgroundColor: palette.FIDESUI_MINOS,
-              color: palette.FIDESUI_CORINTH,
+              backgroundColor: "var(--fidesui-minos)",
+              color: "var(--fidesui-corinth)",
             }}
           >
             <pre>

--- a/clients/privacy-center/features/external-manual-tasks/components/ExternalTaskLayout.tsx
+++ b/clients/privacy-center/features/external-manual-tasks/components/ExternalTaskLayout.tsx
@@ -7,7 +7,6 @@
  */
 
 import { Button, Card, Flex, Typography } from "fidesui";
-import palette from "fidesui/src/palette/palette.module.scss";
 
 import BrandLink from "~/components/BrandLink";
 import { useConfig } from "~/features/common/config.slice";
@@ -46,7 +45,7 @@ export const ExternalTaskLayout = () => {
     <div
       style={{
         minHeight: "100vh",
-        backgroundColor: palette.FIDESUI_NEUTRAL_75,
+        backgroundColor: "var(--fidesui-neutral-75)",
         padding: "32px 16px",
         position: "relative",
       }}


### PR DESCRIPTION
First step of [ENG-3410]

### Description Of Changes

The fidesui palette is exposed two ways: as a JS import (`palette.FIDESUI_*`) and as CSS variables (`var(--fidesui-*)`), both generated from the same SCSS source map. This PR replaces all 40 JS palette imports across `admin-ui` and `privacy-center` with their CSS variable equivalents.

This reduces build-time SCSS module resolution dependencies in TS files and aligns with the CSS-first direction the codebase is heading with Ant Design tokens.

The `:export` block in `palette.module.scss` is still needed for fidesui internals (theme config, CustomTag, Storybook) but no longer has any consumers outside of `fidesui/`.

### Code Changes

* Removed `import palette from "fidesui/src/palette/palette.module.scss"` from 40 files (39 admin-ui + 1 privacy-center)
* Replaced ~114 `palette.FIDESUI_*` references with `"var(--fidesui-*)"` CSS variable strings
* Fixed a latent bug in `TaxonomyTreeEdge.tsx` where `palette.NEUTRAL_400` (missing `FIDESUI_` prefix) was likely resolving to `undefined`

### Steps to Confirm

1. Run `npx tsc --noEmit` in both `clients/admin-ui` and `clients/privacy-center` -- should pass with no errors
2. Verify no palette imports remain: `grep -r 'from "fidesui/src/palette' clients/admin-ui/src/ clients/privacy-center/`
3. Visual spot-check: navigation sidebar, home page cards, taxonomy tree, datamap graph edges, status indicator icons, messaging form verified checkmarks

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [x] No UX review needed
* Followup issues:
  * [x] No followup issues
* Database migrations:
  * [x] No migrations
* Documentation:
  * [x] No documentation updates required

[ENG-3410]: https://ethyca.atlassian.net/browse/ENG-3410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ