### PR TITLE
ENG-3428: remove buggy and redundant action center activity tab tooltip

### DIFF
--- a/changelog/7962-action-center-activity-tab-tooltip-removal.yaml
+++ b/changelog/7962-action-center-activity-tab-tooltip-removal.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Removed redundant and flickering tooltip from error messages in the Action Center Activity tab.
+pr: 7962
+labels: []

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/components/InProgressMonitorTaskItem.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/components/InProgressMonitorTaskItem.tsx
@@ -205,7 +205,6 @@ export const InProgressMonitorTaskItem = ({
                     rows: 1,
                     expandable: true,
                     symbol: "more",
-                    tooltip: true,
                   }}
                 >
                   {task.message || "Unknown error"}


### PR DESCRIPTION
Ticket [ENG-3428] <!-- simply paste the ticket number between the brackets and it will auto-convert to a link -->

### Description Of Changes

Removes the hover tooltip on error messages in the Action Center Activity tab. The tooltip duplicated the content already shown by the inline "more" expand button (in a less readable way), was visually overwhelming for long SQL errors, and exhibited a flickering bug from hover-detection races.

### Code Changes

* Removed `tooltip: true` from the `Paragraph` ellipsis config in `InProgressMonitorTaskItem.tsx`. The `expandable: true` / `symbol: "more"` behavior is preserved.

### Steps to Confirm

1. Spin up a Plus environment with at least one monitor task in `error` status.
2. Navigate to **Data inventory > Action center**, open a monitor, and select the **Activity** tab.
3. Hover over the error message text on a row with an "Error" badge.
4. Confirm no tooltip appears on hover, and that clicking the inline **more** button still expands the full error message.

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-3428]: https://ethyca.atlassian.net/browse/ENG-3428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ