### PR TITLE
ENG-3406: fix stale sidebar data in action center

### DIFF
--- a/changelog/7960-fix-action-center-stale-sidebar.yaml
+++ b/changelog/7960-fix-action-center-stale-sidebar.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Fixed stale sidebar data in the Action Center datastore monitor page after clicking the refresh button
+pr: 7960
+labels: []

--- a/clients/admin-ui/src/pages/data-discovery/action-center/datastore/[monitorId]/index.tsx
+++ b/clients/admin-ui/src/pages/data-discovery/action-center/datastore/[monitorId]/index.tsx
@@ -88,7 +88,12 @@ const DatastoreMonitorResultSystems: NextPage = () => {
         },
       }}
       refresh={async () => {
-        dispatch(monitorFieldUtil.invalidateTags(["Monitor Field Results"]));
+        dispatch(
+          monitorFieldUtil.invalidateTags([
+            "Monitor Field Results",
+            "Monitor Field Details",
+          ]),
+        );
         await trigger({
           monitor_config_id: monitorId,
           monitor_type: APIMonitorType.DATASTORE,


### PR DESCRIPTION
Ticket [ENG-3406] <!-- simply paste the ticket number between the brackets and it will auto-convert to a link -->

### Description Of Changes

Fixes stale sidebar data in the Action Center's datastore classifying monitor page. The refresh button only invalidated the `Monitor Field Results` RTK Query tag (used by the table) but not the `Monitor Field Details` tag (used by the sidebar drawer), so a drawer reopened shortly after a refresh could serve a cached response. This brings the refresh button in line with how other action-center mutations (e.g. classify/mute) already invalidate both tags.

### Code Changes

* Updated the `refresh` handler in `clients/admin-ui/src/pages/data-discovery/action-center/datastore/[monitorId]/index.tsx` to invalidate `Monitor Field Details` in addition to `Monitor Field Results`.

### Steps to Confirm

1. Navigate to a datastore classifying monitor's Action Center results page (`/data-discovery/action-center/datastore/<monitorId>`) that has at least one classified field.
2. Open browser DevTools → Network tab and filter by `fetch/XHR`.
3. Click any field row to open the details sidebar. Observe that a GET request to the field details endpoint (`useGetStagedResourceDetailsQuery`) fires and the sidebar renders with its data.
4. Close the sidebar.
5. Click the refresh button at the top of the page. Observe that the fields list endpoint refetches.
6. Click the same field row again to reopen the sidebar.
7. Confirm that a new GET request to the field details endpoint fires (without this fix, no request fires and the sidebar displays stale cached data).

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-3406]: https://ethyca.atlassian.net/browse/ENG-3406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
