### PR TITLE
ENG-3509: Fix custom field labels missing from privacy request payload

### DIFF
--- a/changelog/7970-custom-field-labels-missing.yaml
+++ b/changelog/7970-custom-field-labels-missing.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Fixed custom field labels missing from privacy request submission payload
+pr: 7970
+labels: []

--- a/clients/admin-ui/cypress/e2e/request-manager/new-request-manager-list-page.cy.ts
+++ b/clients/admin-ui/cypress/e2e/request-manager/new-request-manager-list-page.cy.ts
@@ -359,7 +359,27 @@ describe("New Privacy Requests", () => {
         }).as("postPrivacyRequest");
         cy.getByTestId("submit-btn").click();
         cy.shouldShowMessage("success");
-        cy.wait("@postPrivacyRequest");
+        cy.wait("@postPrivacyRequest")
+          .its("request.body")
+          .then((body) => {
+            const fields = body[0].custom_privacy_request_fields;
+            expect(fields.required_field).to.have.property(
+              "label",
+              "Required example field",
+            );
+            expect(fields.required_field).to.have.property(
+              "value",
+              "A value for the required field",
+            );
+            expect(fields.field_with_default_value).to.have.property(
+              "label",
+              "Example field with default value",
+            );
+            expect(fields.field_with_default_value).to.have.property(
+              "value",
+              "The default value",
+            );
+          });
         cy.wait("@getPrivacyRequests");
       });
     });

--- a/clients/admin-ui/cypress/e2e/request-manager/new-request-manager-list-page.cy.ts
+++ b/clients/admin-ui/cypress/e2e/request-manager/new-request-manager-list-page.cy.ts
@@ -379,6 +379,14 @@ describe("New Privacy Requests", () => {
               "value",
               "The default value",
             );
+            expect(fields.hidden_field).to.have.property(
+              "label",
+              "Hidden example field",
+            );
+            expect(fields.hidden_field).to.have.property(
+              "value",
+              "A value for the hidden but required field",
+            );
           });
         cy.wait("@getPrivacyRequests");
       });

--- a/clients/admin-ui/cypress/e2e/request-manager/new-request-manager-list-page.cy.ts
+++ b/clients/admin-ui/cypress/e2e/request-manager/new-request-manager-list-page.cy.ts
@@ -320,6 +320,11 @@ describe("New Privacy Requests", () => {
         cy.getByTestId(
           "input-custom_privacy_request_fields.field_with_default_value.value",
         ).should("have.value", "The default value");
+
+        // Department field should render as a select dropdown with configured options
+        cy.getByTestId(
+          "input-custom_privacy_request_fields.department.value",
+        ).antSelect("Engineering");
       });
 
       it("can submit a privacy request", () => {

--- a/clients/admin-ui/src/features/privacy-requests/SubmitPrivacyRequestForm.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/SubmitPrivacyRequestForm.tsx
@@ -131,17 +131,24 @@ const CustomFields = ({
             required={Boolean(fieldInfo.required)}
           />
         ) : (
-          <Form.Item
-            name={["custom_privacy_request_fields", fieldName, "value"]}
-            key={fieldName}
-            label={fieldInfo.label}
-            rules={rules[`custom_privacy_request_fields.${fieldName}.value`]}
-            layout="vertical"
-          >
-            <Input
-              data-testid={`input-custom_privacy_request_fields.${fieldName}.value`}
-            />
-          </Form.Item>
+          <div key={fieldName}>
+            <Form.Item
+              name={["custom_privacy_request_fields", fieldName, "label"]}
+              hidden
+            >
+              <Input />
+            </Form.Item>
+            <Form.Item
+              name={["custom_privacy_request_fields", fieldName, "value"]}
+              label={fieldInfo.label}
+              rules={rules[`custom_privacy_request_fields.${fieldName}.value`]}
+              layout="vertical"
+            >
+              <Input
+                data-testid={`input-custom_privacy_request_fields.${fieldName}.value`}
+              />
+            </Form.Item>
+          </div>
         );
       })}
     </>

--- a/clients/admin-ui/src/features/privacy-requests/SubmitPrivacyRequestForm.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/SubmitPrivacyRequestForm.tsx
@@ -136,10 +136,7 @@ const CustomFields = ({
   return (
     <>
       {allInputs.map(([fieldName, fieldInfo]) => {
-        if (
-          "field_type" in fieldInfo &&
-          fieldInfo.field_type === "location"
-        ) {
+        if ("field_type" in fieldInfo && fieldInfo.field_type === "location") {
           return (
             <LocationSelectField
               name={fieldName}
@@ -173,6 +170,7 @@ const CustomFields = ({
             >
               {isSelectField(fieldInfo) ? (
                 <Select
+                  aria-label={fieldInfo.label}
                   options={fieldInfo.options.map((opt) => ({
                     label: opt,
                     value: opt,

--- a/clients/admin-ui/src/features/privacy-requests/SubmitPrivacyRequestForm.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/SubmitPrivacyRequestForm.tsx
@@ -37,6 +37,16 @@ export type LocationCustomPrivacyRequestField = {
   ip_geolocation_hint?: boolean | null;
 };
 
+export type SelectCustomPrivacyRequestField = {
+  label: string;
+  required?: boolean | null;
+  default_value?: string | null;
+  hidden?: boolean | null;
+  query_param_key?: string | null;
+  field_type: "select";
+  options: string[];
+};
+
 export type PrivacyRequestSubmitFormValues = PrivacyRequestCreate & {
   is_verified: boolean;
 };
@@ -87,16 +97,19 @@ const LocationSelectField = ({
   label,
   name,
   required,
+  rules,
 }: {
   label: string;
   name: string;
   required: boolean;
+  rules?: FormRule[];
 }) => {
   return (
     <Form.Item
       label={label}
       name={name}
-      required={required ?? undefined}
+      required={required}
+      rules={rules}
       layout="vertical"
     >
       <LocationSelect />
@@ -112,6 +125,7 @@ const CustomFields = ({
     string,
     | fides__api__schemas__privacy_center_config__CustomPrivacyRequestField
     | LocationCustomPrivacyRequestField
+    | SelectCustomPrivacyRequestField
   > | null;
   rules: Record<string, FormRule[]>;
 }) => {
@@ -122,15 +136,27 @@ const CustomFields = ({
   return (
     <>
       {allInputs.map(([fieldName, fieldInfo]) => {
-        return "field_type" in fieldInfo &&
-          fieldInfo.field_type === "location" ? (
-          <LocationSelectField
-            name={fieldName}
-            key={fieldName}
-            label={fieldInfo.label}
-            required={Boolean(fieldInfo.required)}
-          />
-        ) : (
+        if (
+          "field_type" in fieldInfo &&
+          fieldInfo.field_type === "location"
+        ) {
+          return (
+            <LocationSelectField
+              name={fieldName}
+              key={fieldName}
+              label={fieldInfo.label}
+              required={Boolean(fieldInfo.required)}
+              rules={rules[fieldName]}
+            />
+          );
+        }
+
+        const isSelectField = (
+          info: typeof fieldInfo,
+        ): info is SelectCustomPrivacyRequestField =>
+          "field_type" in info && info.field_type === "select";
+
+        return (
           <div key={fieldName}>
             <Form.Item
               name={["custom_privacy_request_fields", fieldName, "label"]}
@@ -141,12 +167,23 @@ const CustomFields = ({
             <Form.Item
               name={["custom_privacy_request_fields", fieldName, "value"]}
               label={fieldInfo.label}
+              required={Boolean(fieldInfo.required)}
               rules={rules[`custom_privacy_request_fields.${fieldName}.value`]}
               layout="vertical"
             >
-              <Input
-                data-testid={`input-custom_privacy_request_fields.${fieldName}.value`}
-              />
+              {isSelectField(fieldInfo) ? (
+                <Select
+                  options={fieldInfo.options.map((opt) => ({
+                    label: opt,
+                    value: opt,
+                  }))}
+                  data-testid={`input-custom_privacy_request_fields.${fieldName}.value`}
+                />
+              ) : (
+                <Input
+                  data-testid={`input-custom_privacy_request_fields.${fieldName}.value`}
+                />
+              )}
             </Form.Item>
           </div>
         );
@@ -347,7 +384,7 @@ export const CopyPrivacyRequestLinkForm = ({
           ]}
           layout="vertical"
         >
-          <Input />
+          <Input data-testid="input-identity.email" />
         </Form.Item>
         <div className="flex gap-4 self-end">
           <Button

--- a/clients/admin-ui/src/features/privacy-requests/form/helpers.test.ts
+++ b/clients/admin-ui/src/features/privacy-requests/form/helpers.test.ts
@@ -1,6 +1,9 @@
 import { PrivacyRequestOption } from "~/types/api";
 
-import { findActionFromPolicyKey, generateFormRulesFromAction } from "./helpers";
+import {
+  findActionFromPolicyKey,
+  generateFormRulesFromAction,
+} from "./helpers";
 
 const baseAction: PrivacyRequestOption = {
   icon_path: "/icon.svg",
@@ -158,7 +161,7 @@ describe("generateFormRulesFromAction", () => {
         },
       };
       const rules = generateFormRulesFromAction(action);
-      expect(rules["user_location"]).toEqual([
+      expect(rules.user_location).toEqual([
         { required: true, message: "Your location is required" },
       ]);
       // Should not also generate a nested value path
@@ -179,7 +182,7 @@ describe("generateFormRulesFromAction", () => {
         },
       };
       const rules = generateFormRulesFromAction(action);
-      expect(rules["user_location"]).toBeUndefined();
+      expect(rules.user_location).toBeUndefined();
     });
 
     it("generates rules for select fields the same as text fields", () => {
@@ -193,9 +196,9 @@ describe("generateFormRulesFromAction", () => {
         },
       };
       const rules = generateFormRulesFromAction(action);
-      expect(
-        rules["custom_privacy_request_fields.department.value"],
-      ).toEqual([{ required: true, message: "Department is required" }]);
+      expect(rules["custom_privacy_request_fields.department.value"]).toEqual([
+        { required: true, message: "Department is required" },
+      ]);
     });
   });
 });

--- a/clients/admin-ui/src/features/privacy-requests/form/helpers.test.ts
+++ b/clients/admin-ui/src/features/privacy-requests/form/helpers.test.ts
@@ -1,0 +1,201 @@
+import { PrivacyRequestOption } from "~/types/api";
+
+import { findActionFromPolicyKey, generateFormRulesFromAction } from "./helpers";
+
+const baseAction: PrivacyRequestOption = {
+  icon_path: "/icon.svg",
+  title: "Access your data",
+  description: "Access request",
+  policy_key: "default_access_policy",
+};
+
+describe("findActionFromPolicyKey", () => {
+  const actions: PrivacyRequestOption[] = [
+    { ...baseAction, policy_key: "access_policy" },
+    { ...baseAction, policy_key: "erasure_policy", title: "Erase your data" },
+  ];
+
+  it("returns the matching action", () => {
+    expect(findActionFromPolicyKey("erasure_policy", actions)?.title).toBe(
+      "Erase your data",
+    );
+  });
+
+  it("returns undefined for unknown key", () => {
+    expect(findActionFromPolicyKey("unknown", actions)).toBeUndefined();
+  });
+
+  it("returns undefined when actions is undefined", () => {
+    expect(findActionFromPolicyKey("access_policy")).toBeUndefined();
+  });
+});
+
+describe("generateFormRulesFromAction", () => {
+  it("returns only policy_key rule when no action", () => {
+    const rules = generateFormRulesFromAction(undefined);
+    expect(rules).toEqual({
+      policy_key: [{ required: true, message: "Request type is required" }],
+    });
+  });
+
+  describe("identity field rules", () => {
+    it("generates required + email rules when email is required", () => {
+      const action: PrivacyRequestOption = {
+        ...baseAction,
+        identity_inputs: { email: "required" },
+      };
+      const rules = generateFormRulesFromAction(action);
+      expect(rules["identity.email"]).toEqual([
+        { required: true, message: "Email address is required" },
+        { type: "email", message: "Email address must be a valid email" },
+      ]);
+    });
+
+    it("generates only email format rule when email is optional", () => {
+      const action: PrivacyRequestOption = {
+        ...baseAction,
+        identity_inputs: { email: "optional" },
+      };
+      const rules = generateFormRulesFromAction(action);
+      expect(rules["identity.email"]).toEqual([
+        { type: "email", message: "Email address must be a valid email" },
+      ]);
+    });
+
+    it("generates required + pattern rules when phone is required", () => {
+      const action: PrivacyRequestOption = {
+        ...baseAction,
+        identity_inputs: { phone: "required" },
+      };
+      const rules = generateFormRulesFromAction(action);
+      expect(rules["identity.phone_number"]).toHaveLength(2);
+      expect(rules["identity.phone_number"]![0]).toEqual({
+        required: true,
+        message: "Phone number is required",
+      });
+    });
+
+    it("generates only pattern rule when phone is optional", () => {
+      const action: PrivacyRequestOption = {
+        ...baseAction,
+        identity_inputs: { phone: "optional" },
+      };
+      const rules = generateFormRulesFromAction(action);
+      expect(rules["identity.phone_number"]).toHaveLength(1);
+      expect(rules["identity.phone_number"]![0]).toHaveProperty("pattern");
+    });
+
+    it("does not generate identity rules when inputs are null", () => {
+      const action: PrivacyRequestOption = {
+        ...baseAction,
+        identity_inputs: null,
+      };
+      const rules = generateFormRulesFromAction(action);
+      expect(rules["identity.email"]).toBeUndefined();
+      expect(rules["identity.phone_number"]).toBeUndefined();
+    });
+  });
+
+  describe("custom field rules", () => {
+    it("generates required rule for a required text field (no field_type)", () => {
+      const action: PrivacyRequestOption = {
+        ...baseAction,
+        custom_privacy_request_fields: {
+          required_field: {
+            label: "Required field",
+            required: true,
+          },
+        },
+      };
+      const rules = generateFormRulesFromAction(action);
+      expect(
+        rules["custom_privacy_request_fields.required_field.value"],
+      ).toEqual([{ required: true, message: "Required field is required" }]);
+    });
+
+    it("does not generate rule for an optional field", () => {
+      const action: PrivacyRequestOption = {
+        ...baseAction,
+        custom_privacy_request_fields: {
+          optional_field: {
+            label: "Optional field",
+            required: false,
+          },
+        },
+      };
+      const rules = generateFormRulesFromAction(action);
+      expect(
+        rules["custom_privacy_request_fields.optional_field.value"],
+      ).toBeUndefined();
+    });
+
+    it("does not generate required rule for a hidden required field", () => {
+      const action: PrivacyRequestOption = {
+        ...baseAction,
+        custom_privacy_request_fields: {
+          hidden_field: {
+            label: "Hidden field",
+            required: true,
+            hidden: true,
+          },
+        },
+      };
+      const rules = generateFormRulesFromAction(action);
+      expect(
+        rules["custom_privacy_request_fields.hidden_field.value"],
+      ).toBeUndefined();
+    });
+
+    it("generates rule keyed by field name for required location fields", () => {
+      const action: PrivacyRequestOption = {
+        ...baseAction,
+        custom_privacy_request_fields: {
+          user_location: {
+            label: "Your location",
+            required: true,
+            field_type: "location",
+          },
+        },
+      };
+      const rules = generateFormRulesFromAction(action);
+      expect(rules["user_location"]).toEqual([
+        { required: true, message: "Your location is required" },
+      ]);
+      // Should not also generate a nested value path
+      expect(
+        rules["custom_privacy_request_fields.user_location.value"],
+      ).toBeUndefined();
+    });
+
+    it("does not generate rule for optional location fields", () => {
+      const action: PrivacyRequestOption = {
+        ...baseAction,
+        custom_privacy_request_fields: {
+          user_location: {
+            label: "Your location",
+            required: false,
+            field_type: "location",
+          },
+        },
+      };
+      const rules = generateFormRulesFromAction(action);
+      expect(rules["user_location"]).toBeUndefined();
+    });
+
+    it("generates rules for select fields the same as text fields", () => {
+      const action: PrivacyRequestOption = {
+        ...baseAction,
+        custom_privacy_request_fields: {
+          department: {
+            label: "Department",
+            required: true,
+          },
+        },
+      };
+      const rules = generateFormRulesFromAction(action);
+      expect(
+        rules["custom_privacy_request_fields.department.value"],
+      ).toEqual([{ required: true, message: "Department is required" }]);
+    });
+  });
+});

--- a/clients/admin-ui/src/features/privacy-requests/form/helpers.ts
+++ b/clients/admin-ui/src/features/privacy-requests/form/helpers.ts
@@ -49,18 +49,23 @@ export const generateFormRulesFromAction = (
   }
 
   if (action.custom_privacy_request_fields) {
-    Object.entries(action.custom_privacy_request_fields)
-      .filter(
-        ([, fieldInfo]) =>
-          "field_type" in fieldInfo && fieldInfo.field_type !== "location",
-      )
-      .forEach(([fieldName, fieldInfo]) => {
-        if (fieldInfo.required && !fieldInfo.hidden) {
+    Object.entries(action.custom_privacy_request_fields).forEach(
+      ([fieldName, fieldInfo]) => {
+        const isLocation =
+          "field_type" in fieldInfo && fieldInfo.field_type === "location";
+        if (isLocation) {
+          if (fieldInfo.required) {
+            rules[fieldName] = [
+              { required: true, message: `${fieldInfo.label} is required` },
+            ];
+          }
+        } else if (fieldInfo.required && !fieldInfo.hidden) {
           rules[`custom_privacy_request_fields.${fieldName}.value`] = [
             { required: true, message: `${fieldInfo.label} is required` },
           ];
         }
-      });
+      },
+    );
   }
 
   return rules;


### PR DESCRIPTION
Ticket [ENG-3509]

### Description Of Changes

The Ant Design form migration (ENG-3172) had two issues with the privacy request submission form:

1. **Missing custom field labels** -- Only `.value` had a bound `Form.Item`, so Ant Design's form store didn't include `.label` in the submitted data. The backend `CustomPrivacyRequestField` schema requires both `label` and `value`, resulting in a 422.

2. **Missing required field indicators and validation** -- A filter bug in `generateFormRulesFromAction` excluded plain text custom fields from rule generation. The filter `"field_type" in fieldInfo && fieldInfo.field_type !== "location"` only passed fields with an explicit `field_type`, silently dropping fields like `required_field` and `hidden_field` that have no `field_type`. This meant required asterisks were missing and validation didn't fire.

### Code Changes

* Added hidden `Form.Item` for each custom field's `label` property in `CustomFields` component
* Fixed the custom field filter in `generateFormRulesFromAction` to include fields without `field_type`
* Added `required` prop on custom field `Form.Item` to restore asterisks for hidden+required fields
* Added `SelectCustomPrivacyRequestField` type and render select-type custom fields as `<Select>` dropdowns
* Added validation rules for required location fields and passed them to `LocationSelectField`
* Added `data-testid` to `CopyPrivacyRequestLinkForm` email input
* Added unit tests for `generateFormRulesFromAction` and `findActionFromPolicyKey` (15 tests)
* Added Cypress assertion for department select field rendering
* Added Cypress request body assertions for label/value in submission payload

### Steps to Confirm

1. Open Admin UI > Privacy Requests
2. Click "Create request"
3. Select "Access your data" request type
4. Verify required asterisks appear on "Required example field" and "Hidden example field"
5. Try submitting without filling "Required example field" -- should be blocked by validation
6. Verify "Department" renders as a select dropdown with options
7. Fill in required fields, check the confirmation checkbox, and submit
8. Inspect network request to `/api/v1/privacy-request/authenticated` -- verify each custom field entry includes both `label` and `value`

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required

[ENG-3509]: https://ethyca.atlassian.net/browse/ENG-3509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ