### PR TITLE
chore: only trigger code review on /code-review comment

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,8 +8,6 @@
 # (callers, impact analysis, architecture checks, test coverage).
 #
 # Triggers:
-#   - PR opened (non-draft) or moved out of draft
-#   - PR reopened
 #   - Comment containing "/code-review" on a PR (trusted users only)
 #
 # Required secrets:
@@ -21,8 +19,6 @@
 name: Claude Code Review
 
 on:
-  pull_request:
-    types: [opened, ready_for_review, reopened]
   issue_comment:
     types: [created]
 
@@ -37,17 +33,10 @@ jobs:
       group: claude-review-${{ github.event.pull_request.number || github.event.issue.number }}
       cancel-in-progress: true
     if: >
-      (
-        github.event_name == 'pull_request'
-        && !github.event.pull_request.draft
-        && github.actor != 'dependabot[bot]'
-      )
-      || (
-        github.event_name == 'issue_comment'
-        && github.event.issue.pull_request
-        && contains(github.event.comment.body, '/code-review')
-        && contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
-      )
+      github.event_name == 'issue_comment'
+      && github.event.issue.pull_request
+      && contains(github.event.comment.body, '/code-review')
+      && contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
 
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Removes automatic `pull_request` trigger from Claude code review workflow
- Reviews now only run when a trusted user posts `/code-review` on a PR

## Test plan
- [ ] Confirm `/code-review` comment still triggers the review on a test PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)