### PR TITLE
ENG-3455: Add username validation to new user form

### DIFF
--- a/changelog/7957-username-form-validation.yaml
+++ b/changelog/7957-username-form-validation.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Added frontend username validation to the new user form to match backend character restrictions
+pr: 7957
+labels: []

--- a/clients/admin-ui/src/features/common/form/validation.ts
+++ b/clients/admin-ui/src/features/common/form/validation.ts
@@ -1,3 +1,13 @@
+export const usernameRules = [
+  { required: true, message: "Username is required" },
+  { max: 100, message: "Username must be 100 characters or fewer." },
+  {
+    pattern: /^[a-zA-Z0-9._-]+$/,
+    message:
+      "Usernames may only contain letters, numbers, periods, underscores, and hyphens.",
+  },
+];
+
 export const passwordRules = [
   { required: true, message: "Password is required" },
   { min: 8, message: "Password must have at least eight characters." },

--- a/clients/admin-ui/src/features/user-management/UserForm.tsx
+++ b/clients/admin-ui/src/features/user-management/UserForm.tsx
@@ -17,9 +17,11 @@ import DeleteUserModal from "user-management/DeleteUserModal";
 
 import { useAppDispatch, useAppSelector } from "~/app/hooks";
 import { useFeatures } from "~/features/common/features";
-import { passwordRules } from "~/features/common/form/validation";
+import {
+  passwordRules,
+  usernameRules,
+} from "~/features/common/form/validation";
 import { getErrorMessage, isErrorResult } from "~/features/common/helpers";
-import { InfoTooltip } from "~/features/common/InfoTooltip";
 import { USER_MANAGEMENT_ROUTE } from "~/features/common/nav/routes";
 import {
   selectPlusSecuritySettings,
@@ -227,11 +229,7 @@ const UserForm = ({ onSubmit, initialValues, canEditNames }: UserFormProps) => {
             )}
           </Flex>
         </Flex>
-        <Form.Item
-          name="username"
-          label="Username"
-          rules={[{ required: true, message: "Username is required" }]}
-        >
+        <Form.Item name="username" label="Username" rules={usernameRules}>
           <Input
             placeholder="Enter new username"
             disabled={!isNewUser}
@@ -268,12 +266,8 @@ const UserForm = ({ onSubmit, initialValues, canEditNames }: UserFormProps) => {
         {showPasswordLoginToggle && (
           <Form.Item
             name="password_login_enabled"
-            label={
-              <Flex align="center" gap={4}>
-                Allow password login
-                <InfoTooltip label="When enabled, user can log in with username and password. When disabled, user must use SSO." />
-              </Flex>
-            }
+            label="Allow password login"
+            tooltip="When enabled, user can log in with username and password. When disabled, user must use SSO."
             valuePropName="checked"
           >
             <Switch
@@ -285,18 +279,11 @@ const UserForm = ({ onSubmit, initialValues, canEditNames }: UserFormProps) => {
         {showPasswordField && (
           <Form.Item
             name="password"
-            label={
-              <Flex align="center" gap={4}>
-                Password
-                <InfoTooltip label="Password must contain at least 8 characters, 1 number, 1 capital letter, 1 lowercase letter, and at least 1 symbol." />
-              </Flex>
-            }
+            label="Password"
+            tooltip="Password must contain at least 8 characters, 1 number, 1 capital letter, 1 lowercase letter, and at least 1 symbol."
             rules={passwordRules}
           >
-            <Input.Password
-              placeholder="********"
-              data-testid="input-password"
-            />
+            <Input.Password data-testid="input-password" />
           </Form.Item>
         )}
       </div>

--- a/clients/admin-ui/src/features/user-management/UserForm.tsx
+++ b/clients/admin-ui/src/features/user-management/UserForm.tsx
@@ -229,7 +229,7 @@ const UserForm = ({ onSubmit, initialValues, canEditNames }: UserFormProps) => {
             )}
           </Flex>
         </Flex>
-        <Form.Item name="username" label="Username" rules={usernameRules}>
+        <Form.Item name="username" label="Username" rules={isNewUser ? usernameRules : []}>
           <Input
             placeholder="Enter new username"
             disabled={!isNewUser}

--- a/clients/admin-ui/src/features/user-management/UserForm.tsx
+++ b/clients/admin-ui/src/features/user-management/UserForm.tsx
@@ -229,7 +229,11 @@ const UserForm = ({ onSubmit, initialValues, canEditNames }: UserFormProps) => {
             )}
           </Flex>
         </Flex>
-        <Form.Item name="username" label="Username" rules={isNewUser ? usernameRules : []}>
+        <Form.Item
+          name="username"
+          label="Username"
+          rules={isNewUser ? usernameRules : []}
+        >
           <Input
             placeholder="Enter new username"
             disabled={!isNewUser}

--- a/src/fides/api/email_templates/templates/user_invite.html
+++ b/src/fides/api/email_templates/templates/user_invite.html
@@ -6,7 +6,7 @@
   </head>
   <body>
     <main>
-      <p>You've been invited to join Fides, <a href={{admin_ui_url}}/login?invite_code={{invite_code}}&username={{username}}>accept the invite</a> and setup your account.</p>
+      <p>You've been invited to join Fides, <a href="{{admin_ui_url}}/login?invite_code={{invite_code|urlencode}}&username={{username|urlencode}}">accept the invite</a> and setup your account.</p>
     </main>
   </body>
 </html>

--- a/src/fides/api/email_templates/templates/user_invite.html
+++ b/src/fides/api/email_templates/templates/user_invite.html
@@ -6,7 +6,7 @@
   </head>
   <body>
     <main>
-      <p>You've been invited to join Fides, <a href="{{admin_ui_url}}/login?invite_code={{invite_code|urlencode}}&username={{username|urlencode}}">accept the invite</a> and setup your account.</p>
+      <p>You've been invited to join Fides, <a href="{{admin_ui_url}}/login?invite_code={{invite_code|urlencode}}&amp;username={{username|urlencode}}">accept the invite</a> and setup your account.</p>
     </main>
   </body>
 </html>


### PR DESCRIPTION
Ticket [ENG-3455]

### Description Of Changes

The "New user" form wasn't validating usernames beyond requiring they be non-empty. Since usernames are included in email invite links, characters like `&` and `=` get parsed as query parameters, which is a potential XSS vector.

The backend already enforces `[a-zA-Z0-9._-]{1,100}` (added in ENG-3466 / #7953). This PR adds:

1. **Frontend validation** - matching rules so users get immediate feedback before submission
2. **Email template fix** - URL-encodes the username in the invite email template (matching the existing `password_reset.html` pattern) and adds missing `href` quotes

### Code Changes

* Added `usernameRules` to `clients/admin-ui/src/features/common/form/validation.ts` with `required`, `max: 100`, and pattern matching the backend's `USERNAME_PATTERN`
* Applied `usernameRules` to the username `Form.Item` in `UserForm.tsx`
* URL-encoded `username` and `invite_code` in `user_invite.html` template using Jinja2's `urlencode` filter, added missing `href` quotes
* Replaced `InfoTooltip` with native antd `tooltip` prop on password and SSO toggle fields
* Removed unused `InfoTooltip` import

### Steps to Confirm

1. Navigate to User Management > New User
2. Enter an invalid username like `this&is=my&user=name` -- validation error should appear
3. Enter a username longer than 100 characters -- length error should appear
4. Enter a valid username like `jane.doe-1` -- no validation error
5. Verify password and SSO toggle tooltips still display correctly

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-3455]: https://ethyca.atlassian.net/browse/ENG-3455