### PR TITLE
ENG-3176: Migrate consent settings forms to Ant Design

### DIFF
--- a/changelog/7967-consent-settings-forms-ant.yaml
+++ b/changelog/7967-consent-settings-forms-ant.yaml
@@ -1,0 +1,4 @@
+type: Changed
+description: Migrated consent settings forms from Formik/Chakra to Ant Design
+pr: 7967
+labels: []

--- a/clients/admin-ui/cypress/e2e/consent-settings.cy.ts
+++ b/clients/admin-ui/cypress/e2e/consent-settings.cy.ts
@@ -51,7 +51,7 @@ describe("Consent settings", () => {
       cy.visit(GLOBAL_CONSENT_CONFIG_ROUTE);
       cy.getByTestId("consent-configuration");
       cy.getByTestId("setting-Global Privacy Platform").within(() => {
-        cy.get("p").contains("GPP status Enabled");
+        cy.contains("GPP status Enabled").should("exist");
         cy.getByTestId("option-national").should("not.have.attr", "checked");
         cy.getByTestId("option-state").should("have.attr", "checked");
         cy.getByTestId("input-gpp.mspa_covered_transactions").should(
@@ -78,7 +78,7 @@ describe("Consent settings", () => {
       cy.intercept("/api/v1/config?api_set=true", { body: API_CONFIG });
       cy.visit(GLOBAL_CONSENT_CONFIG_ROUTE);
       cy.getByTestId("setting-Global Privacy Platform").within(() => {
-        cy.get("p").contains("GPP status Enabled");
+        cy.contains("GPP status Enabled").should("exist");
         cy.getByTestId("option-national").should("have.attr", "checked");
         cy.getByTestId("option-state").should("not.have.attr", "checked");
         cy.getByTestId("input-gpp.mspa_covered_transactions").should(
@@ -376,7 +376,7 @@ describe("Consent settings", () => {
           "Restrict all vendors",
           { force: true },
         );
-        cy.getByTestId("controlled-select-vendor_ids").should("not.be.visible");
+        cy.getByTestId("controlled-select-vendor_ids").should("not.exist");
         cy.getByTestId("save-restriction-button").click();
         cy.wait("@createRestriction");
         cy.contains("Restriction created successfully").should("be.visible");
@@ -412,7 +412,9 @@ describe("Consent settings", () => {
         // a more comprehensive test of the validation exists in the unit tests, this is just a check of the UI for the error message
         cy.get("input[id='vendor_ids']").type("invalid format{enter}");
         cy.get("input[id='vendor_ids']").blur();
-        cy.getByTestId("error-vendor_ids").should("be.visible");
+        cy.contains("Vendor IDs must be numbers or ranges").should(
+          "be.visible",
+        );
       });
 
       it("displays purpose restrictions table correctly", () => {

--- a/clients/admin-ui/src/features/common/form/useFormFieldsFromSchema.ts
+++ b/clients/admin-ui/src/features/common/form/useFormFieldsFromSchema.ts
@@ -15,16 +15,21 @@ export const useFormFieldsFromSchema = (
     value: string | undefined,
     type?: string,
   ) => {
+    let error;
+    if (typeof value === "undefined" || value === "" || value === undefined) {
+      error = `${label} is required`;
+    }
     if (type === FIDES_DATASET_REFERENCE) {
       if (!value?.includes(".")) {
-        return "Dataset reference must be dot delimited";
-      }
-      const parts = value.split(".");
-      if (parts.length < 3) {
-        return "Dataset reference must include at least three parts";
+        error = "Dataset reference must be dot delimited";
+      } else {
+        const parts = value.split(".");
+        if (parts.length < 3) {
+          error = "Dataset reference must include at least three parts";
+        }
       }
     }
-    return undefined;
+    return error;
   };
 
   const isRequiredField = (key: string): boolean =>

--- a/clients/admin-ui/src/features/common/form/useFormFieldsFromSchema.ts
+++ b/clients/admin-ui/src/features/common/form/useFormFieldsFromSchema.ts
@@ -15,21 +15,16 @@ export const useFormFieldsFromSchema = (
     value: string | undefined,
     type?: string,
   ) => {
-    let error;
-    if (typeof value === "undefined" || value === "" || value === undefined) {
-      error = `${label} is required`;
-    }
     if (type === FIDES_DATASET_REFERENCE) {
       if (!value?.includes(".")) {
-        error = "Dataset reference must be dot delimited";
-      } else {
-        const parts = value.split(".");
-        if (parts.length < 3) {
-          error = "Dataset reference must include at least three parts";
-        }
+        return "Dataset reference must be dot delimited";
+      }
+      const parts = value.split(".");
+      if (parts.length < 3) {
+        return "Dataset reference must include at least three parts";
       }
     }
-    return error;
+    return undefined;
   };
 
   const isRequiredField = (key: string): boolean =>

--- a/clients/admin-ui/src/features/consent-settings/DeprecatedPurposeOverrides.tsx
+++ b/clients/admin-ui/src/features/consent-settings/DeprecatedPurposeOverrides.tsx
@@ -1,9 +1,7 @@
-import { ColumnsType, Table } from "fidesui";
-import { FieldArray, useFormikContext } from "formik";
+import { ColumnsType, Form, Switch, Table } from "fidesui";
 import { useMemo } from "react";
 
 import { useAppSelector } from "~/app/hooks";
-import { CustomSwitch } from "~/features/common/form/inputs";
 import { selectPurposes } from "~/features/common/purpose.slice";
 
 type FormPurposeOverride = {
@@ -23,18 +21,23 @@ const HIDDEN_PURPOSES = [1, 3, 4, 5, 6];
  * @deprecated
  */
 const DeprecatedPurposeOverrides = () => {
-  const { values, setFieldValue } = useFormikContext<{
+  const form = Form.useFormInstance<{
     purposeOverrides: FormPurposeOverride[];
   }>();
+  const watchedOverrides = Form.useWatch("purposeOverrides", form);
+  const purposeOverrides: FormPurposeOverride[] = useMemo(
+    () => watchedOverrides ?? [],
+    [watchedOverrides],
+  );
   const { purposes: purposeMapping } = useAppSelector(selectPurposes);
 
   const dataSourceWithIndex: FormPurposeOverrideWithIndex[] = useMemo(
     () =>
-      values.purposeOverrides.map((override, index) => ({
+      purposeOverrides.map((override, index) => ({
         ...override,
         index,
       })),
-    [values.purposeOverrides],
+    [purposeOverrides],
   );
 
   const columns: ColumnsType<FormPurposeOverrideWithIndex> = useMemo(
@@ -54,20 +57,22 @@ const DeprecatedPurposeOverrides = () => {
         width: 100,
         align: "center",
         render: (_, record) => (
-          <CustomSwitch
-            name={`purposeOverrides[${record.index}].is_included`}
+          <Switch
+            size="small"
+            checked={record.is_included}
             onChange={(checked) => {
-              if (!checked) {
-                setFieldValue(
-                  `purposeOverrides[${record.index}].is_consent`,
-                  false,
-                );
-                setFieldValue(
-                  `purposeOverrides[${record.index}].is_legitimate_interest`,
-                  false,
-                );
-              }
+              const updated = [...purposeOverrides];
+              updated[record.index] = {
+                ...updated[record.index],
+                is_included: checked,
+                ...(checked
+                  ? {}
+                  : { is_consent: false, is_legitimate_interest: false }),
+              };
+              form.setFieldValue("purposeOverrides", updated);
             }}
+            data-testid={`input-purposeOverrides[${record.index}].is_included`}
+            className="mr-2"
           />
         ),
       },
@@ -81,12 +86,23 @@ const DeprecatedPurposeOverrides = () => {
             return null;
           }
           return (
-            <CustomSwitch
-              isDisabled={
-                !values.purposeOverrides[record.index].is_included ||
-                values.purposeOverrides[record.index].is_legitimate_interest
+            <Switch
+              size="small"
+              checked={record.is_consent}
+              disabled={
+                !purposeOverrides[record.index]?.is_included ||
+                purposeOverrides[record.index]?.is_legitimate_interest
               }
-              name={`purposeOverrides[${record.index}].is_consent`}
+              onChange={(checked) => {
+                const updated = [...purposeOverrides];
+                updated[record.index] = {
+                  ...updated[record.index],
+                  is_consent: checked,
+                };
+                form.setFieldValue("purposeOverrides", updated);
+              }}
+              data-testid={`input-purposeOverrides[${record.index}].is_consent`}
+              className="mr-2"
             />
           );
         },
@@ -101,34 +117,40 @@ const DeprecatedPurposeOverrides = () => {
             return null;
           }
           return (
-            <CustomSwitch
-              isDisabled={
-                !values.purposeOverrides[record.index].is_included ||
-                values.purposeOverrides[record.index].is_consent
+            <Switch
+              size="small"
+              checked={record.is_legitimate_interest}
+              disabled={
+                !purposeOverrides[record.index]?.is_included ||
+                purposeOverrides[record.index]?.is_consent
               }
-              name={`purposeOverrides[${record.index}].is_legitimate_interest`}
+              onChange={(checked) => {
+                const updated = [...purposeOverrides];
+                updated[record.index] = {
+                  ...updated[record.index],
+                  is_legitimate_interest: checked,
+                };
+                form.setFieldValue("purposeOverrides", updated);
+              }}
+              data-testid={`input-purposeOverrides[${record.index}].is_legitimate_interest`}
+              className="mr-2"
             />
           );
         },
       },
     ],
-    [purposeMapping, values.purposeOverrides, setFieldValue],
+    [purposeMapping, purposeOverrides, form],
   );
 
   return (
-    <FieldArray
-      name="purposeOverrides"
-      render={() => (
-        <Table
-          dataSource={dataSourceWithIndex}
-          columns={columns}
-          rowKey="purpose"
-          pagination={false}
-          size="small"
-          bordered
-          data-testid="deprecated-purpose-overrides-table"
-        />
-      )}
+    <Table
+      dataSource={dataSourceWithIndex}
+      columns={columns}
+      rowKey="purpose"
+      pagination={false}
+      size="small"
+      bordered
+      data-testid="deprecated-purpose-overrides-table"
     />
   );
 };

--- a/clients/admin-ui/src/features/consent-settings/FrameworkStatus.tsx
+++ b/clients/admin-ui/src/features/consent-settings/FrameworkStatus.tsx
@@ -1,4 +1,4 @@
-import { ChakraStack as Stack, ChakraText as Text, Tag } from "fidesui";
+import { Flex, Tag } from "fidesui";
 
 import DocsLink from "~/features/common/DocsLink";
 
@@ -9,27 +9,21 @@ const FrameworkStatus = ({
   name: string;
   enabled: boolean;
 }) => (
-  <Stack
-    spacing={2}
-    fontSize="sm"
-    lineHeight="5"
-    fontWeight="medium"
-    color="gray.700"
-  >
-    <Text>
+  <Flex vertical gap="small" className="text-sm font-medium">
+    <span>
       {name} status{" "}
       {enabled ? (
         <Tag color="success">Enabled</Tag>
       ) : (
         <Tag color="error">Disabled</Tag>
       )}
-    </Text>
-    <Text>
+    </span>
+    <span>
       To {enabled ? "disable" : "enable"} {name}, please contact your Fides
       administrator or{" "}
       <DocsLink href="mailto:support@ethyca.com">Ethyca support</DocsLink>.
-    </Text>
-  </Stack>
+    </span>
+  </Flex>
 );
 
 export default FrameworkStatus;

--- a/clients/admin-ui/src/features/consent-settings/GppConfiguration.tsx
+++ b/clients/admin-ui/src/features/consent-settings/GppConfiguration.tsx
@@ -1,53 +1,21 @@
 import {
-  ChakraDivider as Divider,
-  ChakraStack as Stack,
-  ChakraText as Text,
   Checkbox,
+  Divider,
+  Flex,
   Form,
+  Radio,
+  Switch,
+  Typography,
 } from "fidesui";
-import { useField, useFormikContext } from "formik";
 import { ReactNode } from "react";
 
 import { useAppSelector } from "~/app/hooks";
 import { useFeatures } from "~/features/common/features";
-import ControlledRadioGroup from "~/features/common/form/ControlledRadioGroup";
-import { CustomSwitch } from "~/features/common/form/inputs";
 import { selectGppSettings } from "~/features/config-settings/config-settings.slice";
 import { GPPUSApproach, PrivacyExperienceGPPSettings } from "~/types/api";
 
 import FrameworkStatus from "./FrameworkStatus";
 import SettingsBox from "./SettingsBox";
-
-const CheckboxField = ({
-  name,
-  label,
-  tooltip,
-  onChange,
-}: {
-  name: string;
-  label: string;
-  tooltip?: string;
-  onChange?: (checked: boolean) => void;
-}) => {
-  const [field] = useField({ name, type: "checkbox" });
-
-  return (
-    <Form.Item tooltip={tooltip}>
-      <Checkbox
-        name={field.name}
-        checked={field.checked}
-        onChange={(e) => {
-          field.onChange(e);
-          onChange?.(e.target.checked);
-        }}
-        onBlur={field.onBlur}
-        data-testid={`input-${field.name}`}
-      >
-        {label}
-      </Checkbox>
-    </Form.Item>
-  );
-};
 
 const Section = ({
   title,
@@ -56,113 +24,173 @@ const Section = ({
   title: string;
   children: ReactNode;
 }) => (
-  <Stack spacing={3} mb={3} data-testid={`section-${title}`}>
-    <Text fontSize="sm" fontWeight="bold" lineHeight={5} color="gray.700">
+  <Flex vertical gap="middle" className="mb-3" data-testid={`section-${title}`}>
+    <Typography.Text strong className="text-sm">
       {title}
-    </Text>
+    </Typography.Text>
     {children}
-  </Stack>
+  </Flex>
 );
 
 const GppConfiguration = () => {
   const { tcf: isTcfEnabled } = useFeatures();
   const gppSettings = useAppSelector(selectGppSettings);
   const isEnabled = !!gppSettings.enabled;
-  const { values, setFieldValue } = useFormikContext<{
+  const form = Form.useFormInstance<{
     gpp: PrivacyExperienceGPPSettings;
   }>();
-  const showMspa = !!values.gpp.us_approach;
+  const gppValues = Form.useWatch("gpp", form);
+  const showMspa = !!gppValues?.us_approach;
 
   return (
     <SettingsBox title="Global Privacy Platform">
-      <Stack spacing={6}>
+      <Flex vertical gap="large">
         <FrameworkStatus name="GPP" enabled={isEnabled} />
         {isEnabled ? (
           <>
             <Section title="GPP U.S.">
-              <ControlledRadioGroup
-                name="gpp.us_approach"
-                layout="stacked"
-                defaultFirstSelected={false}
-                options={[
-                  {
-                    label: "Enable U.S. National",
-                    value: GPPUSApproach.NATIONAL,
-                    tooltip:
-                      "When US National is selected, Fides will present the same privacy notices to all consumers located anywhere in the United States.",
-                  },
-                  {
-                    label: "Enable U.S. State-by-State",
-                    value: GPPUSApproach.STATE,
-                    tooltip:
-                      "When state-by-state is selected, Fides will only present consent to consumers and save their preferences if they are located in a state that is supported by the GPP. The consent options presented to consumers will vary depending on the regulations in each state.",
-                  },
-                  {
-                    label: "Enable US National and State-by-State notices",
-                    value: GPPUSApproach.ALL,
-                    tooltip:
-                      "When enabled, Fides can be configured to serve the National and U.S. state notices. This mode is intended to provide consent coverage to U.S. states with new privacy laws where GPP support lags behind the effective date of state laws.",
-                  },
-                ]}
-              />
+              <Form.Item name={["gpp", "us_approach"]} noStyle>
+                <Radio.Group data-testid="input-gpp.us_approach">
+                  <Flex vertical gap="middle">
+                    <Radio
+                      value={GPPUSApproach.NATIONAL}
+                      data-testid={`option-${GPPUSApproach.NATIONAL}`}
+                    >
+                      <Flex align="center" gap="small">
+                        <Typography.Text className="text-sm font-medium">
+                          Enable U.S. National
+                        </Typography.Text>
+                        <Form.Item
+                          tooltip="When US National is selected, Fides will present the same privacy notices to all consumers located anywhere in the United States."
+                          noStyle
+                        >
+                          <span />
+                        </Form.Item>
+                      </Flex>
+                    </Radio>
+                    <Radio
+                      value={GPPUSApproach.STATE}
+                      data-testid={`option-${GPPUSApproach.STATE}`}
+                    >
+                      <Flex align="center" gap="small">
+                        <Typography.Text className="text-sm font-medium">
+                          Enable U.S. State-by-State
+                        </Typography.Text>
+                        <Form.Item
+                          tooltip="When state-by-state is selected, Fides will only present consent to consumers and save their preferences if they are located in a state that is supported by the GPP. The consent options presented to consumers will vary depending on the regulations in each state."
+                          noStyle
+                        >
+                          <span />
+                        </Form.Item>
+                      </Flex>
+                    </Radio>
+                    <Radio
+                      value={GPPUSApproach.ALL}
+                      data-testid={`option-${GPPUSApproach.ALL}`}
+                    >
+                      <Flex align="center" gap="small">
+                        <Typography.Text className="text-sm font-medium">
+                          Enable US National and State-by-State notices
+                        </Typography.Text>
+                        <Form.Item
+                          tooltip="When enabled, Fides can be configured to serve the National and U.S. state notices. This mode is intended to provide consent coverage to U.S. states with new privacy laws where GPP support lags behind the effective date of state laws."
+                          noStyle
+                        >
+                          <span />
+                        </Form.Item>
+                      </Flex>
+                    </Radio>
+                  </Flex>
+                </Radio.Group>
+              </Form.Item>
             </Section>
             {showMspa ? (
               <Section title="MSPA">
-                {/* Remove this font style when upgrading to an ant form */}
-                <div className="font-medium">
-                  <CheckboxField
-                    name="gpp.mspa_covered_transactions"
-                    label="All transactions covered by MSPA"
-                    tooltip="When selected, the Fides CMP will communicate to downstream vendors that all preferences are covered under the MSPA."
-                    onChange={(checked) => {
-                      if (!checked) {
-                        setFieldValue("gpp.mspa_service_provider_mode", false);
-                        setFieldValue("gpp.mspa_opt_out_option_mode", false);
+                <Form.Item
+                  name={["gpp", "mspa_covered_transactions"]}
+                  valuePropName="checked"
+                  tooltip="When selected, the Fides CMP will communicate to downstream vendors that all preferences are covered under the MSPA."
+                >
+                  <Checkbox
+                    data-testid="input-gpp.mspa_covered_transactions"
+                    onChange={(e) => {
+                      if (!e.target.checked) {
+                        form.setFieldValue(
+                          ["gpp", "mspa_service_provider_mode"],
+                          false,
+                        );
+                        form.setFieldValue(
+                          ["gpp", "mspa_opt_out_option_mode"],
+                          false,
+                        );
                       }
                     }}
-                  />
-                </div>
-                <CustomSwitch
+                  >
+                    All transactions covered by MSPA
+                  </Checkbox>
+                </Form.Item>
+                <Form.Item
+                  name={["gpp", "mspa_service_provider_mode"]}
                   label="Enable MSPA service provider mode"
-                  name="gpp.mspa_service_provider_mode"
-                  variant="switchFirst"
                   tooltip="Enable service provider mode if you do not engage in any sales or sharing of personal information."
-                  isDisabled={
-                    !!values.gpp.mspa_opt_out_option_mode ||
-                    !values.gpp.mspa_covered_transactions
-                  }
-                />
-                <CustomSwitch
+                  layout="horizontal"
+                  colon={false}
+                  valuePropName="checked"
+                >
+                  <Switch
+                    size="small"
+                    disabled={
+                      !!gppValues?.mspa_opt_out_option_mode ||
+                      !gppValues?.mspa_covered_transactions
+                    }
+                    data-testid="input-gpp.mspa_service_provider_mode"
+                  />
+                </Form.Item>
+                <Form.Item
+                  name={["gpp", "mspa_opt_out_option_mode"]}
                   label="Enable MSPA opt-out option mode"
-                  name="gpp.mspa_opt_out_option_mode"
-                  variant="switchFirst"
                   tooltip="Enable opt-out option mode if you engage or may engage in the sales or sharing of personal information, or process any information for the purpose of targeted advertising."
-                  isDisabled={
-                    !!values.gpp.mspa_service_provider_mode ||
-                    !values.gpp.mspa_covered_transactions
-                  }
-                />
+                  layout="horizontal"
+                  colon={false}
+                  valuePropName="checked"
+                >
+                  <Switch
+                    size="small"
+                    disabled={
+                      !!gppValues?.mspa_service_provider_mode ||
+                      !gppValues?.mspa_covered_transactions
+                    }
+                    data-testid="input-gpp.mspa_opt_out_option_mode"
+                  />
+                </Form.Item>
               </Section>
             ) : null}
           </>
         ) : null}
         {isTcfEnabled ? (
           <>
-            <Divider color="gray.200" />
+            <Divider className="my-0" />
             <Section title="GPP Europe">
-              <Text fontSize="sm" fontWeight="medium">
+              <Typography.Text className="text-sm font-medium">
                 Configure TCF string for Global Privacy Platform
-              </Text>
-              <CustomSwitch
+              </Typography.Text>
+              <Form.Item
+                name={["gpp", "enable_tcfeu_string"]}
                 label="Enable TC string"
-                name="gpp.enable_tcfeu_string"
-                variant="switchFirst"
                 tooltip="When enabled, the GPP API will include a TCF EU consent string for users who are in regions where TCF applies."
-              />
+                layout="horizontal"
+                colon={false}
+                valuePropName="checked"
+              >
+                <Switch
+                  size="small"
+                  data-testid="input-gpp.enable_tcfeu_string"
+                />
+              </Form.Item>
             </Section>
           </>
         ) : null}
-      </Stack>
+      </Flex>
     </SettingsBox>
   );
 };

--- a/clients/admin-ui/src/features/consent-settings/PublisherSettings.tsx
+++ b/clients/admin-ui/src/features/consent-settings/PublisherSettings.tsx
@@ -1,5 +1,4 @@
 import { Form, isoCodesToOptions, LocationSelect, Typography } from "fidesui";
-import { useFormikContext } from "formik";
 
 import { useFeatures } from "~/features/common/features";
 import { useGetOnlyCountryLocationsQuery } from "~/features/locations/locations.slice";
@@ -13,9 +12,10 @@ export type TCFPublisherSettings = {
 
 const PublisherSettings = () => {
   const { tcf: isTcfEnabled } = useFeatures();
-  const { values, setFieldValue } = useFormikContext<{
+  const form = Form.useFormInstance<{
     tcfPublisherSettings: TCFPublisherSettings;
   }>();
+  const publisherSettings = Form.useWatch("tcfPublisherSettings", form);
   const { data: locationRegulationResponse, isLoading: locationsLoading } =
     useGetOnlyCountryLocationsQuery();
 
@@ -41,12 +41,12 @@ const PublisherSettings = () => {
             allSelectedCountries?.map((location) => location.id),
           )}
           placeholder="Select a country"
-          value={values.tcfPublisherSettings.publisher_country_code
+          value={publisherSettings?.publisher_country_code
             ?.replace("_", "-")
             .toUpperCase()}
           onChange={(value) =>
-            setFieldValue(
-              "tcfPublisherSettings.publisher_country_code",
+            form.setFieldValue(
+              ["tcfPublisherSettings", "publisher_country_code"],
               value?.toLowerCase(),
             )
           }

--- a/clients/admin-ui/src/features/consent-settings/SettingsBox.tsx
+++ b/clients/admin-ui/src/features/consent-settings/SettingsBox.tsx
@@ -1,34 +1,14 @@
-import {
-  ChakraBox as Box,
-  ChakraBoxProps as BoxProps,
-  ChakraText as Text,
-} from "fidesui";
+import { Card, CardProps } from "fidesui";
 import { ReactNode } from "react";
 
 const SettingsBox = ({
   title,
   children,
   ...props
-}: { title: string; children: ReactNode } & BoxProps) => (
-  <Box
-    backgroundColor="var(--fidesui-bg-corinth)"
-    borderRadius="4px"
-    padding="3"
-    data-testid={`setting-${title}`}
-    {...props}
-  >
-    <Text
-      as="h3"
-      fontSize="md"
-      fontWeight="bold"
-      lineHeight={5}
-      color="gray.700"
-      mb={3}
-    >
-      {title}
-    </Text>
+}: { title: string; children: ReactNode } & CardProps) => (
+  <Card title={title} data-testid={`setting-${title}`} {...props}>
     {children}
-  </Box>
+  </Card>
 );
 
 export default SettingsBox;

--- a/clients/admin-ui/src/features/consent-settings/tcf/CreateTCFConfigModal.tsx
+++ b/clients/admin-ui/src/features/consent-settings/tcf/CreateTCFConfigModal.tsx
@@ -1,8 +1,15 @@
-import { Button, ChakraText as Text, Modal, Space, useMessage } from "fidesui";
-import { Form, Formik } from "formik";
-import * as Yup from "yup";
+import {
+  Button,
+  Form,
+  Input,
+  Modal,
+  Space,
+  Typography,
+  useMessage,
+} from "fidesui";
+import isEqual from "lodash/isEqual";
+import { useEffect, useMemo, useState } from "react";
 
-import { CustomTextInput } from "~/features/common/form/inputs";
 import { useCreateTCFConfigurationMutation } from "~/features/consent-settings/tcf/tcf-config.slice";
 import { isErrorResult } from "~/types/errors";
 
@@ -14,9 +21,7 @@ interface CreateTCFConfigModalProps {
   onSuccess?: (configId: string) => void;
 }
 
-const ValidationSchema = Yup.object().shape({
-  name: Yup.string().required().label("Name"),
-});
+const defaultInitialValues = { name: "" };
 
 export const CreateTCFConfigModal = ({
   isOpen,
@@ -25,6 +30,22 @@ export const CreateTCFConfigModal = ({
 }: CreateTCFConfigModalProps) => {
   const message = useMessage();
   const [createTCFConfiguration] = useCreateTCFConfigurationMutation();
+  const [form] = Form.useForm<{ name: string }>();
+
+  const allValues = Form.useWatch([], form);
+  const [submittable, setSubmittable] = useState(false);
+
+  useEffect(() => {
+    form
+      .validateFields({ validateOnly: true })
+      .then(() => setSubmittable(true))
+      .catch(() => setSubmittable(false));
+  }, [form, allValues]);
+
+  const isDirty = useMemo(
+    () => !isEqual(allValues, defaultInitialValues),
+    [allValues],
+  );
 
   const handleSubmit = async (values: { name: string }) => {
     const result = await createTCFConfiguration({ name: values.name });
@@ -46,41 +67,38 @@ export const CreateTCFConfigModal = ({
       destroyOnHidden
       footer={null}
     >
-      <Formik
-        initialValues={{ name: "" }}
-        onSubmit={handleSubmit}
-        validationSchema={ValidationSchema}
+      <Form
+        form={form}
+        layout="vertical"
+        onFinish={handleSubmit}
+        initialValues={defaultInitialValues}
       >
-        {({ isValid, dirty }) => (
-          <Form>
-            <Space orientation="vertical" size="small" className="w-full">
-              <Text>
-                TCF configurations allow you to define unique sets of publisher
-                restrictions. These configurations can be added to privacy
-                experiences.
-              </Text>
-              <CustomTextInput
-                id="name"
-                name="name"
-                label="Name"
-                isRequired
-                variant="stacked"
-              />
-              <Space className="w-full justify-end pt-6">
-                <Button onClick={onClose}>Cancel</Button>
-                <Button
-                  type="primary"
-                  htmlType="submit"
-                  disabled={!isValid || !dirty}
-                  data-testid="save-config-button"
-                >
-                  Save
-                </Button>
-              </Space>
-            </Space>
-          </Form>
-        )}
-      </Formik>
+        <Space orientation="vertical" size="small" className="w-full">
+          <Typography.Text>
+            TCF configurations allow you to define unique sets of publisher
+            restrictions. These configurations can be added to privacy
+            experiences.
+          </Typography.Text>
+          <Form.Item
+            name="name"
+            label="Name"
+            rules={[{ required: true, message: "Name is required" }]}
+          >
+            <Input data-testid="input-name" />
+          </Form.Item>
+          <Space className="w-full justify-end pt-6">
+            <Button onClick={onClose}>Cancel</Button>
+            <Button
+              type="primary"
+              htmlType="submit"
+              disabled={!submittable || !isDirty}
+              data-testid="save-config-button"
+            >
+              Save
+            </Button>
+          </Space>
+        </Space>
+      </Form>
     </Modal>
   );
 };

--- a/clients/admin-ui/src/features/consent-settings/tcf/PublisherRestrictionsConfig.tsx
+++ b/clients/admin-ui/src/features/consent-settings/tcf/PublisherRestrictionsConfig.tsx
@@ -1,9 +1,4 @@
-import {
-  Button,
-  ChakraSkeleton as Skeleton,
-  ChakraText as Text,
-  Space,
-} from "fidesui";
+import { Button, Skeleton, Space } from "fidesui";
 import { useEffect, useState } from "react";
 
 import {
@@ -68,7 +63,7 @@ export const PublisherRestrictionsConfig = ({
   ]);
 
   return (
-    <SettingsBox title="Publisher restrictions" fontSize="sm">
+    <SettingsBox title="Publisher restrictions">
       <Space orientation="vertical" size="small" style={{ width: "100%" }}>
         <TCFOverrideToggle
           defaultChecked={showTcfOverrideConfig}
@@ -78,26 +73,26 @@ export const PublisherRestrictionsConfig = ({
           <>
             {isTcfConfigurationsLoading && (
               <>
-                <Skeleton height="20px" />
-                <Skeleton height="20px" />
-                <Skeleton height="32px" width="200px" />
+                <Skeleton.Input active block />
+                <Skeleton.Input active block />
+                <Skeleton.Input active style={{ width: 200 }} />
               </>
             )}
             {!isTcfConfigurationsLoading && tcfConfigurations?.items?.length ? (
               <>
-                <Text>
+                <p>
                   The table below allows you to adjust which TCF purposes you
                   allow as part of your user facing notices and business
                   activities.
-                </Text>
-                <Text>
+                </p>
+                <p>
                   To configure this section, select a TCF purpose to edit the
                   restriction type and vendors.{" "}
                   <DocsLink href={PUBLISHER_RESTRICTIONS_DOCS_URL}>
                     Learn more about publisher restrictions
                   </DocsLink>{" "}
                   in our docs.
-                </Text>
+                </p>
                 <TCFConfigurationDropdown
                   selectedConfigId={selectedTCFConfigId || ""}
                   configurations={tcfConfigurations?.items || []}
@@ -106,14 +101,14 @@ export const PublisherRestrictionsConfig = ({
               </>
             ) : (
               <>
-                <Text>
+                <p>
                   To define custom publisher restrictions select &quot;create
                   configuration&quot; below.{" "}
                   <DocsLink href={PUBLISHER_RESTRICTIONS_DOCS_URL}>
                     Learn more about publisher restrictions
                   </DocsLink>{" "}
                   in our docs.
-                </Text>
+                </p>
                 <Button
                   onClick={() => setIsCreateModalOpen(true)}
                   data-testid="create-config-button"

--- a/clients/admin-ui/src/features/consent-settings/tcf/PublisherRestrictionsConfig.tsx
+++ b/clients/admin-ui/src/features/consent-settings/tcf/PublisherRestrictionsConfig.tsx
@@ -101,14 +101,14 @@ export const PublisherRestrictionsConfig = ({
               </>
             ) : (
               <>
-                <p>
+                <Typography.Paragraph>
                   To define custom publisher restrictions select &quot;create
                   configuration&quot; below.{" "}
                   <DocsLink href={PUBLISHER_RESTRICTIONS_DOCS_URL}>
                     Learn more about publisher restrictions
                   </DocsLink>{" "}
                   in our docs.
-                </p>
+                </Typography.Paragraph>
                 <Button
                   onClick={() => setIsCreateModalOpen(true)}
                   data-testid="create-config-button"

--- a/clients/admin-ui/src/features/consent-settings/tcf/PublisherRestrictionsConfig.tsx
+++ b/clients/admin-ui/src/features/consent-settings/tcf/PublisherRestrictionsConfig.tsx
@@ -1,4 +1,4 @@
-import { Button, Skeleton, Space } from "fidesui";
+import { Button, Skeleton, Space, Typography } from "fidesui";
 import { useEffect, useState } from "react";
 
 import {
@@ -80,19 +80,19 @@ export const PublisherRestrictionsConfig = ({
             )}
             {!isTcfConfigurationsLoading && tcfConfigurations?.items?.length ? (
               <>
-                <p>
+                <Typography.Paragraph>
                   The table below allows you to adjust which TCF purposes you
                   allow as part of your user facing notices and business
                   activities.
-                </p>
-                <p>
+                </Typography.Paragraph>
+                <Typography.Paragraph>
                   To configure this section, select a TCF purpose to edit the
                   restriction type and vendors.{" "}
                   <DocsLink href={PUBLISHER_RESTRICTIONS_DOCS_URL}>
                     Learn more about publisher restrictions
                   </DocsLink>{" "}
                   in our docs.
-                </p>
+                </Typography.Paragraph>
                 <TCFConfigurationDropdown
                   selectedConfigId={selectedTCFConfigId || ""}
                   configurations={tcfConfigurations?.items || []}

--- a/clients/admin-ui/src/features/consent-settings/tcf/PurposeRestrictionFormModal.tsx
+++ b/clients/admin-ui/src/features/consent-settings/tcf/PurposeRestrictionFormModal.tsx
@@ -245,27 +245,27 @@ export const PurposeRestrictionFormModal = ({
         initialValues={computedInitialValues}
         key={restrictionId ?? "create"}
       >
-        <Flex vertical className="gap-6">
-          <Typography.Text className="text-sm">
+        <Flex vertical>
+          <Typography.Text>
             Define how specific vendors are restricted from processing data for
             this purpose. Select a restriction type, set whether the listed
             vendors are restricted or allowed, and specify which vendor IDs the
             restriction applies to.
           </Typography.Text>
-          <Tooltip
-            title={
-              !isPurposeFlexible
-                ? "Non-flexible purposes only support Purpose restrictions and cannot be restricted by consent or legitimate interest settings."
-                : undefined
-            }
+          <Form.Item
+            name="restriction_type"
+            label="Restriction type"
+            tooltip="Choose how vendors are permitted to process data for this purpose. This setting overrides the vendor's declared legal basis in the Global Vendor List."
+            rules={[
+              { required: true, message: "Restriction type is required" },
+            ]}
           >
-            <Form.Item
-              name="restriction_type"
-              label="Restriction type"
-              tooltip="Choose how vendors are permitted to process data for this purpose. This setting overrides the vendor's declared legal basis in the Global Vendor List."
-              rules={[
-                { required: true, message: "Restriction type is required" },
-              ]}
+            <Tooltip
+              title={
+                !isPurposeFlexible
+                  ? "Non-flexible purposes only support Purpose restrictions and cannot be restricted by consent or legitimate interest settings."
+                  : undefined
+              }
             >
               <Select
                 aria-label="Restriction type"
@@ -274,8 +274,8 @@ export const PurposeRestrictionFormModal = ({
                 data-testid="controlled-select-restriction_type"
                 className="w-full"
               />
-            </Form.Item>
-          </Tooltip>
+            </Tooltip>
+          </Form.Item>
           <Form.Item
             name="vendor_restriction"
             label="Vendor restriction"
@@ -348,7 +348,7 @@ export const PurposeRestrictionFormModal = ({
             </Form.Item>
           )}
           <Flex justify="flex-end" className="gap-3 pt-4">
-            <Button onClick={onClose} data-testid="cancel-restriction-button">
+            <Button onClick={handleClose} data-testid="cancel-restriction-button">
               Cancel
             </Button>
             <Button

--- a/clients/admin-ui/src/features/consent-settings/tcf/PurposeRestrictionFormModal.tsx
+++ b/clients/admin-ui/src/features/consent-settings/tcf/PurposeRestrictionFormModal.tsx
@@ -252,20 +252,24 @@ export const PurposeRestrictionFormModal = ({
             vendors are restricted or allowed, and specify which vendor IDs the
             restriction applies to.
           </Typography.Text>
-          <Form.Item
-            name="restriction_type"
-            label="Restriction type"
-            tooltip="Choose how vendors are permitted to process data for this purpose. This setting overrides the vendor's declared legal basis in the Global Vendor List."
-            rules={[
-              { required: true, message: "Restriction type is required" },
-            ]}
+          <Tooltip
+            title={
+              !isPurposeFlexible
+                ? "Non-flexible purposes only support Purpose restrictions and cannot be restricted by consent or legitimate interest settings."
+                : undefined
+            }
           >
-            <Tooltip
-              title={
-                !isPurposeFlexible
-                  ? "Non-flexible purposes only support Purpose restrictions and cannot be restricted by consent or legitimate interest settings."
+            <Form.Item
+              name="restriction_type"
+              label="Restriction type"
+              tooltip={
+                isPurposeFlexible
+                  ? "Choose how vendors are permitted to process data for this purpose. This setting overrides the vendor's declared legal basis in the Global Vendor List."
                   : undefined
               }
+              rules={[
+                { required: true, message: "Restriction type is required" },
+              ]}
             >
               <Select
                 aria-label="Restriction type"
@@ -274,8 +278,8 @@ export const PurposeRestrictionFormModal = ({
                 data-testid="controlled-select-restriction_type"
                 className="w-full"
               />
-            </Tooltip>
-          </Form.Item>
+            </Form.Item>
+          </Tooltip>
           <Form.Item
             name="vendor_restriction"
             label="Vendor restriction"
@@ -348,7 +352,10 @@ export const PurposeRestrictionFormModal = ({
             </Form.Item>
           )}
           <Flex justify="flex-end" className="gap-3 pt-4">
-            <Button onClick={handleClose} data-testid="cancel-restriction-button">
+            <Button
+              onClick={handleClose}
+              data-testid="cancel-restriction-button"
+            >
               Cancel
             </Button>
             <Button

--- a/clients/admin-ui/src/features/consent-settings/tcf/PurposeRestrictionFormModal.tsx
+++ b/clients/admin-ui/src/features/consent-settings/tcf/PurposeRestrictionFormModal.tsx
@@ -171,6 +171,14 @@ export const PurposeRestrictionFormModal = ({
     !!vendorRestriction &&
     vendorRestriction !== TCFVendorRestriction.RESTRICT_ALL_VENDORS;
 
+  // Clear vendor_ids when switching to "restrict all vendors" since the field
+  // unmounts and stale values would otherwise persist in the form store.
+  useEffect(() => {
+    if (vendorRestriction === TCFVendorRestriction.RESTRICT_ALL_VENDORS) {
+      form.setFieldValue("vendor_ids", []);
+    }
+  }, [vendorRestriction, form]);
+
   const handleSubmit = async (values: FormValues): Promise<void> => {
     try {
       const request: Omit<TCFPublisherRestrictionRequest, "purpose_id"> = {

--- a/clients/admin-ui/src/features/consent-settings/tcf/PurposeRestrictionFormModal.tsx
+++ b/clients/admin-ui/src/features/consent-settings/tcf/PurposeRestrictionFormModal.tsx
@@ -1,15 +1,15 @@
 import {
   Button,
-  ChakraCollapse as Collapse,
-  ChakraText as Text,
   Flex,
+  Form,
+  Select,
   Tooltip,
+  Typography,
   useMessage,
 } from "fidesui";
-import { Form, FormikProvider, useFormik } from "formik";
-import * as Yup from "yup";
+import isEqual from "lodash/isEqual";
+import { useEffect, useMemo, useState } from "react";
 
-import { ControlledSelect } from "~/features/common/form/ControlledSelect";
 import { isErrorResult } from "~/features/common/helpers";
 import ConfirmCloseModal from "~/features/common/modals/ConfirmCloseModal";
 import {
@@ -70,9 +70,8 @@ export const PurposeRestrictionFormModal = ({
     purposeId && FORBIDDEN_LEGITIMATE_INTEREST_PURPOSE_IDS.includes(+purposeId)
   );
 
-  // Get the list of restriction types that are already in use for this purpose
   const usedRestrictionTypes = existingRestrictions
-    .filter((r) => r.id !== restrictionId) // Exclude current restriction when editing
+    .filter((r) => r.id !== restrictionId)
     .map((r) => r.restriction_type);
 
   const restrictionTypeOptions = [
@@ -138,41 +137,42 @@ export const PurposeRestrictionFormModal = ({
     },
   ];
 
-  // Create validation schema
-  const validationSchema = Yup.object().shape({
-    restriction_type: Yup.string().required("Restriction type is required"),
-    vendor_restriction: Yup.string().required("Vendor restriction is required"),
-    vendor_ids: Yup.array().when("vendor_restriction", {
-      is: (val: string) => val !== TCFVendorRestriction.RESTRICT_ALL_VENDORS,
-      then: (schema) =>
-        schema
-          .required("At least one vendor ID is required")
-          .min(1, "At least one vendor ID is required")
-          .test(
-            "valid-format",
-            "Vendor IDs must be numbers or ranges (e.g., 10 or 15-300)",
-            (value) => value?.every((id) => isValidVendorIdFormat(id)) ?? true,
-          )
-          .test(
-            "no-conflicts",
-            ERROR_MESSAGE,
-            (value, context) =>
-              !checkForVendorRestrictionConflicts(
-                {
-                  ...context.parent,
-                  vendor_ids: value,
-                } as FormValues,
-                existingRestrictions,
-                purposeId,
-                restrictionId,
-              ),
-          ),
+  const computedInitialValues = useMemo(
+    () => ({
+      ...initialValues,
+      restriction_type: isPurposeFlexible
+        ? initialValues.restriction_type
+        : TCFRestrictionType.PURPOSE_RESTRICTION,
     }),
-  });
+    [initialValues, isPurposeFlexible],
+  );
+
+  const [form] = Form.useForm<FormValues>();
+
+  const allValues = Form.useWatch([], form);
+  const vendorRestriction = Form.useWatch("vendor_restriction", form);
+  const restrictionType = Form.useWatch("restriction_type", form);
+  const [submittable, setSubmittable] = useState(false);
+
+  useEffect(() => {
+    form
+      .validateFields({ validateOnly: true })
+      .then(() => setSubmittable(true))
+      .catch(() => setSubmittable(false));
+  }, [form, allValues]);
+
+  const isDirty = useMemo(
+    () => !isEqual(allValues, computedInitialValues),
+    [allValues, computedInitialValues],
+  );
+
+  const showVendorIds =
+    !!restrictionType &&
+    !!vendorRestriction &&
+    vendorRestriction !== TCFVendorRestriction.RESTRICT_ALL_VENDORS;
 
   const handleSubmit = async (values: FormValues): Promise<void> => {
     try {
-      // Convert form values to API request format
       const request: Omit<TCFPublisherRestrictionRequest, "purpose_id"> = {
         restriction_type: values.restriction_type as TCFRestrictionType,
         vendor_restriction: values.vendor_restriction as TCFVendorRestriction,
@@ -215,119 +215,145 @@ export const PurposeRestrictionFormModal = ({
     }
   };
 
-  const formik = useFormik({
-    initialValues: {
-      ...initialValues,
-      restriction_type: isPurposeFlexible
-        ? initialValues.restriction_type
-        : TCFRestrictionType.PURPOSE_RESTRICTION,
-    },
-    onSubmit: handleSubmit,
-    validationSchema,
-  });
-  const { values, validateField, setTouched } = formik;
+  const handleClose = () => {
+    form.resetFields();
+    onClose();
+  };
 
   return (
-    <FormikProvider value={formik}>
-      <ConfirmCloseModal
-        open={isOpen}
-        onClose={() => {
-          formik.resetForm();
-          onClose();
-        }}
-        getIsDirty={() => formik.dirty}
-        centered
-        destroyOnHidden
-        title="Edit restriction"
-        footer={null}
+    <ConfirmCloseModal
+      open={isOpen}
+      onClose={handleClose}
+      getIsDirty={() => isDirty}
+      centered
+      destroyOnHidden
+      title="Edit restriction"
+      footer={null}
+    >
+      <Form
+        form={form}
+        layout="vertical"
+        onFinish={handleSubmit}
+        initialValues={computedInitialValues}
+        key={restrictionId ?? "create"}
       >
-        <Form>
-          <Flex vertical className="gap-6">
-            <Text className="text-sm">
-              Define how specific vendors are restricted from processing data
-              for this purpose. Select a restriction type, set whether the
-              listed vendors are restricted or allowed, and specify which vendor
-              IDs the restriction applies to.
-            </Text>
-            <Tooltip
-              title={
-                !isPurposeFlexible
-                  ? "Non-flexible purposes only support Purpose restrictions and cannot be restricted by consent or legitimate interest settings."
-                  : undefined
-              }
+        <Flex vertical className="gap-6">
+          <Typography.Text className="text-sm">
+            Define how specific vendors are restricted from processing data for
+            this purpose. Select a restriction type, set whether the listed
+            vendors are restricted or allowed, and specify which vendor IDs the
+            restriction applies to.
+          </Typography.Text>
+          <Tooltip
+            title={
+              !isPurposeFlexible
+                ? "Non-flexible purposes only support Purpose restrictions and cannot be restricted by consent or legitimate interest settings."
+                : undefined
+            }
+          >
+            <Form.Item
+              name="restriction_type"
+              label="Restriction type"
+              tooltip="Choose how vendors are permitted to process data for this purpose. This setting overrides the vendor's declared legal basis in the Global Vendor List."
+              rules={[
+                { required: true, message: "Restriction type is required" },
+              ]}
             >
-              <ControlledSelect
-                name="restriction_type"
-                label="Restriction type"
+              <Select
+                aria-label="Restriction type"
                 options={restrictionTypeOptions}
-                layout="stacked"
-                tooltip="Choose how vendors are permitted to process data for this purpose. This setting overrides the vendor's declared legal basis in the Global Vendor List."
-                isRequired
                 disabled={!isPurposeFlexible}
-                className="w-full" // tooltip wrapper makes this necessary
+                data-testid="controlled-select-restriction_type"
+                className="w-full"
               />
-            </Tooltip>
-            <ControlledSelect
-              name="vendor_restriction"
-              label="Vendor restriction"
+            </Form.Item>
+          </Tooltip>
+          <Form.Item
+            name="vendor_restriction"
+            label="Vendor restriction"
+            tooltip="Decide if the restriction applies to all vendors, specific vendors, or if only certain vendors are allowed."
+            rules={[
+              { required: true, message: "Vendor restriction is required" },
+            ]}
+          >
+            <Select
+              aria-label="Vendor restriction"
               options={vendorRestrictionOptions}
-              layout="stacked"
-              tooltip="Decide if the restriction applies to all vendors, specific vendors, or if only certain vendors are allowed."
-              isRequired
+              data-testid="controlled-select-vendor_restriction"
             />
-            <Collapse
-              in={
-                !!values.restriction_type &&
-                !!values.vendor_restriction &&
-                values.vendor_restriction !==
-                  TCFVendorRestriction.RESTRICT_ALL_VENDORS
-              }
-              animateOpacity
+          </Form.Item>
+          {showVendorIds && (
+            <Form.Item
+              name="vendor_ids"
+              label="Vendor IDs"
+              tooltip="List the specific vendors that are restricted or allowed from processing data for this purpose."
+              extra="Enter IDs (e.g. 123) or ranges (e.g. 1-10) and press enter"
+              dependencies={["vendor_restriction"]}
+              rules={[
+                {
+                  required: true,
+                  message: "At least one vendor ID is required",
+                },
+                {
+                  validator: (_, value) => {
+                    if (
+                      value?.length &&
+                      !value.every((id: string) => isValidVendorIdFormat(id))
+                    ) {
+                      return Promise.reject(
+                        new Error(
+                          "Vendor IDs must be numbers or ranges (e.g., 10 or 15-300)",
+                        ),
+                      );
+                    }
+                    return Promise.resolve();
+                  },
+                },
+                {
+                  validator: (_, value) => {
+                    const currentValues = form.getFieldsValue(true);
+                    if (
+                      checkForVendorRestrictionConflicts(
+                        { ...currentValues, vendor_ids: value } as FormValues,
+                        existingRestrictions,
+                        purposeId,
+                        restrictionId,
+                      )
+                    ) {
+                      return Promise.reject(new Error(ERROR_MESSAGE));
+                    }
+                    return Promise.resolve();
+                  },
+                },
+              ]}
             >
-              <ControlledSelect
-                name="vendor_ids"
-                label="Vendor IDs"
+              <Select
+                aria-label="Vendor IDs"
                 mode="tags"
                 options={[]}
-                layout="stacked"
                 placeholder="Enter vendor IDs"
                 open={false}
-                // eslint-disable-next-line react/no-unstable-nested-components
                 suffixIcon={<span />}
-                tooltip="List the specific vendors that are restricted or allowed from processing data for this purpose."
-                disabled={
-                  values.vendor_restriction ===
-                  TCFVendorRestriction.RESTRICT_ALL_VENDORS
-                }
                 tokenSeparators={[",", " "]}
-                onBlur={() => {
-                  // Add small delay to allow Ant Select to create tag before validation
-                  setTimeout(() => {
-                    setTouched({
-                      vendor_ids: true,
-                    });
-                    validateField("vendor_ids");
-                  }, 100);
-                }}
-                helperText="Enter IDs (e.g. 123) or ranges (e.g. 1-10) and press enter"
-                isRequired
+                data-testid="controlled-select-vendor_ids"
               />
-            </Collapse>
-            <Flex justify="flex-end" className="gap-3 pt-4">
-              <Button onClick={onClose} data-testid="cancel-restriction-button">
-                Cancel
-              </Button>
-              <Button
-                type="primary"
-                htmlType="submit"
-                data-testid="save-restriction-button"
-              >
-                Save
-              </Button>
-            </Flex>
+            </Form.Item>
+          )}
+          <Flex justify="flex-end" className="gap-3 pt-4">
+            <Button onClick={onClose} data-testid="cancel-restriction-button">
+              Cancel
+            </Button>
+            <Button
+              type="primary"
+              htmlType="submit"
+              disabled={!submittable || !isDirty}
+              data-testid="save-restriction-button"
+            >
+              Save
+            </Button>
           </Flex>
-        </Form>
-      </ConfirmCloseModal>
-    </FormikProvider>
+        </Flex>
+      </Form>
+    </ConfirmCloseModal>
   );
 };

--- a/clients/admin-ui/src/features/consent-settings/tcf/PurposeRestrictionFormModal.tsx
+++ b/clients/admin-ui/src/features/consent-settings/tcf/PurposeRestrictionFormModal.tsx
@@ -1,12 +1,4 @@
-import {
-  Button,
-  Flex,
-  Form,
-  Select,
-  Tooltip,
-  Typography,
-  useMessage,
-} from "fidesui";
+import { Button, Flex, Form, Select, Typography, useMessage } from "fidesui";
 import isEqual from "lodash/isEqual";
 import { useEffect, useMemo, useState } from "react";
 
@@ -53,6 +45,12 @@ const defaultInitialValues: FormValues = {
   vendor_restriction: "",
   vendor_ids: [],
 };
+
+const FLEXIBLE_PURPOSE_RESTRICTION_TOOLTIP =
+  "Choose how vendors are permitted to process data for this purpose. This setting overrides the vendor's declared legal basis in the Global Vendor List.";
+
+const NON_FLEXIBLE_PURPOSE_RESTRICTION_TOOLTIP =
+  "Non-flexible purposes only support Purpose restrictions and cannot be restricted by consent or legitimate interest settings.";
 
 export const PurposeRestrictionFormModal = ({
   isOpen,
@@ -246,40 +244,32 @@ export const PurposeRestrictionFormModal = ({
         key={restrictionId ?? "create"}
       >
         <Flex vertical>
-          <Typography.Text>
+          <Typography.Text className="mb-4">
             Define how specific vendors are restricted from processing data for
             this purpose. Select a restriction type, set whether the listed
             vendors are restricted or allowed, and specify which vendor IDs the
             restriction applies to.
           </Typography.Text>
-          <Tooltip
-            title={
-              !isPurposeFlexible
-                ? "Non-flexible purposes only support Purpose restrictions and cannot be restricted by consent or legitimate interest settings."
-                : undefined
+          <Form.Item
+            name="restriction_type"
+            label="Restriction type"
+            tooltip={
+              isPurposeFlexible
+                ? FLEXIBLE_PURPOSE_RESTRICTION_TOOLTIP
+                : NON_FLEXIBLE_PURPOSE_RESTRICTION_TOOLTIP
             }
+            rules={[
+              { required: true, message: "Restriction type is required" },
+            ]}
           >
-            <Form.Item
-              name="restriction_type"
-              label="Restriction type"
-              tooltip={
-                isPurposeFlexible
-                  ? "Choose how vendors are permitted to process data for this purpose. This setting overrides the vendor's declared legal basis in the Global Vendor List."
-                  : undefined
-              }
-              rules={[
-                { required: true, message: "Restriction type is required" },
-              ]}
-            >
-              <Select
-                aria-label="Restriction type"
-                options={restrictionTypeOptions}
-                disabled={!isPurposeFlexible}
-                data-testid="controlled-select-restriction_type"
-                className="w-full"
-              />
-            </Form.Item>
-          </Tooltip>
+            <Select
+              aria-label="Restriction type"
+              options={restrictionTypeOptions}
+              disabled={!isPurposeFlexible}
+              data-testid="controlled-select-restriction_type"
+              className="w-full"
+            />
+          </Form.Item>
           <Form.Item
             name="vendor_restriction"
             label="Vendor restriction"

--- a/clients/admin-ui/src/features/consent-settings/tcf/TCFConfigurationDropdown.tsx
+++ b/clients/admin-ui/src/features/consent-settings/tcf/TCFConfigurationDropdown.tsx
@@ -1,20 +1,17 @@
 import {
   Button,
   Card,
-  ChakraInputGroup as InputGroup,
-  ChakraSkeleton as Skeleton,
-  ChakraText as Text,
   ConfirmationModal,
   Dropdown,
   Flex,
   Icons,
   Input,
   Radio,
+  Skeleton,
   Space,
-  useChakraDisclosure as useDisclosure,
   useMessage,
 } from "fidesui";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { getErrorMessage } from "~/features/common/helpers";
 import { useHasPermission } from "~/features/common/Restrict";
@@ -54,9 +51,9 @@ interface DropdownContentProps {
 
 const LoadingContent = () => (
   <Space orientation="vertical" size="small">
-    <Skeleton width="100%" className="h-4" />
-    <Skeleton width="100%" className="h-4" />
-    <Skeleton width="100%" className="h-4" />
+    <Skeleton.Input active block size="small" />
+    <Skeleton.Input active block size="small" />
+    <Skeleton.Input active block size="small" />
   </Space>
 );
 
@@ -93,7 +90,7 @@ const ConfigurationList = ({
           name="tcf-config-id"
           data-testid="tcf-config-item"
         >
-          <Text className="text-sm">{config.name}</Text>
+          <span className="text-sm">{config.name}</span>
         </Radio>
         {userCanDeleteConfigs && (
           <Button
@@ -144,7 +141,7 @@ const DropdownContent = ({
   if (isLoading) {
     content = <LoadingContent />;
   } else if (searchResults.length === 0) {
-    content = <Text className="text-center">No configurations found.</Text>;
+    content = <p className="text-center">No configurations found.</p>;
   } else {
     content = (
       <ConfigurationList
@@ -177,14 +174,13 @@ const DropdownContent = ({
       }}
     >
       {configurations.length > 10 && (
-        <InputGroup size="sm">
-          <Input
-            className="mb-4"
-            placeholder="Search..."
-            onChange={(e) => setSearchTerm(e.target.value)}
-            value={searchTerm}
-          />
-        </InputGroup>
+        <Input
+          size="small"
+          className="mb-4"
+          placeholder="Search..."
+          onChange={(e) => setSearchTerm(e.target.value)}
+          value={searchTerm}
+        />
       )}
 
       {content}
@@ -238,16 +234,13 @@ export const TCFConfigurationDropdown = ({
   const message = useMessage();
   const [deleteTCFConfiguration] = useDeleteTCFConfigurationMutation();
 
-  const {
-    isOpen: modalIsOpen,
-    onOpen: modalOnOpen,
-    onClose: modalOnClose,
-  } = useDisclosure();
-  const {
-    isOpen: deleteIsOpen,
-    onOpen: onDeleteOpen,
-    onClose: onDeleteClose,
-  } = useDisclosure();
+  const [modalIsOpen, setModalIsOpen] = useState(false);
+  const modalOnOpen = useCallback(() => setModalIsOpen(true), []);
+  const modalOnClose = useCallback(() => setModalIsOpen(false), []);
+
+  const [deleteIsOpen, setDeleteIsOpen] = useState(false);
+  const onDeleteOpen = useCallback(() => setDeleteIsOpen(true), []);
+  const onDeleteClose = useCallback(() => setDeleteIsOpen(false), []);
 
   const [searchTerm, setSearchTerm] = useState<string>("");
   const [configToDelete, setConfigToDelete] = useState<TCFConfiguration>();
@@ -300,7 +293,7 @@ export const TCFConfigurationDropdown = ({
         trigger={["click"]}
         styles={{
           root: {
-            zIndex: 999, // putting this behind Chakra's modal. Can possibly remove this after Modal is migrated to Ant Design.
+            zIndex: 999,
           },
         }}
         popupRender={() =>

--- a/clients/admin-ui/src/features/consent-settings/tcf/TCFOverrideToggle.tsx
+++ b/clients/admin-ui/src/features/consent-settings/tcf/TCFOverrideToggle.tsx
@@ -1,7 +1,6 @@
 import { SerializedError } from "@reduxjs/toolkit";
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 import {
-  ChakraText as Text,
   ConfirmationModal,
   Space,
   Switch,
@@ -100,7 +99,7 @@ export const TCFOverrideToggle = ({
   return (
     <>
       <Space orientation="vertical" size="small">
-        <Text>Configure overrides for TCF related purposes.</Text>
+        <span>Configure overrides for TCF related purposes.</span>
         <Space size="small">
           <Switch
             size="small"
@@ -112,7 +111,7 @@ export const TCFOverrideToggle = ({
             onClick={handleBeforeChange}
             data-testid="tcf-override-toggle"
           />
-          <Text>Override vendor purposes</Text>
+          <span>Override vendor purposes</span>
           <InfoTooltip label="Toggle on if you want to globally change any flexible legal bases or remove TCF purposes from your CMP" />
         </Space>
       </Space>

--- a/clients/admin-ui/src/pages/settings/consent/index.tsx
+++ b/clients/admin-ui/src/pages/settings/consent/index.tsx
@@ -244,38 +244,11 @@ const ConsentConfigPage: NextPage = () => {
             initialValues={initialValues}
             key={formKey}
           >
-            {/* Hidden fields for child-managed array/object values */}
+            {/* Hidden fields for values managed imperatively by child components */}
             <Form.Item name="purposeOverrides" hidden noStyle>
               <Input />
             </Form.Item>
             <Form.Item name={["gpp", "enabled"]} hidden noStyle>
-              <Input />
-            </Form.Item>
-            <Form.Item name={["gpp", "us_approach"]} hidden noStyle>
-              <Input />
-            </Form.Item>
-            <Form.Item
-              name={["gpp", "mspa_covered_transactions"]}
-              hidden
-              noStyle
-            >
-              <Input />
-            </Form.Item>
-            <Form.Item
-              name={["gpp", "mspa_service_provider_mode"]}
-              hidden
-              noStyle
-            >
-              <Input />
-            </Form.Item>
-            <Form.Item
-              name={["gpp", "mspa_opt_out_option_mode"]}
-              hidden
-              noStyle
-            >
-              <Input />
-            </Form.Item>
-            <Form.Item name={["gpp", "enable_tcfeu_string"]} hidden noStyle>
               <Input />
             </Form.Item>
             <Form.Item

--- a/clients/admin-ui/src/pages/settings/consent/index.tsx
+++ b/clients/admin-ui/src/pages/settings/consent/index.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-array-index-key */
 import { SerializedError } from "@reduxjs/toolkit";
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 import { Button, Flex, Form, Input, Spin, useMessage } from "fidesui";

--- a/clients/admin-ui/src/pages/settings/consent/index.tsx
+++ b/clients/admin-ui/src/pages/settings/consent/index.tsx
@@ -1,17 +1,10 @@
 /* eslint-disable react/no-array-index-key */
 import { SerializedError } from "@reduxjs/toolkit";
 import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
-import {
-  Button,
-  ChakraBox as Box,
-  ChakraStack as Stack,
-  ChakraText as Text,
-  Spin,
-  useMessage,
-} from "fidesui";
-import { Form, Formik } from "formik";
+import { Button, Flex, Form, Input, Spin, useMessage } from "fidesui";
+import isEqual from "lodash/isEqual";
 import type { NextPage } from "next";
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { useAppSelector } from "~/app/hooks";
 import { useFeatures } from "~/features/common/features";
@@ -99,62 +92,69 @@ const ConsentConfigPage: NextPage = () => {
   const { isLoading: isPurposesLoading } = useGetPurposesQuery();
 
   const message = useMessage();
+  const [form] = Form.useForm<FormValues>();
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleSubmit = async (values: FormValues) => {
-    const handleResult = (
-      result:
-        | { data: object }
-        | { error: FetchBaseQueryError | SerializedError },
-    ) => {
-      if (isErrorResult(result)) {
-        const errorMsg = getErrorMessage(
-          result.error,
-          `An unexpected error occurred while saving. Please try again.`,
-        );
-        message.error(errorMsg);
-      } else {
-        message.success("Settings saved successfully");
-      }
-    };
-
-    const payload: TCFPurposeOverrideSchema[] = [
-      ...values.purposeOverrides.map((po) => {
-        let requiredLegalBasis;
-        if (po.is_consent) {
-          requiredLegalBasis = TCFLegalBasisEnum.CONSENT;
+    setIsSubmitting(true);
+    try {
+      const handleResult = (
+        result:
+          | { data: object }
+          | { error: FetchBaseQueryError | SerializedError },
+      ) => {
+        if (isErrorResult(result)) {
+          const errorMsg = getErrorMessage(
+            result.error,
+            `An unexpected error occurred while saving. Please try again.`,
+          );
+          message.error(errorMsg);
+        } else {
+          message.success("Settings saved successfully");
         }
+      };
 
-        if (po.is_legitimate_interest) {
-          requiredLegalBasis = TCFLegalBasisEnum.LEGITIMATE_INTERESTS;
+      const payload: TCFPurposeOverrideSchema[] = [
+        ...values.purposeOverrides.map((po) => {
+          let requiredLegalBasis;
+          if (po.is_consent) {
+            requiredLegalBasis = TCFLegalBasisEnum.CONSENT;
+          }
+
+          if (po.is_legitimate_interest) {
+            requiredLegalBasis = TCFLegalBasisEnum.LEGITIMATE_INTERESTS;
+          }
+
+          return {
+            purpose: po.purpose,
+            is_included: po.is_included,
+            required_legal_basis: requiredLegalBasis,
+          };
+        }),
+      ];
+
+      // Try to patch TCF overrides first
+      if (isTcfOverrideEnabled) {
+        const result = await patchTcfPurposeOverridesTrigger(payload);
+        if (isErrorResult(result)) {
+          handleResult(result);
+          return;
         }
-
-        return {
-          purpose: po.purpose,
-          is_included: po.is_included,
-          required_legal_basis: requiredLegalBasis,
-        };
-      }),
-    ];
-
-    // Try to patch TCF overrides first
-    if (isTcfOverrideEnabled) {
-      const result = await patchTcfPurposeOverridesTrigger(payload);
-      if (isErrorResult(result)) {
-        handleResult(result);
-        return;
       }
+      // Then we update config values
+      // For GPP, do not pass in `enabled`
+      const { enabled, ...updatedGpp } = values.gpp;
+      const configResult = await patchConfigSettingsTrigger({
+        gpp: updatedGpp,
+        plus_consent_settings: {
+          tcf_publisher_country_code:
+            values.tcfPublisherSettings.publisher_country_code ?? null,
+        },
+      });
+      handleResult(configResult);
+    } finally {
+      setIsSubmitting(false);
     }
-    // Then we update config values
-    // For GPP, do not pass in `enabled`
-    const { enabled, ...updatedGpp } = values.gpp;
-    const configResult = await patchConfigSettingsTrigger({
-      gpp: updatedGpp,
-      plus_consent_settings: {
-        tcf_publisher_country_code:
-          values.tcfPublisherSettings.publisher_country_code ?? null,
-      },
-    });
-    handleResult(configResult);
   };
 
   const initialValues = useMemo(
@@ -181,6 +181,21 @@ const ConsentConfigPage: NextPage = () => {
     [tcfPurposeOverrides, gppSettings, plusConsentSettings],
   );
 
+  const allValues = Form.useWatch([], form);
+  const [submittable, setSubmittable] = useState(false);
+
+  useEffect(() => {
+    form
+      .validateFields({ validateOnly: true })
+      .then(() => setSubmittable(true))
+      .catch(() => setSubmittable(false));
+  }, [form, allValues]);
+
+  const isDirty = useMemo(
+    () => (!allValues ? false : !isEqual(allValues, initialValues)),
+    [allValues, initialValues],
+  );
+
   const hasLegacyLegalBasisOverrides = useMemo(() => {
     return (
       tcfPurposeOverrides?.some(
@@ -195,6 +210,9 @@ const ConsentConfigPage: NextPage = () => {
   const isPublisherRestrictionsFlagEnabled =
     useFeatures()?.flags?.publisherRestrictions;
 
+  // Stable key for reinitialize behavior
+  const formKey = useMemo(() => JSON.stringify(initialValues), [initialValues]);
+
   return (
     <Layout title="Consent Configuration">
       {isHealthCheckLoading ||
@@ -204,9 +222,9 @@ const ConsentConfigPage: NextPage = () => {
       isConfigSetLoading ? (
         <Spin />
       ) : (
-        <Box data-testid="consent-configuration">
+        <div data-testid="consent-configuration">
           <PageHeader heading="Consent settings" />
-          <Stack spacing={3} mb={3}>
+          <Flex vertical gap="middle" className="mb-3">
             <SettingsBox title="Transparency & Consent Framework settings">
               <FrameworkStatus name="TCF" enabled={isTcfEnabled} />
             </SettingsBox>
@@ -218,58 +236,97 @@ const ConsentConfigPage: NextPage = () => {
                   isTCFOverrideEnabled={isTcfOverrideEnabled}
                 />
               )}
-          </Stack>
-          <Formik<FormValues>
+          </Flex>
+          <Form<FormValues>
+            form={form}
+            layout="vertical"
+            onFinish={handleSubmit}
             initialValues={initialValues}
-            enableReinitialize
-            onSubmit={handleSubmit}
+            key={formKey}
           >
-            {({ dirty, isValid, isSubmitting }) => (
-              <Form>
-                <Stack spacing={6}>
-                  {/* Legacy vendor overrides */}
-                  {isTcfEnabled &&
-                    (hasLegacyLegalBasisOverrides ||
-                      !isPublisherRestrictionsFlagEnabled) && (
-                      <SettingsBox title="Vendor overrides" fontSize="sm">
-                        <TCFOverrideToggle
-                          defaultChecked={isTcfOverrideEnabled}
-                          disabled={isPatchConfigSettingsLoading}
-                        />
-                        {isTcfOverrideEnabled && (
-                          <Stack mt={2} spacing={2}>
-                            <Text>
-                              The table below allows you to adjust which TCF
-                              purposes you allow as part of your user facing
-                              notices and business activites.
-                            </Text>
-                            <Text>
-                              To configure this section, select the purposes you
-                              allow and where available, the appropriate legal
-                              bases (either Consent or Legitimate Interest).
-                            </Text>
-                            <DeprecatedPurposeOverrides />
-                          </Stack>
-                        )}
-                      </SettingsBox>
+            {/* Hidden fields for child-managed array/object values */}
+            <Form.Item name="purposeOverrides" hidden noStyle>
+              <Input />
+            </Form.Item>
+            <Form.Item name={["gpp", "enabled"]} hidden noStyle>
+              <Input />
+            </Form.Item>
+            <Form.Item name={["gpp", "us_approach"]} hidden noStyle>
+              <Input />
+            </Form.Item>
+            <Form.Item
+              name={["gpp", "mspa_covered_transactions"]}
+              hidden
+              noStyle
+            >
+              <Input />
+            </Form.Item>
+            <Form.Item
+              name={["gpp", "mspa_service_provider_mode"]}
+              hidden
+              noStyle
+            >
+              <Input />
+            </Form.Item>
+            <Form.Item
+              name={["gpp", "mspa_opt_out_option_mode"]}
+              hidden
+              noStyle
+            >
+              <Input />
+            </Form.Item>
+            <Form.Item name={["gpp", "enable_tcfeu_string"]} hidden noStyle>
+              <Input />
+            </Form.Item>
+            <Form.Item
+              name={["tcfPublisherSettings", "publisher_country_code"]}
+              hidden
+              noStyle
+            >
+              <Input />
+            </Form.Item>
+            <Flex vertical gap="large">
+              {/* Legacy vendor overrides */}
+              {isTcfEnabled &&
+                (hasLegacyLegalBasisOverrides ||
+                  !isPublisherRestrictionsFlagEnabled) && (
+                  <SettingsBox title="Vendor overrides">
+                    <TCFOverrideToggle
+                      defaultChecked={isTcfOverrideEnabled}
+                      disabled={isPatchConfigSettingsLoading}
+                    />
+                    {isTcfOverrideEnabled && (
+                      <Flex vertical gap="small" className="mt-2">
+                        <p>
+                          The table below allows you to adjust which TCF
+                          purposes you allow as part of your user facing notices
+                          and business activites.
+                        </p>
+                        <p>
+                          To configure this section, select the purposes you
+                          allow and where available, the appropriate legal bases
+                          (either Consent or Legitimate Interest).
+                        </p>
+                        <DeprecatedPurposeOverrides />
+                      </Flex>
                     )}
-                  <PublisherSettings />
-                  <GppConfiguration />
-                  <Button
-                    htmlType="submit"
-                    type="primary"
-                    disabled={!dirty || !isValid}
-                    loading={isSubmitting}
-                    data-testid="save-btn"
-                    className="self-start"
-                  >
-                    Save
-                  </Button>
-                </Stack>
-              </Form>
-            )}
-          </Formik>
-        </Box>
+                  </SettingsBox>
+                )}
+              <PublisherSettings />
+              <GppConfiguration />
+              <Button
+                htmlType="submit"
+                type="primary"
+                disabled={!isDirty || !submittable}
+                loading={isSubmitting}
+                data-testid="save-btn"
+                className="self-start"
+              >
+                Save
+              </Button>
+            </Flex>
+          </Form>
+        </div>
       )}
     </Layout>
   );


### PR DESCRIPTION
Ticket [ENG-3176]

### Description Of Changes

Migrates the consent settings page (`/settings/consent`) and all components under `features/consent-settings/` from Chakra UI + Formik to Ant Design v6 + antd Form. Part of the broader form migration initiative (parent ticket ENG-3165).

### Code Changes

* Replace `<Formik>` with antd `Form` using `Form.useForm`, `Form.useWatch`, and `onFinish` across 6 form components
* Replace Formik hooks (`useFormikContext`, `useField`, `FieldArray`) with `Form.useFormInstance()` and `Form.useWatch` in child components
* Replace Formik-wrapped components (`ControlledRadioGroup`, `CustomSwitch`, `CheckboxField`, `ControlledSelect`, `CustomTextInput`) with `Form.Item` + native antd controls
* Convert Yup validation to antd `rules` with custom validators
* Replace Chakra layout/display components (`Box`, `Stack`, `Text`, `Skeleton`, `Collapse`, `Divider`) with antd equivalents (`Card`, `Flex`, `Skeleton.Input`, `Divider`) or plain HTML
* Replace `useChakraDisclosure` with `useState`
* Update Cypress e2e selectors for DOM changes

### Steps to Confirm

1. Navigate to **Settings → Consent** and verify the page renders without errors
2. Verify GPP radio buttons work (National, State-by-State, Both) and MSPA section appears/disappears
3. Verify MSPA conditional disable logic: uncheck "covered transactions" → switches reset and disable; toggle one mode → other mode disables
4. Verify Publisher country dropdown populates and saves
5. Verify Save button is disabled when form is clean, enabled when dirty, and submits correctly
6. If TCF + publisher restrictions flag enabled: verify TCF config creation, dropdown selection, and purpose restriction editing
7. If legacy overrides present: verify vendor overrides table with switches

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [x] No followup issues
* Database migrations:
  * [x] No migrations
* Documentation:
  * [x] No documentation updates required

[ENG-3176]: https://ethyca.atlassian.net/browse/ENG-3176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ