### PR TITLE
ENG-3261: close re-invite validation gap and null-email modal render

### DIFF
--- a/changelog/7963-fix-reinvite-flow-validation.yaml
+++ b/changelog/7963-fix-reinvite-flow-validation.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Tightened reinvite user endpoint validation so disabled users whose disabled_reason is not pending_invite are rejected, and guarded the reinvite confirmation modal against rendering a null email address.
+pr: 7963
+labels: []

--- a/clients/admin-ui/src/features/user-management/EditUserForm.tsx
+++ b/clients/admin-ui/src/features/user-management/EditUserForm.tsx
@@ -71,8 +71,10 @@ const ReinviteSection = ({ user }: ReinviteSectionProps) => {
     const content = (
       <>
         <p>
-          Are you sure you want to send a new invitation to {user.username}? A
-          new invitation email will be sent to {user.email_address}.
+          Are you sure you want to send a new invitation to {user.username}?
+          {user.email_address
+            ? ` A new invitation email will be sent to ${user.email_address}.`
+            : ""}
         </p>
         {!user.invite_expired ? (
           <p>The previous invitation code will no longer be valid.</p>

--- a/src/fides/api/v1/endpoints/user_endpoints.py
+++ b/src/fides/api/v1/endpoints/user_endpoints.py
@@ -603,16 +603,10 @@ def reinvite_user(
             detail="User not found.",
         )
 
-    if not user.disabled:
+    if not user.disabled or user.disabled_reason != DisabledReason.pending_invite:
         raise HTTPException(
             status_code=HTTP_400_BAD_REQUEST,
             detail="User does not have a pending invitation.",
-        )
-
-    if user.disabled_reason and user.disabled_reason != DisabledReason.pending_invite:
-        raise HTTPException(
-            status_code=HTTP_400_BAD_REQUEST,
-            detail="User is disabled for a reason other than a pending invitation.",
         )
 
     try:

--- a/tests/ops/api/v1/endpoints/test_user_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_user_endpoints.py
@@ -35,6 +35,7 @@ from fides.api.oauth.jwt import generate_jwe
 from fides.api.oauth.roles import APPROVER, CONTRIBUTOR, OWNER, VIEWER
 from fides.api.oauth.utils import extract_payload
 from fides.api.schemas.messaging.messaging import MessagingActionType
+from fides.api.schemas.user import DisabledReason
 from fides.common.scope_registry import (
     PRIVACY_REQUEST_READ,
     SCOPE_REGISTRY,
@@ -2959,16 +2960,43 @@ class TestReinviteUser:
         assert response.status_code == HTTP_400_BAD_REQUEST
         assert response.json()["detail"] == "User does not have a pending invitation."
 
-    def test_reinvite_user_without_invite_record(
+    def test_reinvite_disabled_user_without_pending_invite_reason(
         self, db, api_client, generate_auth_header
     ):
-        """Test reinviting a disabled user without FidesUserInvite record returns 400"""
+        """A disabled user whose disabled_reason is not pending_invite must be rejected."""
         user = FidesUser.create(
             db=db,
             data={
-                "username": "disabled_no_invite",
+                "username": "disabled_no_reason",
                 "email_address": "disabled@example.com",
                 "disabled": True,
+            },
+        )
+        FidesUserPermissions.create(
+            db=db,
+            data={"user_id": user.id, "roles": [VIEWER]},
+        )
+
+        url = V1_URL_PREFIX + f"/user/{user.id}/reinvite"
+        auth_header = generate_auth_header(scopes=[USER_CREATE])
+
+        response = api_client.post(url, headers=auth_header)
+        assert response.status_code == HTTP_400_BAD_REQUEST
+        assert response.json()["detail"] == "User does not have a pending invitation."
+
+        user.delete(db)
+
+    def test_reinvite_user_without_invite_record(
+        self, db, api_client, generate_auth_header
+    ):
+        """A user flagged as pending_invite but missing a FidesUserInvite row must be rejected."""
+        user = FidesUser.create(
+            db=db,
+            data={
+                "username": "pending_no_invite",
+                "email_address": "pending@example.com",
+                "disabled": True,
+                "disabled_reason": DisabledReason.pending_invite,
             },
         )
         FidesUserPermissions.create(

--- a/tests/ops/api/v1/endpoints/test_user_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_user_endpoints.py
@@ -2866,6 +2866,7 @@ class TestReinviteUser:
                 "username": "invited_user",
                 "email_address": "invited@example.com",
                 "disabled": True,
+                "disabled_reason": DisabledReason.pending_invite,
             },
         )
         FidesUserPermissions.create(


### PR DESCRIPTION
Ticket [ENG-3261] <!-- simply paste the ticket number between the brackets and it will auto-convert to a link -->

### Description Of Changes

Follow-up cleanup from #6904 (Re-invite Expired Users). The reinvite endpoint's two-check validation let a disabled user with `disabled_reason=None` fall through to the service layer, and the reinvite confirmation modal rendered an empty email when `user.email_address` was null. Both paths are now closed.

### Code Changes

* Collapsed the two guards in `reinvite_user` (`user_endpoints.py`) into `if not user.disabled or user.disabled_reason != DisabledReason.pending_invite`, closing the `disabled_reason=None` gap.
* Guarded the email sentence in `ReinviteSection`'s confirmation modal (`EditUserForm.tsx`) so it only renders when `user.email_address` is truthy.
* Renamed `test_reinvite_user_without_invite_record` to `test_reinvite_disabled_user_without_pending_invite_reason` to reflect what the new endpoint guard rejects.
* Added a new `test_reinvite_user_without_invite_record` covering a user with `disabled_reason=pending_invite` but no `FidesUserInvite` row, preserving service-layer rejection coverage.

### Steps to Confirm

1. Run `pytest tests/ops/api/v1/endpoints/test_user_endpoints.py::TestReinviteUser` — all reinvite tests pass.
2. Create an invited user, then set their `disabled_reason` to NULL directly in the DB. `POST /api/v1/user/<user_id>/reinvite` returns 400 with `"User does not have a pending invitation."` (previously the request fell through to the service layer).
3. For the same user, set `email_address` to NULL in the DB, open their edit page in the admin UI, and click "Reinvite user". The confirmation modal asks only "Are you sure you want to send a new invitation to <username>?" with no trailing "…will be sent to ." sentence.
4. Restore the email; the modal now includes "A new invitation email will be sent to <email>."

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-3261]: https://ethyca.atlassian.net/browse/ENG-3261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ