### PR TITLE
Fix migration downgrade: use raw SQL for DROP INDEX IF EXISTS

### DIFF
--- a/src/fides/api/alembic/migrations/versions/xx_2026_04_10_1000_c5d6e7f8a9b0_add_composite_created_at_id_index.py
+++ b/src/fides/api/alembic/migrations/versions/xx_2026_04_10_1000_c5d6e7f8a9b0_add_composite_created_at_id_index.py
@@ -45,16 +45,8 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_index(
-        CURRENT_INDEX_NAME,
-        table_name="privacy_preferences_current",
-        if_exists=True,
-    )
-    op.drop_index(
-        HISTORIC_INDEX_NAME,
-        table_name="privacy_preferences_historic",
-        if_exists=True,
-    )
+    op.execute(sa.text(f"DROP INDEX IF EXISTS {CURRENT_INDEX_NAME}"))
+    op.execute(sa.text(f"DROP INDEX IF EXISTS {HISTORIC_INDEX_NAME}"))
     op.execute(
         sa.text(
             "DELETE FROM post_upgrade_background_migration_tasks "

--- a/src/fides/api/alembic/migrations/versions/xx_2026_04_10_1000_c5d6e7f8a9b0_add_composite_created_at_id_index.py
+++ b/src/fides/api/alembic/migrations/versions/xx_2026_04_10_1000_c5d6e7f8a9b0_add_composite_created_at_id_index.py
@@ -45,6 +45,9 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    # Raw SQL because op.drop_index(..., if_exists=True) requires alembic>=1.12
+    # and we pin 1.8.1. The indexes may not exist yet if the background task
+    # hasn't run, so IF EXISTS is necessary.
     op.execute(sa.text(f"DROP INDEX IF EXISTS {CURRENT_INDEX_NAME}"))
     op.execute(sa.text(f"DROP INDEX IF EXISTS {HISTORIC_INDEX_NAME}"))
     op.execute(


### PR DESCRIPTION
### Description Of Changes

The `c5d6e7f8a9b0` migration downgrade used `op.drop_index(..., if_exists=True)`, which requires alembic >= 1.12. We pin alembic == 1.8.1, so this would raise a `TypeError` at downgrade time. Replaced with raw SQL `DROP INDEX IF EXISTS` which works on any alembic version.

### Code Changes

* Replaced `op.drop_index(..., if_exists=True)` calls in the `c5d6e7f8a9b0` migration downgrade with `op.execute(sa.text("DROP INDEX IF EXISTS ..."))` 

### Steps to Confirm

1. Run `alembic downgrade` past revision `c5d6e7f8a9b0` — should succeed whether or not the indexes were created by the background task

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [x] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [x] Ensure that your downrev is up to date with the latest revision on `main`
  * [x] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required