### PR TITLE
ENG-3462: Fix console warnings and errors in Admin UI

### DIFF
--- a/changelog/7959-fix-console-warnings-errors.yaml
+++ b/changelog/7959-fix-console-warnings-errors.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Fix various console warnings and errors in Admin UI
+pr: 7959
+labels: []

--- a/clients/admin-ui/src/features/connection-type/connection-type.slice.ts
+++ b/clients/admin-ui/src/features/connection-type/connection-type.slice.ts
@@ -101,12 +101,11 @@ export const { reducer } = connectionTypeSlice;
 
 export const selectConnectionTypeState = (state: RootState) =>
   state.connectionType;
-export const selectConnectionTypeFilters = (
-  state: RootState,
-): ConnectionTypeParams => ({
-  search: state.connectionType.search,
-  system_type: state.connectionType.system_type,
-});
+export const selectConnectionTypeFilters = createSelector(
+  (state: RootState) => state.connectionType.search,
+  (state: RootState) => state.connectionType.system_type,
+  (search, system_type): ConnectionTypeParams => ({ search, system_type }),
+);
 
 export const connectionTypeApi = baseApi.injectEndpoints({
   endpoints: (build) => ({

--- a/clients/admin-ui/src/features/privacy-experience/preview/Preview.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/preview/Preview.tsx
@@ -452,8 +452,7 @@ const Preview = ({
         id={PREVIEW_CONTAINER_ID}
         key={values.component}
         data-a11y-dialog-ignore-focus-trap="" // tells a11y-dialog to ignore focus trap
-        // @ts-expect-error - React 18 doesn't support inert attribute
-        inert=""
+        inert
       />
     </Flex>
   );

--- a/clients/admin-ui/src/features/privacy-requests/pre-approval-webhooks/PreApprovalWebhooksPage.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/pre-approval-webhooks/PreApprovalWebhooksPage.tsx
@@ -10,6 +10,7 @@ import {
   Tooltip,
   Typography,
   useMessage,
+  useModal,
 } from "fidesui";
 import { useState } from "react";
 
@@ -59,6 +60,7 @@ const PreApprovalWebhooksPage = () => {
   const [patchConnection] = usePatchDatastoreConnectionMutation();
   const [patchSecrets] = usePatchDatastoreConnectionSecretsMutation();
   const message = useMessage();
+  const confirmModal = useModal();
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingWebhook, setEditingWebhook] =
@@ -69,24 +71,17 @@ const PreApprovalWebhooksPage = () => {
 
   const openCreateModal = () => {
     setEditingWebhook(null);
-    form.resetFields();
     setIsModalOpen(true);
   };
 
   const openEditModal = (webhook: PreApprovalWebhookResponse) => {
     setEditingWebhook(webhook);
-    form.setFieldsValue({
-      name: webhook.name,
-      url: "",
-      authorization: "",
-    });
     setIsModalOpen(true);
   };
 
   const handleCancel = () => {
     setIsModalOpen(false);
     setEditingWebhook(null);
-    form.resetFields();
   };
 
   const handleSubmit = async (values: WebhookFormValues) => {
@@ -183,7 +178,7 @@ const PreApprovalWebhooksPage = () => {
               icon={<Icons.TrashCan />}
               aria-label="Delete webhook"
               onClick={() => {
-                Modal.confirm({
+                confirmModal.confirm({
                   title: "Delete this webhook?",
                   content: "This action cannot be undone.",
                   okText: "Delete",
@@ -241,6 +236,11 @@ const PreApprovalWebhooksPage = () => {
           layout="vertical"
           onFinish={handleSubmit}
           autoComplete="off"
+          initialValues={
+            editingWebhook
+              ? { name: editingWebhook.name, url: "", authorization: "" }
+              : undefined
+          }
         >
           <Form.Item
             label="Webhook name"
@@ -264,6 +264,12 @@ const PreApprovalWebhooksPage = () => {
           <Form.Item
             label="Authorization header"
             name="authorization"
+            rules={[
+              {
+                required: !editingWebhook,
+                message: "Please enter an authorization header",
+              },
+            ]}
             help={
               editingWebhook
                 ? "Leave blank to keep the existing authorization value"

--- a/clients/admin-ui/src/features/properties/DeletePropertyModal.tsx
+++ b/clients/admin-ui/src/features/properties/DeletePropertyModal.tsx
@@ -1,4 +1,4 @@
-import { ChakraText as Text, Tooltip, useMessage, useModal } from "fidesui";
+import { Tooltip, Typography, useMessage, useModal } from "fidesui";
 import router from "next/router";
 import React from "react";
 
@@ -43,12 +43,12 @@ const DeletePropertyModal = ({ property, triggerComponent }: Props) => {
       modal.confirm({
         title: `Delete ${property.name}`,
         content: (
-          <Text color="gray.500">
+          <Typography.Text>
             You are about to delete property {property.name}. This action is not
             reversible and will result in {property.name} no longer being
             available for your data governance. Are you sure you want to
             proceed?
-          </Text>
+          </Typography.Text>
         ),
         okText: "Ok",
         centered: true,

--- a/clients/admin-ui/src/features/properties/PropertyForm.tsx
+++ b/clients/admin-ui/src/features/properties/PropertyForm.tsx
@@ -150,7 +150,9 @@ export const PropertyForm = ({ property, isLoading, handleSubmit }: Props) => {
                   data-testid="input-type"
                 />
               </Form.Item>
-              <Form.Item name="paths" hidden />
+              <Form.Item name="paths" hidden noStyle>
+                <Input />
+              </Form.Item>
               <Form.Item
                 name="experiences"
                 label="Experiences"

--- a/clients/admin-ui/src/home/ActivityFeedCard.tsx
+++ b/clients/admin-ui/src/home/ActivityFeedCard.tsx
@@ -107,7 +107,7 @@ export const ActivityFeedCard = () => {
     }
     return (
       <>
-        {items.map((item) => {
+        {items.map((item, i) => {
           const cta =
             item.event_type && ACTION_CTA[item.event_type]
               ? ACTION_CTA[item.event_type]
@@ -115,7 +115,7 @@ export const ActivityFeedCard = () => {
           const href = cta ? cta.route(item.action_data ?? {}) : null;
 
           return (
-            <div key={item.id}>
+            <div key={item.id || i}>
               {href ? (
                 <RouterLink
                   unstyled

--- a/clients/admin-ui/src/home/ActivityFeedCard.tsx
+++ b/clients/admin-ui/src/home/ActivityFeedCard.tsx
@@ -115,7 +115,7 @@ export const ActivityFeedCard = () => {
           const href = cta ? cta.route(item.action_data ?? {}) : null;
 
           return (
-            <div key={item.id || i}>
+            <div key={item.id ?? i}>
               {href ? (
                 <RouterLink
                   unstyled

--- a/clients/fidesui/src/components/charts/AreaChart.tsx
+++ b/clients/fidesui/src/components/charts/AreaChart.tsx
@@ -97,7 +97,11 @@ export const AreaChart = ({
   return (
     <div ref={containerRef} className="h-full w-full">
       {containerWidth > 0 && (
-        <ResponsiveContainer width="100%" height="100%">
+        <ResponsiveContainer
+          width="100%"
+          height="100%"
+          initialDimension={{ width: 1, height: 1 }}
+        >
           <RechartsAreaChart
             data={chartData}
             margin={{ top: 5, right: 5, bottom: 0, left: -15 }}

--- a/clients/fidesui/src/components/charts/BarChart.tsx
+++ b/clients/fidesui/src/components/charts/BarChart.tsx
@@ -160,7 +160,11 @@ export const BarChart = ({
   return (
     <div ref={containerRef} className="h-full w-full">
       {containerWidth > 0 && (
-        <ResponsiveContainer width="100%" height="100%">
+        <ResponsiveContainer
+          width="100%"
+          height="100%"
+          initialDimension={{ width: 1, height: 1 }}
+        >
           <RechartsBarChart
             data={chartData}
             margin={{ top: 0, right: 0, bottom: 0, left: 0 }}

--- a/clients/fidesui/src/components/charts/RadarChart.tsx
+++ b/clients/fidesui/src/components/charts/RadarChart.tsx
@@ -293,7 +293,11 @@ export const RadarChart = ({
       })}
       onMouseLeave={tooltipContent ? handleTickLeave : undefined}
     >
-      <ResponsiveContainer width="100%" height="100%">
+      <ResponsiveContainer
+        width="100%"
+        height="100%"
+        initialDimension={{ width: 1, height: 1 }}
+      >
         <RechartsRadarChart
           data={empty ? EMPTY_GRID_DATA : data}
           cx="50%"

--- a/clients/fidesui/src/components/charts/Sparkline.tsx
+++ b/clients/fidesui/src/components/charts/Sparkline.tsx
@@ -124,7 +124,11 @@ export const Sparkline = ({
   );
 
   return (
-    <ResponsiveContainer width="100%" height="100%">
+    <ResponsiveContainer
+      width="100%"
+      height="100%"
+      initialDimension={{ width: 1, height: 1 }}
+    >
       <AreaChart
         data={chartData}
         margin={{

--- a/clients/fidesui/src/components/charts/StackedBarChart.tsx
+++ b/clients/fidesui/src/components/charts/StackedBarChart.tsx
@@ -290,7 +290,11 @@ export const StackedBarChart = ({
     sortedData.length * barHeight + (sortedData.length - 1) * rowGap + rowGap;
 
   return (
-    <ResponsiveContainer width="100%" height={chartHeight}>
+    <ResponsiveContainer
+      width="100%"
+      height={chartHeight}
+      initialDimension={{ width: 1, height: 1 }}
+    >
       <BarChart
         data={sortedData}
         layout="vertical"

--- a/clients/fidesui/src/components/data-entry/LocationSelect.tsx
+++ b/clients/fidesui/src/components/data-entry/LocationSelect.tsx
@@ -93,13 +93,15 @@ export type LocationSelectProps = (
 
 export const LocationSelect = (props: LocationSelectProps) => {
   const {
-    mode,
     includeCountryOnlyOptions = false,
     options: { countries, regions } = {
       countries: iso31661,
       regions: iso31662,
     },
+    ...selectProps
   } = props;
+
+  const { mode } = selectProps;
 
   const defaultProps = {
     "data-testid": "iso_select",
@@ -154,7 +156,7 @@ export const LocationSelect = (props: LocationSelectProps) => {
     <Select<string, IsoOption>
       placeholder={mode ? "🌐 Select locations" : "🌐 Select location"}
       {...defaultProps}
-      {...props}
+      {...selectProps}
       options={isoSelectOptions}
     />
   );

--- a/clients/fidesui/src/hoc/CustomTag.tsx
+++ b/clients/fidesui/src/hoc/CustomTag.tsx
@@ -104,6 +104,10 @@ const withCustomProps = (WrappedComponent: typeof Tag) => {
         };
       }
 
+      const closeIconContent = props.closeIcon ?? (
+        <Icons.CloseLarge size={12} />
+      );
+
       const customProps: TagProps = {
         // If not a brand color, pass through to Ant Tag
         color: brandColor ? undefined : color,
@@ -121,19 +125,40 @@ const withCustomProps = (WrappedComponent: typeof Tag) => {
         variant: retainDefaultBorder || !brandColor ? "outlined" : "filled",
         ...props,
         closeIcon:
+          // eslint-disable-next-line no-nested-ternary
           (props.closable ?? props.onClose) ? (
             // Ant's own close icon doesn't currently use a button element,
             // so we need to use our own for accessibility.
             //
             // NOTE: Ant Design overrides aria-label with "Close" no matter what,
             // but we fix this post-render using useEffect above.
-            <button
-              type="button"
-              className={styles.closeButton}
-              aria-label={closeButtonLabel}
-            >
-              {props.closeIcon ?? <Icons.CloseLarge size={12} />}
-            </button>
+            //
+            // When onClick is set, the tag is wrapped in an outer <button>,
+            // so we use a <span> to avoid invalid button-in-button nesting.
+            onClick ? (
+              <span
+                role="button"
+                tabIndex={0}
+                className={styles.closeButton}
+                aria-label={closeButtonLabel}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    (e.target as HTMLElement).click();
+                  }
+                }}
+              >
+                {closeIconContent}
+              </span>
+            ) : (
+              <button
+                type="button"
+                className={styles.closeButton}
+                aria-label={closeButtonLabel}
+              >
+                {closeIconContent}
+              </button>
+            )
           ) : undefined,
         children: (
           <>

--- a/clients/fidesui/src/hoc/CustomTag.tsx
+++ b/clients/fidesui/src/hoc/CustomTag.tsx
@@ -141,9 +141,11 @@ const withCustomProps = (WrappedComponent: typeof Tag) => {
                 tabIndex={0}
                 className={styles.closeButton}
                 aria-label={closeButtonLabel}
+                onClick={(e) => e.stopPropagation()}
                 onKeyDown={(e) => {
                   if (e.key === "Enter" || e.key === " ") {
                     e.preventDefault();
+                    e.stopPropagation();
                     (e.target as HTMLElement).click();
                   }
                 }}


### PR DESCRIPTION
Ticket [ENG-3462]

### Description Of Changes

Addresses several non-Ant-migration console warnings and errors across the Admin UI and fidesui packages.

### Code Changes

* **CustomTag** - Use `<span role="button">` instead of `<button>` for close icon when tag has `onClick` (fixes button-in-button nesting warning)
* **LocationSelect** - Destructure `includeCountryOnlyOptions` before spreading remaining props to prevent unrecognized DOM prop warning
* **Preview** - Remove `@ts-expect-error` for `inert` attribute (supported in React 19)
* **connection-type.slice** - Memoize `selectConnectionTypeFilters` with `createSelector` to prevent unnecessary re-renders
* **PropertyForm** - Add child `<Input>` to hidden `Form.Item` and add `noStyle` to fix antd `name` warning
* **ActivityFeedCard** - Add fallback index key for items with missing `id`
* **DeletePropertyModal** - Replace `ChakraText` with `Typography.Text` to fix hydration warning
* **PreApprovalWebhooksPage** - Use `useModal` hook instead of static `Modal.confirm`, use `initialValues` instead of imperative `form.setFieldsValue`/`form.resetFields`, add validation rule for authorization field
* **Charts (AreaChart, BarChart, RadarChart, Sparkline, StackedBarChart)** - Add `initialDimension` to `ResponsiveContainer` to suppress Recharts dimension warnings

### Steps to Confirm

1. Run the Admin UI locally and navigate through the app
2. Open the browser console and verify the following warnings are resolved:
   - No `includeCountryOnlyOptions` DOM prop warning on pages with location selects
   - No button-in-button nesting warning when using closable tags with onClick
   - No antd Form.Item `name` warning on the property form
   - No Recharts dimension warnings on dashboard charts
3. Verify closable tags still function correctly (close button works, keyboard accessible)
4. Verify the pre-approval webhooks page create/edit/delete flows still work

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required

[ENG-3462]: https://ethyca.atlassian.net/browse/ENG-3462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ