### PR TITLE
ENG-3543: Fix Ticket setup tab appearing on non-Jira integrations

### DIFF
--- a/changelog/7987-fix-jira-ticket-setup-tab.yaml
+++ b/changelog/7987-fix-jira-ticket-setup-tab.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Fixed Ticket setup tab appearing on non-Jira integrations
+pr: 7987
+labels: []

--- a/clients/admin-ui/src/features/integrations/hooks/useFeatureBasedTabs.tsx
+++ b/clients/admin-ui/src/features/integrations/hooks/useFeatureBasedTabs.tsx
@@ -224,7 +224,10 @@ export const useFeatureBasedTabs = ({
       });
     }
 
-    if (enabledFeatures?.includes(IntegrationFeature.DSR_AUTOMATION)) {
+    if (
+      enabledFeatures?.includes(IntegrationFeature.DSR_AUTOMATION) &&
+      connection?.connection_type === ConnectionType.JIRA_TICKET
+    ) {
       tabItems.push({
         label: "Ticket setup",
         key: "configuration",


### PR DESCRIPTION
Ticket [ENG-3543]

### Description Of Changes

The "Ticket setup" tab (which renders `JiraConfigTab`) was appearing on non-Jira integrations that have `DSR_AUTOMATION` in their `enabledFeatures`, such as Salesforce and any dynamically-loaded integration using the default feature set. Added a `connection_type === JIRA_TICKET` guard so the tab only renders for actual Jira connections.

### Code Changes

* Added `connection?.connection_type === ConnectionType.JIRA_TICKET` check to the `DSR_AUTOMATION` feature gate in `useFeatureBasedTabs.tsx`

### Steps to Confirm

1. Navigate to a Jira ticketing integration detail page — verify the "Ticket setup" tab is present
2. Navigate to a Salesforce integration detail page — verify the "Ticket setup" tab is **not** present
3. Navigate to any other non-Jira integration — verify the "Ticket setup" tab is **not** present
4. Verify all other tabs (Connection, Linked system, Data discovery, etc.) still render correctly

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required

[ENG-3543]: https://ethyca.atlassian.net/browse/ENG-3543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ