### PR TITLE
Scope check_object_exists to current PostgreSQL schema

### DIFF
--- a/changelog/7990-scope-check-object-exists-to-schema.yaml
+++ b/changelog/7990-scope-check-object-exists-to-schema.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Fixed background index creation skipping indexes on shared-database staging environments
+pr: 7990
+labels: []

--- a/src/fides/api/migrations/post_upgrade_index_creation.py
+++ b/src/fides/api/migrations/post_upgrade_index_creation.py
@@ -281,10 +281,13 @@ def check_object_exists(db: Session, object_name: str) -> bool:
             SELECT 1
             FROM pg_indexes
             WHERE indexname = :object_name
+              AND schemaname = current_schema()
         ) OR EXISTS (
             SELECT 1
-            FROM pg_constraint
-            WHERE conname = :object_name
+            FROM pg_constraint c
+            JOIN pg_namespace n ON c.connamespace = n.oid
+            WHERE c.conname = :object_name
+              AND n.nspname = current_schema()
         )
         """
     )


### PR DESCRIPTION
### Description Of Changes

On shared-database staging environments (where multiple environments use separate PostgreSQL schemas on the same DB), the `check_object_exists` function in the post-upgrade background index creation task was querying `pg_indexes` and `pg_constraint` **without filtering by schema**. This caused it to find indexes created by other environments (e.g., `nightly`) and incorrectly skip creation in the current environment (e.g., `plus-rc`), while still marking `completed_at` in the tracking table.

The result: indexes were missing in some environments but the `post_upgrade_background_migration_tasks` table said they were created.

### Code Changes

* Add `AND schemaname = current_schema()` filter to the `pg_indexes` query in `check_object_exists`
* Add `JOIN pg_namespace` and `AND n.nspname = current_schema()` filter to the `pg_constraint` query in `check_object_exists`

### Steps to Confirm

1. On a shared-database staging environment, clear `completed_at` for any background index task: `UPDATE post_upgrade_background_migration_tasks SET completed_at = NULL WHERE key = 'idx_privacy_preferences_current_created_at_id';`
2. Restart the webserver
3. Verify `completed_at` is re-populated and the index exists in the correct schema

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required