### PR TITLE
POC: Alembic merge heads for git-flow migration reconciliation

### DIFF
--- a/src/fides/api/alembic/migrations/versions/xx_2026_04_20_1000_aaaa11112222_hotfix_main_migration.py
+++ b/src/fides/api/alembic/migrations/versions/xx_2026_04_20_1000_aaaa11112222_hotfix_main_migration.py
@@ -1,0 +1,33 @@
+"""DEMO: hotfix migration that landed on main
+
+This simulates a hotfix migration added directly to main.
+Both this and the "dev" migration share the same down_revision,
+creating two alembic heads (a multi-head scenario).
+
+Revision ID: aaaa11112222
+Revises: d6e7f8a9b0c1
+Create Date: 2026-04-20 10:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "aaaa11112222"
+down_revision = "d6e7f8a9b0c1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Simulated hotfix: add an index for a production query performance issue
+    op.create_index(
+        "ix_demo_hotfix_placeholder",
+        "privacyrequest",
+        ["status"],
+        if_not_exists=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_demo_hotfix_placeholder", table_name="privacyrequest")

--- a/src/fides/api/alembic/migrations/versions/xx_2026_04_20_1000_bbbb33334444_dev_feature_migration.py
+++ b/src/fides/api/alembic/migrations/versions/xx_2026_04_20_1000_bbbb33334444_dev_feature_migration.py
@@ -1,0 +1,32 @@
+"""DEMO: feature migration that was developed on dev branch
+
+This simulates a feature migration on the dev branch.
+It shares the same down_revision as the hotfix migration,
+creating two alembic heads (a multi-head scenario).
+
+Revision ID: bbbb33334444
+Revises: d6e7f8a9b0c1
+Create Date: 2026-04-20 10:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "bbbb33334444"
+down_revision = "d6e7f8a9b0c1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Simulated feature: add a column for a new feature on dev
+    op.add_column(
+        "privacyrequest",
+        sa.Column("demo_feature_flag", sa.Boolean(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("privacyrequest", "demo_feature_flag")

--- a/src/fides/api/alembic/migrations/versions/xx_2026_04_20_1100_cccc55556666_merge_main_and_dev_heads.py
+++ b/src/fides/api/alembic/migrations/versions/xx_2026_04_20_1100_cccc55556666_merge_main_and_dev_heads.py
@@ -1,0 +1,28 @@
+"""DEMO: merge divergent heads from main and dev
+
+This is the resolution. When main is merged back into dev (or vice versa),
+alembic detects two heads. Running `alembic merge heads` generates this
+migration automatically. It has no schema changes — just unifies the chain.
+
+In practice you'd run:
+    alembic merge heads -m "merge main hotfix and dev feature"
+
+Revision ID: cccc55556666
+Revises: ('aaaa11112222', 'bbbb33334444')
+Create Date: 2026-04-20 11:00:00.000000
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "cccc55556666"
+down_revision = ("aaaa11112222", "bbbb33334444")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary

Proof-of-concept demonstrating that divergent alembic migrations are resolvable when adopting git-flow.

**The scenario:**
- A hotfix migration lands on `main` (`aaaa11112222`)
- A feature migration develops independently on `dev` (`bbbb33334444`)
- Both share the same `down_revision`, creating two alembic heads

**The resolution:**
- `alembic merge heads` generates a merge migration (`cccc55556666`) with `down_revision = ("aaaa11112222", "bbbb33334444")`
- Single head restored, no data loss, no conflicts

**Migration chain:**
```
d6e7f8a9b0c1 (previous head)
     |
     +---> aaaa11112222 (hotfix on main)
     |
     +---> bbbb33334444 (feature on dev)
             \       /
              v     v
        cccc55556666 (merge migration)
```

**Key takeaway:** This is a standard alembic feature. The merge migration has no schema changes — it just unifies the revision graph. Can be automated in CI by detecting `alembic heads` returning >1 result.

> ⚠️ Not intended to merge. Demo only for the [git-flow branching proposal](https://ethyca.atlassian.net/wiki/spaces/EN/pages/4544528386).

## Test plan

- [x] Python parses all three migrations correctly
- [x] Chain visualization confirms single head after merge
- [ ] (optional) Run `alembic upgrade head` in a test DB to confirm execution order

🤖 Generated with [Claude Code](https://claude.com/claude-code)