### PR TITLE
ENG-3508: Fix integration form fields blank after creation

### DIFF
--- a/changelog/7986-fix-integration-form-caching.yaml
+++ b/changelog/7986-fix-integration-form-caching.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Fixed integration form fields blank after creation until page reload
+pr: 7986
+labels: []

--- a/clients/admin-ui/src/features/common/form/useFormFieldsFromSchema.ts
+++ b/clients/admin-ui/src/features/common/form/useFormFieldsFromSchema.ts
@@ -15,21 +15,21 @@ export const useFormFieldsFromSchema = (
     value: string | undefined,
     type?: string,
   ) => {
-    let error;
-    if (typeof value === "undefined" || value === "" || value === undefined) {
-      error = `${label} is required`;
+    // Required validation is handled by the Form.Item `required` rule in
+    // FormFieldFromSchema. This function only does format validation.
+    if (!value) {
+      return undefined;
     }
     if (type === FIDES_DATASET_REFERENCE) {
-      if (!value?.includes(".")) {
-        error = "Dataset reference must be dot delimited";
-      } else {
-        const parts = value.split(".");
-        if (parts.length < 3) {
-          error = "Dataset reference must include at least three parts";
-        }
+      if (!value.includes(".")) {
+        return "Dataset reference must be dot delimited";
+      }
+      const parts = value.split(".");
+      if (parts.length < 3) {
+        return "Dataset reference must include at least three parts";
       }
     }
-    return error;
+    return undefined;
   };
 
   const isRequiredField = (key: string): boolean =>
@@ -39,9 +39,10 @@ export const useFormFieldsFromSchema = (
     key: string,
     fieldSchema: ConnectionTypeSecretSchemaProperty,
   ) => {
-    if (isRequiredField(key)) {
+    const refType = fieldSchema.allOf?.[0].$ref;
+    if (refType) {
       return (value: string | undefined) =>
-        validateField(fieldSchema.title, value, fieldSchema.allOf?.[0].$ref);
+        validateField(fieldSchema.title, value, refType);
     }
     return undefined;
   };

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParameters.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParameters.tsx
@@ -52,6 +52,13 @@ import {
 } from "./ConnectorParametersForm";
 import { generateIntegrationKey } from "./helpers";
 
+const DEFAULT_VALUES: ConnectionConfigFormValues = {
+  description: "",
+  instance_key: "",
+  name: "",
+  dataset: [],
+};
+
 /**
  * Only handles creating saas connectors. The BE handler automatically
  * configures the connector using the saas config and creates the
@@ -406,13 +413,6 @@ export const ConnectorParameters = ({
     setSelectedConnectionOption,
   });
 
-  const defaultValues: ConnectionConfigFormValues = {
-    description: "",
-    instance_key: "",
-    name: "",
-    dataset: [],
-  };
-
   if (!secretsSchema && connectionOption.type !== SystemType.MANUAL) {
     return null;
   }
@@ -443,7 +443,7 @@ export const ConnectorParameters = ({
       </Box>
       <ConnectorParametersForm
         secretsSchema={secretsSchema}
-        defaultValues={defaultValues}
+        defaultValues={DEFAULT_VALUES}
         isSubmitting={isSubmitting}
         isAuthorizing={isAuthorizing}
         onSaveClick={handleSubmit}

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParametersForm.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParametersForm.tsx
@@ -17,7 +17,7 @@ import {
   useMessage,
 } from "fidesui";
 import _ from "lodash";
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo } from "react";
 import { DatastoreConnectionStatus } from "src/features/datastore-connections/types";
 
 import { useFeatures } from "~/features/common/features";
@@ -179,9 +179,25 @@ export const ConnectorParametersForm = ({
     connectionOption,
   ]);
 
+  useEffect(() => {
+    form.setFieldsValue(initialFormValues);
+  }, [form, initialFormValues]);
+
   const handleFinish = async (values: ConnectionConfigFormValues) => {
     const processedValues = preprocessValues(values);
     await onSaveClick(processedValues);
+
+    // After a successful create, mask secrets immediately so the user sees
+    // stars instead of blank fields while waiting for the refetch.
+    if (!isEditingConnection && secretsSchema) {
+      const maskedSecrets: Record<string, string> = {};
+      Object.keys(secretsSchema.properties).forEach((key) => {
+        if (processedValues.secrets[key]) {
+          maskedSecrets[key] = "**********";
+        }
+      });
+      form.setFieldsValue({ secrets: maskedSecrets });
+    }
 
     // Save property assignments if editing
     if (

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParametersForm.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParametersForm.tsx
@@ -180,8 +180,10 @@ export const ConnectorParametersForm = ({
   ]);
 
   useEffect(() => {
-    form.setFieldsValue(initialFormValues);
-  }, [form, initialFormValues]);
+    if (isEditingConnection) {
+      form.setFieldsValue(initialFormValues);
+    }
+  }, [form, initialFormValues, isEditingConnection]);
 
   const handleFinish = async (values: ConnectionConfigFormValues) => {
     const processedValues = preprocessValues(values);

--- a/clients/admin-ui/src/features/integrations/add-integration/ConfigureIntegrationForm.tsx
+++ b/clients/admin-ui/src/features/integrations/add-integration/ConfigureIntegrationForm.tsx
@@ -204,10 +204,6 @@ export const ConfigureIntegrationForm = ({
 
   const [form] = Form.useForm<FormValues>();
 
-  useEffect(() => {
-    form.setFieldsValue(initialValues);
-  }, [form, initialValues]);
-
   const messageApi = useMessage();
 
   const isSaas = connectionOption.type === SystemType.SAAS;

--- a/clients/admin-ui/src/features/integrations/add-integration/ConfigureIntegrationForm.tsx
+++ b/clients/admin-ui/src/features/integrations/add-integration/ConfigureIntegrationForm.tsx
@@ -8,7 +8,7 @@ import {
   Text,
   useMessage,
 } from "fidesui";
-import { isEmpty, isUndefined, mapValues, omitBy } from "lodash";
+import { isEmpty, isEqual, isUndefined, mapValues, omitBy } from "lodash";
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
@@ -423,7 +423,10 @@ export const ConfigureIntegrationForm = ({
   // Form state tracking for parent component
   const allValues = Form.useWatch([], form);
   const [submittable, setSubmittable] = useState(false);
-  const isDirty = form.isFieldsTouched();
+  const isDirty = useMemo(
+    () => allValues !== undefined && !isEqual(allValues, initialValues),
+    [allValues, initialValues],
+  );
 
   useEffect(() => {
     form

--- a/clients/admin-ui/src/features/integrations/add-integration/ConfigureIntegrationForm.tsx
+++ b/clients/admin-ui/src/features/integrations/add-integration/ConfigureIntegrationForm.tsx
@@ -204,6 +204,10 @@ export const ConfigureIntegrationForm = ({
 
   const [form] = Form.useForm<FormValues>();
 
+  useEffect(() => {
+    form.setFieldsValue(initialValues);
+  }, [form, initialValues]);
+
   const messageApi = useMessage();
 
   const isSaas = connectionOption.type === SystemType.SAAS;


### PR DESCRIPTION
Ticket [ENG-3508]

### Description Of Changes

After creating a new integration on the system portal, antd Form fields were blank (e.g. "Integration identifier" showed as read-only but empty). A full page reload populated them correctly. This was caused by antd Form only consuming `initialValues` on mount -- the Formik-to-antd migration removed `enableReinitialize` behavior without a replacement.

Also fixed duplicate "is required" validation messages on secrets fields, where both the Form.Item `required` rule and a custom validator were producing the same error.

### Code Changes

* **`ConnectorParametersForm.tsx`** - Added `useEffect` with `form.setFieldsValue(initialFormValues)` to sync form values when async data arrives after mount (secrets, datasets, properties). Also masks secrets with stars immediately after successful create instead of waiting for refetch.
* **`ConnectorParameters.tsx`** - Hoisted `defaultValues` to a module-level constant to prevent `initialFormValues` from recomputing on every render (which would clobber user edits via the new `useEffect`).
* **`ConfigureIntegrationForm.tsx`** - Same `useEffect` pattern for the integration page modal form.
* **`useFormFieldsFromSchema.ts`** - Removed redundant required-field check from `validateField` (the Form.Item `required` rule already handles it), fixing duplicate error messages. Custom validator now only returns for fields needing format validation.

### Steps to Confirm

1. Go to a System page -> Integrations tab -> Add a new integration (e.g. BigQuery)
2. Fill in name and credentials, click Save
3. Confirm all fields populate immediately after save (name, Integration identifier, secrets show as masked stars)
4. Refresh the page and confirm the same data persists
5. Edit a field, confirm the edit is preserved (not overwritten)
6. Submit the form with an empty required field, confirm the error message appears only once

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required

[ENG-3508]: https://ethyca.atlassian.net/browse/ENG-3508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ