### PR TITLE
Add Fides.matomo() integration helper

### DIFF
--- a/changelog/7991-fides-matomo-integration.yaml
+++ b/changelog/7991-fides-matomo-integration.yaml
@@ -1,0 +1,4 @@
+type: Added
+description: Add `Fides.matomo()` integration helper
+pr: 7991
+labels: []

--- a/clients/fides-js/__tests__/integrations/matomo.test.ts
+++ b/clients/fides-js/__tests__/integrations/matomo.test.ts
@@ -53,23 +53,50 @@ describe("matomo", () => {
   });
 
   describe("requireConsent idempotency", () => {
-    test("does not push requireConsent again on subsequent events", () => {
+    test("pushes requireConsent exactly once at init, not on subsequent events", () => {
       setupFidesWithConsent({ analytics: true });
       matomo();
 
-      // Synthetic event fired synchronously; record state
-      const lengthAfterInit = getPaq().length;
-
-      // Dispatch another event
-      triggerConsentEvent("FidesUpdated", { analytics: false });
-
-      // Only this matomo() instance's handler should have fired.
-      // Commands after init should NOT include another requireConsent.
-      const newCommands = getPaq().slice(lengthAfterInit);
-      const requireCalls = newCommands.filter(
+      // requireConsent is pushed synchronously at call time, before any event
+      // fires. Synthetic event then pushes the grant. Count should be 1.
+      const requireCallsAfterInit = getPaq().filter(
         (cmd) => cmd[0] === "requireConsent",
       );
-      expect(requireCalls).toHaveLength(0);
+      expect(requireCallsAfterInit).toHaveLength(1);
+
+      triggerConsentEvent("FidesUpdated", { analytics: false });
+
+      const requireCallsAfterEvent = getPaq().filter(
+        (cmd) => cmd[0] === "requireConsent",
+      );
+      expect(requireCallsAfterEvent).toHaveLength(1);
+    });
+
+    test("subsequent events push grants/revokes to current window._paq (orphan guard)", () => {
+      // Mirrors what matomo.js does at runtime: after processing the queued
+      // Array, it swaps window._paq with a wrapper object whose `push`
+      // forwards to the live Tracker. Subsequent events must push to the NEW
+      // _paq, not to an orphaned pre-swap reference.
+      setupFidesWithConsent({ analytics: true });
+      matomo();
+
+      const wrapperCalls: unknown[][] = [];
+      const wrapper = {
+        push: (cmd: unknown[]) => {
+          wrapperCalls.push(cmd);
+          return 0;
+        },
+      };
+      setPaq(wrapper as unknown as unknown[][]);
+
+      triggerConsentEvent("FidesUpdated", { analytics: false });
+
+      expect(wrapperCalls).toEqual(
+        expect.arrayContaining([
+          ["forgetConsentGiven"],
+          ["forgetCookieConsentGiven"],
+        ]),
+      );
     });
   });
 
@@ -88,21 +115,24 @@ describe("matomo", () => {
     });
   });
 
-  describe("Conditional requireConsent", () => {
-    test("pushes requireConsent on first event when consent key is present", () => {
-      setupFidesWithConsent({ analytics: true });
+  describe("requireConsent timing", () => {
+    test("pushes requireConsent synchronously at call time, before any event fires", () => {
+      // Fides is not initialized yet; no synthetic event should fire.
+      window.Fides = undefined as any;
       matomo();
 
-      expect(getPaq()).toEqual(expect.arrayContaining([["requireConsent"]]));
+      // requireConsent must already be in the queue by the time matomo()
+      // returns, so it lands ahead of the site's Matomo tracker snippet.
+      expect(getPaq()).toEqual([["requireConsent"]]);
     });
 
-    test("does NOT push requireConsent when consent key is absent (OMIT mode)", () => {
+    test("pushes requireConsent regardless of whether consent key is present (OMIT mode)", () => {
+      // Even in OMIT mode we push requireConsent up front; the event handler
+      // then grants consent to unblock tracking.
       setupFidesWithConsent({ essential: true });
       matomo();
 
-      expect(getPaq()).not.toEqual(
-        expect.arrayContaining([["requireConsent"]]),
-      );
+      expect(getPaq()).toEqual(expect.arrayContaining([["requireConsent"]]));
     });
   });
 
@@ -247,11 +277,18 @@ describe("matomo", () => {
       );
     });
 
-    test("takes no action when neither key is present", () => {
+    test("grants consent when neither analytics nor performance key is present (OMIT)", () => {
       setupFidesWithConsent({ marketing: true });
       matomo();
 
-      expect(getPaq()).toEqual([]);
+      // requireConsent pushed at init, then a grant to unblock tracking.
+      expect(getPaq()).toEqual(
+        expect.arrayContaining([["requireConsent"], ["rememberConsentGiven"]]),
+      );
+      // No revoke commands
+      expect(getPaq()).not.toEqual(
+        expect.arrayContaining([["forgetConsentGiven"]]),
+      );
     });
   });
 
@@ -285,13 +322,16 @@ describe("matomo", () => {
   });
 
   describe("Non-applicable flag modes", () => {
-    test("OMIT mode: no consent key, Matomo tracks freely", () => {
-      // Simulates OMIT mode where the analytics key is absent
+    test("OMIT mode: no consent key, Matomo is granted consent to unblock tracking", () => {
+      // Simulates OMIT mode where the analytics key is absent. We push
+      // requireConsent up front to be safe, then grant on the event so
+      // tracking actually flows in jurisdictions where consent isn't required.
       setupFidesWithConsent({});
       matomo();
 
-      // No requireConsent, no grant, no revoke
-      expect(getPaq()).toEqual([]);
+      expect(getPaq()).toEqual(
+        expect.arrayContaining([["requireConsent"], ["rememberConsentGiven"]]),
+      );
     });
 
     test("INCLUDE mode with boolean: key present as true, consent granted", () => {
@@ -325,11 +365,13 @@ describe("matomo", () => {
     });
 
     test("responds to FidesUpdated events", () => {
-      window.Fides = { consent: {}, initialized: false } as any as FidesGlobal;
+      // No Fides.consent on window → synthetic event does not fire.
+      window.Fides = { initialized: false } as any as FidesGlobal;
       matomo();
 
-      // Initially no commands (no consent key)
-      expect(getPaq()).toEqual([]);
+      // requireConsent pushed synchronously at init; no grant/revoke yet
+      // because no synthetic event fired and no real event has been dispatched.
+      expect(getPaq()).toEqual([["requireConsent"]]);
 
       // Now consent arrives via event
       triggerConsentEvent("FidesUpdated", { analytics: false });

--- a/clients/fides-js/__tests__/integrations/matomo.test.ts
+++ b/clients/fides-js/__tests__/integrations/matomo.test.ts
@@ -52,8 +52,6 @@ describe("matomo", () => {
     window.Fides = undefined as any;
   });
 
-  // NOTE: This test must run before other matomo() calls to avoid leaked event
-  // listeners from prior tests (subscribeToConsent listeners cannot be removed).
   describe("requireConsent idempotency", () => {
     test("does not push requireConsent again on subsequent events", () => {
       setupFidesWithConsent({ analytics: true });

--- a/clients/fides-js/__tests__/integrations/matomo.test.ts
+++ b/clients/fides-js/__tests__/integrations/matomo.test.ts
@@ -195,6 +195,24 @@ describe("matomo", () => {
       );
     });
 
+    test("pushes setConsentGiven and setCookieConsentGiven when granted with rememberConsent: false", () => {
+      setupFidesWithConsent({ analytics: true });
+      matomo({ consentMode: "both", rememberConsent: false });
+
+      expect(getPaq()).toEqual(
+        expect.arrayContaining([
+          ["setConsentGiven"],
+          ["setCookieConsentGiven"],
+        ]),
+      );
+      expect(getPaq()).not.toEqual(
+        expect.arrayContaining([["rememberConsentGiven"]]),
+      );
+      expect(getPaq()).not.toEqual(
+        expect.arrayContaining([["rememberCookieConsentGiven"]]),
+      );
+    });
+
     test("pushes both revoke commands when consent is revoked", () => {
       setupFidesWithConsent({ analytics: false });
       matomo({ consentMode: "both" });

--- a/clients/fides-js/__tests__/integrations/matomo.test.ts
+++ b/clients/fides-js/__tests__/integrations/matomo.test.ts
@@ -1,0 +1,326 @@
+import { FidesGlobal } from "../../src/fides";
+import { matomo } from "../../src/integrations/matomo";
+
+// Mock fidesDebugger global
+/* eslint-disable */
+// @ts-ignore
+globalThis.fidesDebugger = jest.fn();
+/* eslint-enable */
+
+// Helpers to avoid eslint no-underscore-dangle errors with window._paq
+const PAQ = "_paq" as const;
+const getPaq = (): unknown[][] => (window as any)[PAQ];
+const setPaq = (value: unknown[][]) => {
+  (window as any)[PAQ] = value;
+};
+const deletePaq = () => {
+  delete (window as any)[PAQ];
+};
+
+/**
+ * Setup Fides with consent
+ */
+const setupFidesWithConsent = (consent: Record<string, boolean | string>) => {
+  window.Fides = {
+    consent,
+    initialized: true,
+  } as any as FidesGlobal;
+};
+
+/**
+ * Trigger a Fides consent event
+ */
+const triggerConsentEvent = (
+  eventName: string,
+  consent: Record<string, boolean | string>,
+) => {
+  window.dispatchEvent(
+    new CustomEvent(eventName, {
+      detail: { consent },
+    }),
+  );
+};
+
+describe("matomo", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setPaq([]);
+  });
+
+  afterEach(() => {
+    deletePaq();
+    window.Fides = undefined as any;
+  });
+
+  // NOTE: This test must run before other matomo() calls to avoid leaked event
+  // listeners from prior tests (subscribeToConsent listeners cannot be removed).
+  describe("requireConsent idempotency", () => {
+    test("does not push requireConsent again on subsequent events", () => {
+      setupFidesWithConsent({ analytics: true });
+      matomo();
+
+      // Synthetic event fired synchronously; record state
+      const lengthAfterInit = getPaq().length;
+
+      // Dispatch another event
+      triggerConsentEvent("FidesUpdated", { analytics: false });
+
+      // Only this matomo() instance's handler should have fired.
+      // Commands after init should NOT include another requireConsent.
+      const newCommands = getPaq().slice(lengthAfterInit);
+      const requireCalls = newCommands.filter(
+        (cmd) => cmd[0] === "requireConsent",
+      );
+      expect(requireCalls).toHaveLength(0);
+    });
+  });
+
+  describe("_paq initialization", () => {
+    test("creates _paq if it does not exist", () => {
+      deletePaq();
+      matomo();
+      expect(Array.isArray(getPaq())).toBe(true);
+    });
+
+    test("reuses existing _paq", () => {
+      const existing: unknown[][] = [["existingCommand"]];
+      setPaq(existing);
+      matomo();
+      expect(getPaq()).toBe(existing);
+    });
+  });
+
+  describe("Conditional requireConsent", () => {
+    test("pushes requireConsent on first event when consent key is present", () => {
+      setupFidesWithConsent({ analytics: true });
+      matomo();
+
+      expect(getPaq()).toEqual(expect.arrayContaining([["requireConsent"]]));
+    });
+
+    test("does NOT push requireConsent when consent key is absent (OMIT mode)", () => {
+      setupFidesWithConsent({ essential: true });
+      matomo();
+
+      expect(getPaq()).not.toEqual(
+        expect.arrayContaining([["requireConsent"]]),
+      );
+    });
+  });
+
+  describe("Tracking consent mode", () => {
+    test("pushes rememberConsentGiven when granted (default rememberConsent: true)", () => {
+      setupFidesWithConsent({ analytics: true });
+      matomo({ consentMode: "tracking" });
+
+      expect(getPaq()).toEqual(
+        expect.arrayContaining([["requireConsent"], ["rememberConsentGiven"]]),
+      );
+    });
+
+    test("pushes setConsentGiven when granted with rememberConsent: false", () => {
+      setupFidesWithConsent({ analytics: true });
+      matomo({ consentMode: "tracking", rememberConsent: false });
+
+      expect(getPaq()).toEqual(expect.arrayContaining([["setConsentGiven"]]));
+      expect(getPaq()).not.toEqual(
+        expect.arrayContaining([["rememberConsentGiven"]]),
+      );
+    });
+
+    test("pushes forgetConsentGiven when revoked", () => {
+      setupFidesWithConsent({ analytics: false });
+      matomo({ consentMode: "tracking" });
+
+      expect(getPaq()).toEqual(
+        expect.arrayContaining([["requireConsent"], ["forgetConsentGiven"]]),
+      );
+    });
+  });
+
+  describe("Cookie consent mode", () => {
+    test("pushes requireCookieConsent and rememberCookieConsentGiven when granted", () => {
+      setupFidesWithConsent({ analytics: true });
+      matomo({ consentMode: "cookie" });
+
+      expect(getPaq()).toEqual(
+        expect.arrayContaining([
+          ["requireCookieConsent"],
+          ["rememberCookieConsentGiven"],
+        ]),
+      );
+      expect(getPaq()).not.toEqual(
+        expect.arrayContaining([["requireConsent"]]),
+      );
+    });
+
+    test("pushes setCookieConsentGiven when granted with rememberConsent: false", () => {
+      setupFidesWithConsent({ analytics: true });
+      matomo({ consentMode: "cookie", rememberConsent: false });
+
+      expect(getPaq()).toEqual(
+        expect.arrayContaining([["setCookieConsentGiven"]]),
+      );
+    });
+
+    test("pushes forgetCookieConsentGiven when revoked", () => {
+      setupFidesWithConsent({ analytics: false });
+      matomo({ consentMode: "cookie" });
+
+      expect(getPaq()).toEqual(
+        expect.arrayContaining([["forgetCookieConsentGiven"]]),
+      );
+    });
+  });
+
+  describe("Both consent mode", () => {
+    test("pushes both require commands on init", () => {
+      setupFidesWithConsent({ analytics: true });
+      matomo({ consentMode: "both" });
+
+      expect(getPaq()).toEqual(
+        expect.arrayContaining([["requireConsent"], ["requireCookieConsent"]]),
+      );
+    });
+
+    test("pushes both grant commands when consent is granted", () => {
+      setupFidesWithConsent({ analytics: true });
+      matomo({ consentMode: "both" });
+
+      expect(getPaq()).toEqual(
+        expect.arrayContaining([
+          ["rememberConsentGiven"],
+          ["rememberCookieConsentGiven"],
+        ]),
+      );
+    });
+
+    test("pushes both revoke commands when consent is revoked", () => {
+      setupFidesWithConsent({ analytics: false });
+      matomo({ consentMode: "both" });
+
+      expect(getPaq()).toEqual(
+        expect.arrayContaining([
+          ["forgetConsentGiven"],
+          ["forgetCookieConsentGiven"],
+        ]),
+      );
+    });
+  });
+
+  describe("Consent key resolution", () => {
+    test("uses analytics key when present", () => {
+      setupFidesWithConsent({ analytics: true, performance: false });
+      matomo();
+
+      // analytics=true should result in grant, not revoke
+      expect(getPaq()).toEqual(
+        expect.arrayContaining([["rememberConsentGiven"]]),
+      );
+      expect(getPaq()).not.toEqual(
+        expect.arrayContaining([["forgetConsentGiven"]]),
+      );
+    });
+
+    test("falls back to performance key when analytics is absent", () => {
+      setupFidesWithConsent({ performance: true });
+      matomo();
+
+      expect(getPaq()).toEqual(
+        expect.arrayContaining([["requireConsent"], ["rememberConsentGiven"]]),
+      );
+    });
+
+    test("takes no action when neither key is present", () => {
+      setupFidesWithConsent({ marketing: true });
+      matomo();
+
+      expect(getPaq()).toEqual([]);
+    });
+  });
+
+  describe("Consent value normalization", () => {
+    test("handles string opt_in", () => {
+      setupFidesWithConsent({ analytics: "opt_in" });
+      matomo();
+
+      expect(getPaq()).toEqual(
+        expect.arrayContaining([["rememberConsentGiven"]]),
+      );
+    });
+
+    test("handles string opt_out", () => {
+      setupFidesWithConsent({ analytics: "opt_out" });
+      matomo();
+
+      expect(getPaq()).toEqual(
+        expect.arrayContaining([["forgetConsentGiven"]]),
+      );
+    });
+
+    test("handles string acknowledge as granted", () => {
+      setupFidesWithConsent({ analytics: "acknowledge" });
+      matomo();
+
+      expect(getPaq()).toEqual(
+        expect.arrayContaining([["rememberConsentGiven"]]),
+      );
+    });
+  });
+
+  describe("Non-applicable flag modes", () => {
+    test("OMIT mode: no consent key, Matomo tracks freely", () => {
+      // Simulates OMIT mode where the analytics key is absent
+      setupFidesWithConsent({});
+      matomo();
+
+      // No requireConsent, no grant, no revoke
+      expect(getPaq()).toEqual([]);
+    });
+
+    test("INCLUDE mode with boolean: key present as true, consent granted", () => {
+      // Simulates INCLUDE mode where non-applicable key is set to true
+      setupFidesWithConsent({ analytics: true });
+      matomo();
+
+      expect(getPaq()).toEqual(
+        expect.arrayContaining([["requireConsent"], ["rememberConsentGiven"]]),
+      );
+    });
+  });
+
+  describe("Event subscription", () => {
+    test.each(["FidesReady", "FidesUpdated"])(
+      "subscribes to %s event",
+      (eventName) => {
+        const spy = jest.spyOn(window, "addEventListener");
+        matomo();
+        expect(spy).toHaveBeenCalledWith(eventName, expect.any(Function));
+      },
+    );
+
+    test("pushes consent immediately if Fides is already initialized (synthetic event)", () => {
+      setupFidesWithConsent({ analytics: true });
+      matomo();
+
+      expect(getPaq()).toEqual(
+        expect.arrayContaining([["rememberConsentGiven"]]),
+      );
+    });
+
+    test("responds to FidesUpdated events", () => {
+      window.Fides = { consent: {}, initialized: false } as any as FidesGlobal;
+      matomo();
+
+      // Initially no commands (no consent key)
+      expect(getPaq()).toEqual([]);
+
+      // Now consent arrives via event
+      triggerConsentEvent("FidesUpdated", { analytics: false });
+
+      expect(getPaq()).toEqual(
+        expect.arrayContaining([["requireConsent"], ["forgetConsentGiven"]]),
+      );
+    });
+  });
+});

--- a/clients/fides-js/docs/interfaces/Fides.md
+++ b/clients/fides-js/docs/interfaces/Fides.md
@@ -511,7 +511,8 @@ with Matomo's tracking consent and/or cookie consent APIs via `_paq.push()`.
 The integration automatically detects whether consent is applicable based on
 the presence of consent keys in the Fides consent object. When consent is not
 applicable (e.g. user is in a non-consent jurisdiction), Matomo is left in its
-default state and tracks freely.
+default state and tracks freely. Note: the integration looks for `analytics`
+or `performance` consent keys specifically.
 
 #### Parameters
 

--- a/clients/fides-js/docs/interfaces/Fides.md
+++ b/clients/fides-js/docs/interfaces/Fides.md
@@ -500,6 +500,67 @@ With custom consent mapping:
 
 ***
 
+### matomo()
+
+> **matomo**: (`options`?) => `void`
+
+Enable the Matomo integration. This should be called immediately after
+FidesJS is included. Once enabled, FidesJS will automatically sync consent
+with Matomo's tracking consent and/or cookie consent APIs via `_paq.push()`.
+
+The integration automatically detects whether consent is applicable based on
+the presence of consent keys in the Fides consent object. When consent is not
+applicable (e.g. user is in a non-consent jurisdiction), Matomo is left in its
+default state and tracks freely.
+
+#### Parameters
+
+| Parameter | Type | Description |
+| ------ | ------ | ------ |
+| `options`? | \{ `consentMode`: `"tracking"` \| `"cookie"` \| `"both"`; `rememberConsent`: `boolean`; \} | Optional configuration for the Matomo integration |
+| `options.consentMode`? | `"tracking"` \| `"cookie"` \| `"both"` | Which Matomo consent mechanism to manage: "tracking" (default), "cookie", or "both" |
+| `options.rememberConsent`? | `boolean` | Whether to persist consent via Matomo's mtm_consent cookie (default: true). When false, uses session-only consent that must be re-established on each page load. |
+
+#### Returns
+
+`void`
+
+#### Examples
+
+Basic usage in your site's `<head>`:
+```html
+<head>
+  <script src="path/to/fides.js"></script>
+  <script>Fides.matomo()</script>
+</head>
+```
+
+Managing both tracking and cookie consent:
+```html
+<head>
+  <script src="path/to/fides.js"></script>
+  <script>
+    Fides.matomo({
+      consentMode: "both"
+    });
+  </script>
+</head>
+```
+
+Using session-only consent (no Matomo cookie persistence):
+```html
+<head>
+  <script src="path/to/fides.js"></script>
+  <script>
+    Fides.matomo({
+      rememberConsent: false
+    });
+  </script>
+</head>
+```
+
+***
+
 ### shopify()
 
 > **shopify**: (`options`?) => `void`

--- a/clients/fides-js/docs/interfaces/Fides.md
+++ b/clients/fides-js/docs/interfaces/Fides.md
@@ -504,23 +504,30 @@ With custom consent mapping:
 
 > **matomo**: (`options`?) => `void`
 
-Enable the Matomo integration. This should be called immediately after
-FidesJS is included. Once enabled, FidesJS will automatically sync consent
-with Matomo's tracking consent and/or cookie consent APIs via `_paq.push()`.
+Enable the Matomo integration. FidesJS will automatically sync consent
+with Matomo's tracking and/or cookie consent APIs via `_paq.push()`.
 
-The integration automatically detects whether consent is applicable based on
-the presence of consent keys in the Fides consent object. When consent is not
-applicable (e.g. user is in a non-consent jurisdiction), Matomo is left in its
-default state and tracks freely. Note: the integration looks for `analytics`
-or `performance` consent keys specifically.
+The integration looks for `analytics` or `performance` keys in the Fides
+consent object. When neither key is present (e.g. a non-consent
+jurisdiction), consent is granted to Matomo so tracking proceeds
+normally.
+
+### Call before your Matomo tracker snippet
+
+`Fides.matomo()` synchronously pushes `requireConsent` into `_paq` so
+Matomo enters consent-required mode before the first `trackPageView`.
+For this to work, **`Fides.matomo()` must run before the standard Matomo
+tracker snippet on the page**. If the order is reversed, `trackPageView`
+is queued ahead of `requireConsent` and the first page view fires
+without consent.
 
 #### Parameters
 
 | Parameter | Type | Description |
 | ------ | ------ | ------ |
 | `options`? | \{ `consentMode`: `"tracking"` \| `"cookie"` \| `"both"`; `rememberConsent`: `boolean`; \} | Optional configuration for the Matomo integration |
-| `options.consentMode`? | `"tracking"` \| `"cookie"` \| `"both"` | Which Matomo consent mechanism to manage: "tracking" (default), "cookie", or "both" |
-| `options.rememberConsent`? | `boolean` | Whether to persist consent via Matomo's mtm_consent cookie (default: true). When false, uses session-only consent that must be re-established on each page load. |
+| `options.consentMode`? | `"tracking"` \| `"cookie"` \| `"both"` | Which Matomo consent mechanism to manage: `"tracking"` (default), `"cookie"`, or `"both"` |
+| `options.rememberConsent`? | `boolean` | Persist consent via Matomo's `mtm_consent` cookie. Default `true`. Set `false` for session-only consent. |
 
 #### Returns
 
@@ -528,36 +535,29 @@ or `performance` consent keys specifically.
 
 #### Examples
 
-Basic usage in your site's `<head>`:
+Recommended page setup. `Fides.matomo()` runs before the Matomo tracker
+snippet so `requireConsent` is queued ahead of `trackPageView`:
 ```html
 <head>
   <script src="path/to/fides.js"></script>
-  <script>Fides.matomo()</script>
-</head>
-```
+  <script>Fides.matomo();</script>
 
-Managing both tracking and cookie consent:
-```html
-<head>
-  <script src="path/to/fides.js"></script>
+  <!-- Your standard Matomo tracker snippet goes here, unchanged -->
   <script>
-    Fides.matomo({
-      consentMode: "both"
-    });
+    var _paq = window._paq = window._paq || [];
+    // ... _paq.push(['trackPageView']), setTrackerUrl, setSiteId, etc.
   </script>
 </head>
 ```
 
-Using session-only consent (no Matomo cookie persistence):
+Manage both tracking and cookie consent:
 ```html
-<head>
-  <script src="path/to/fides.js"></script>
-  <script>
-    Fides.matomo({
-      rememberConsent: false
-    });
-  </script>
-</head>
+<script>Fides.matomo({ consentMode: "both" });</script>
+```
+
+Session-only consent (no `mtm_consent` cookie written by Matomo):
+```html
+<script>Fides.matomo({ rememberConsent: false });</script>
 ```
 
 ***

--- a/clients/fides-js/rollup.config.mjs
+++ b/clients/fides-js/rollup.config.mjs
@@ -313,6 +313,7 @@ const copyStub = {
     },
   ],
   onLog(level, log) {
+    // fides-stub.js is intentionally empty; suppress Rollup's EMPTY_BUNDLE warning
     if (log.code === "EMPTY_BUNDLE") return;
   },
 };

--- a/clients/fides-js/rollup.config.mjs
+++ b/clients/fides-js/rollup.config.mjs
@@ -312,6 +312,9 @@ const copyStub = {
       format: "es",
     },
   ],
+  onLog(level, log) {
+    if (log.code === "EMPTY_BUNDLE") return;
+  },
 };
 
 rollupOptions.push(copyStub);

--- a/clients/fides-js/src/docs/fides.ts
+++ b/clients/fides-js/src/docs/fides.ts
@@ -421,53 +421,53 @@ export interface Fides {
   }) => { consent: () => Record<string, "granted" | "denied"> | null };
 
   /**
-   * Enable the Matomo integration. This should be called immediately after
-   * FidesJS is included. Once enabled, FidesJS will automatically sync consent
-   * with Matomo's tracking consent and/or cookie consent APIs via `_paq.push()`.
+   * Enable the Matomo integration. FidesJS will automatically sync consent
+   * with Matomo's tracking and/or cookie consent APIs via `_paq.push()`.
    *
-   * The integration automatically detects whether consent is applicable based on
-   * the presence of consent keys in the Fides consent object. When consent is not
-   * applicable (e.g. user is in a non-consent jurisdiction), Matomo is left in its
-   * default state and tracks freely. Note: the integration looks for `analytics`
-   * or `performance` consent keys specifically.
+   * The integration looks for `analytics` or `performance` keys in the Fides
+   * consent object. When neither key is present (e.g. a non-consent
+   * jurisdiction), consent is granted to Matomo so tracking proceeds
+   * normally.
+   *
+   * ### Call before your Matomo tracker snippet
+   *
+   * `Fides.matomo()` synchronously pushes `requireConsent` into `_paq` so
+   * Matomo enters consent-required mode before the first `trackPageView`.
+   * For this to work, **`Fides.matomo()` must run before the standard Matomo
+   * tracker snippet on the page**. If the order is reversed, `trackPageView`
+   * is queued ahead of `requireConsent` and the first page view fires
+   * without consent.
    *
    * @param options - Optional configuration for the Matomo integration
-   * @param options.consentMode - Which Matomo consent mechanism to manage: "tracking" (default), "cookie", or "both"
-   * @param options.rememberConsent - Whether to persist consent via Matomo's mtm_consent cookie (default: true). When false, uses session-only consent that must be re-established on each page load.
+   * @param options.consentMode - Which Matomo consent mechanism to manage: `"tracking"` (default), `"cookie"`, or `"both"`
+   * @param options.rememberConsent - Persist consent via Matomo's `mtm_consent` cookie. Default `true`. Set `false` for session-only consent.
    *
    * @example
-   * Basic usage in your site's `<head>`:
+   * Recommended page setup. `Fides.matomo()` runs before the Matomo tracker
+   * snippet so `requireConsent` is queued ahead of `trackPageView`:
    * ```html
    * <head>
    *   <script src="path/to/fides.js"></script>
-   *   <script>Fides.matomo()</script>
-   * </head>
-   * ```
+   *   <script>Fides.matomo();</script>
    *
-   * @example
-   * Managing both tracking and cookie consent:
-   * ```html
-   * <head>
-   *   <script src="path/to/fides.js"></script>
+   *   <!-- Your standard Matomo tracker snippet goes here, unchanged -->
    *   <script>
-   *     Fides.matomo({
-   *       consentMode: "both"
-   *     });
+   *     var _paq = window._paq = window._paq || [];
+   *     // ... _paq.push(['trackPageView']), setTrackerUrl, setSiteId, etc.
    *   </script>
    * </head>
    * ```
    *
    * @example
-   * Using session-only consent (no Matomo cookie persistence):
+   * Manage both tracking and cookie consent:
    * ```html
-   * <head>
-   *   <script src="path/to/fides.js"></script>
-   *   <script>
-   *     Fides.matomo({
-   *       rememberConsent: false
-   *     });
-   *   </script>
-   * </head>
+   * <script>Fides.matomo({ consentMode: "both" });</script>
+   * ```
+   *
+   * @example
+   * Session-only consent (no `mtm_consent` cookie written by Matomo):
+   * ```html
+   * <script>Fides.matomo({ rememberConsent: false });</script>
    * ```
    */
   matomo: (options?: {

--- a/clients/fides-js/src/docs/fides.ts
+++ b/clients/fides-js/src/docs/fides.ts
@@ -428,7 +428,8 @@ export interface Fides {
    * The integration automatically detects whether consent is applicable based on
    * the presence of consent keys in the Fides consent object. When consent is not
    * applicable (e.g. user is in a non-consent jurisdiction), Matomo is left in its
-   * default state and tracks freely.
+   * default state and tracks freely. Note: the integration looks for `analytics`
+   * or `performance` consent keys specifically.
    *
    * @param options - Optional configuration for the Matomo integration
    * @param options.consentMode - Which Matomo consent mechanism to manage: "tracking" (default), "cookie", or "both"

--- a/clients/fides-js/src/docs/fides.ts
+++ b/clients/fides-js/src/docs/fides.ts
@@ -421,6 +421,60 @@ export interface Fides {
   }) => { consent: () => Record<string, "granted" | "denied"> | null };
 
   /**
+   * Enable the Matomo integration. This should be called immediately after
+   * FidesJS is included. Once enabled, FidesJS will automatically sync consent
+   * with Matomo's tracking consent and/or cookie consent APIs via `_paq.push()`.
+   *
+   * The integration automatically detects whether consent is applicable based on
+   * the presence of consent keys in the Fides consent object. When consent is not
+   * applicable (e.g. user is in a non-consent jurisdiction), Matomo is left in its
+   * default state and tracks freely.
+   *
+   * @param options - Optional configuration for the Matomo integration
+   * @param options.consentMode - Which Matomo consent mechanism to manage: "tracking" (default), "cookie", or "both"
+   * @param options.rememberConsent - Whether to persist consent via Matomo's mtm_consent cookie (default: true). When false, uses session-only consent that must be re-established on each page load.
+   *
+   * @example
+   * Basic usage in your site's `<head>`:
+   * ```html
+   * <head>
+   *   <script src="path/to/fides.js"></script>
+   *   <script>Fides.matomo()</script>
+   * </head>
+   * ```
+   *
+   * @example
+   * Managing both tracking and cookie consent:
+   * ```html
+   * <head>
+   *   <script src="path/to/fides.js"></script>
+   *   <script>
+   *     Fides.matomo({
+   *       consentMode: "both"
+   *     });
+   *   </script>
+   * </head>
+   * ```
+   *
+   * @example
+   * Using session-only consent (no Matomo cookie persistence):
+   * ```html
+   * <head>
+   *   <script src="path/to/fides.js"></script>
+   *   <script>
+   *     Fides.matomo({
+   *       rememberConsent: false
+   *     });
+   *   </script>
+   * </head>
+   * ```
+   */
+  matomo: (options?: {
+    consentMode?: "tracking" | "cookie" | "both";
+    rememberConsent?: boolean;
+  }) => void;
+
+  /**
    * Enable the Shopify integration. This should be called immediately after
    * FidesJS is included. Once enabled, FidesJS will automatically push all
    * consent updates to Shopify's Customer Privacy API, which can then be used

--- a/clients/fides-js/src/integrations/matomo.ts
+++ b/clients/fides-js/src/integrations/matomo.ts
@@ -47,10 +47,8 @@ const DEFAULT_CONSENT_KEYS = ["analytics", "performance"];
 const paqsWithRequireConsent = new WeakSet<unknown[][]>();
 
 const consentModeChecks = (consentMode: MatomoConsentMode) => ({
-  isTracking: () =>
-    consentMode === "tracking" || consentMode === "both",
-  isCookie: () =>
-    consentMode === "cookie" || consentMode === "both",
+  isTracking: () => consentMode === "tracking" || consentMode === "both",
+  isCookie: () => consentMode === "cookie" || consentMode === "both",
 });
 
 /**

--- a/clients/fides-js/src/integrations/matomo.ts
+++ b/clients/fides-js/src/integrations/matomo.ts
@@ -119,6 +119,7 @@ export const matomo = (options?: Partial<MatomoOptions>): void => {
 
   // Ensure _paq exists (Matomo's standard pre-load queue pattern)
   window._paq = window._paq ?? [];
+  const paq = window._paq;
 
   let requireConsentPushed = false;
 
@@ -136,16 +137,11 @@ export const matomo = (options?: Partial<MatomoOptions>): void => {
     // consent-required mode. The grant/revoke that follows immediately after
     // ensures there is no tracking gap.
     if (!requireConsentPushed) {
-      pushRequireConsent(window._paq!, opts.consentMode);
+      pushRequireConsent(paq, opts.consentMode);
       requireConsentPushed = true;
     }
 
     const granted = processExternalConsentValue(consent[key]);
-    pushConsentUpdate(
-      window._paq!,
-      opts.consentMode,
-      opts.rememberConsent,
-      granted,
-    );
+    pushConsentUpdate(paq, opts.consentMode, opts.rememberConsent, granted);
   });
 };

--- a/clients/fides-js/src/integrations/matomo.ts
+++ b/clients/fides-js/src/integrations/matomo.ts
@@ -31,9 +31,17 @@ export interface MatomoOptions {
   rememberConsent: boolean;
 }
 
+/**
+ * Matomo's _paq is an Array until matomo.js loads, after which it is replaced
+ * with a tracker wrapper object whose `push` method forwards commands to the
+ * live Tracker. Both shapes accept `.push([...])`, so we type the minimum
+ * contract we need: an object with a push method.
+ */
+type MatomoPaq = { push: (cmd: unknown[]) => unknown };
+
 declare global {
   interface Window {
-    _paq?: unknown[][];
+    _paq?: MatomoPaq;
   }
 }
 
@@ -43,8 +51,6 @@ const DEFAULT_OPTIONS: MatomoOptions = {
 };
 
 const DEFAULT_CONSENT_KEYS = ["analytics", "performance"];
-
-const paqsWithRequireConsent = new WeakSet<unknown[][]>();
 
 const consentModeChecks = (consentMode: MatomoConsentMode) => ({
   isTracking: () => consentMode === "tracking" || consentMode === "both",
@@ -63,7 +69,7 @@ const findConsentKey = (consent: NoticeConsent): string | null =>
  * Push requireConsent / requireCookieConsent to _paq based on consentMode.
  */
 const pushRequireConsent = (
-  paq: unknown[][],
+  paq: MatomoPaq,
   consentMode: MatomoConsentMode,
 ): void => {
   const mode = consentModeChecks(consentMode);
@@ -81,7 +87,7 @@ const pushRequireConsent = (
  * Push the appropriate grant or revoke command to _paq.
  */
 const pushConsentUpdate = (
-  paq: unknown[][],
+  paq: MatomoPaq,
   consentMode: MatomoConsentMode,
   rememberConsent: boolean,
   granted: boolean,
@@ -126,26 +132,34 @@ const pushConsentUpdate = (
 export const matomo = (options?: Partial<MatomoOptions>): void => {
   const opts: MatomoOptions = { ...DEFAULT_OPTIONS, ...options };
 
-  // Ensure _paq exists (Matomo's standard pre-load queue pattern)
-  window._paq = window._paq ?? [];
-  const paq = window._paq;
+  // Ensure _paq exists (Matomo's standard pre-load queue pattern).
+  window._paq = window._paq ?? ([] as unknown as MatomoPaq);
+
+  // Push requireConsent synchronously at call time so Matomo enters
+  // consent-required mode before the site's Matomo tracker snippet runs.
+  // This prevents the first trackPageView from firing before Fides has had a
+  // chance to resolve consent. Relies on Fides.matomo() being called before
+  // the Matomo tracker snippet on the page.
+  pushRequireConsent(window._paq, opts.consentMode);
 
   subscribeToConsent((consent) => {
+    // Read `window._paq` freshly at push time: matomo.js replaces it with a
+    // tracker wrapper once loaded, and a reference captured at setup would be
+    // orphaned (pushes would vanish into the discarded Array).
+    const paq = window._paq ?? ([] as unknown as MatomoPaq);
+    window._paq = paq;
+
     const key = findConsentKey(consent);
 
     if (key === null) {
+      // OMIT mode: consent isn't applicable in this jurisdiction. We already
+      // put Matomo into consent-required mode synchronously, so unblock
+      // tracking by granting consent here.
       fidesDebugger(
-        "[Fides Matomo] No consent key found in Fides consent, skipping",
+        "[Fides Matomo] No consent key found in Fides consent, granting",
       );
+      pushConsentUpdate(paq, opts.consentMode, opts.rememberConsent, true);
       return;
-    }
-
-    // On the first event where the consent key is present, put Matomo into
-    // consent-required mode. The grant/revoke that follows immediately after
-    // ensures there is no tracking gap.
-    if (!paqsWithRequireConsent.has(paq)) {
-      pushRequireConsent(paq, opts.consentMode);
-      paqsWithRequireConsent.add(paq);
     }
 
     const granted = processExternalConsentValue(consent[key]);

--- a/clients/fides-js/src/integrations/matomo.ts
+++ b/clients/fides-js/src/integrations/matomo.ts
@@ -44,6 +44,8 @@ const DEFAULT_OPTIONS: MatomoOptions = {
 
 const DEFAULT_CONSENT_KEYS = ["analytics", "performance"];
 
+const paqsWithRequireConsent = new WeakSet<unknown[][]>();
+
 /**
  * Find the first consent key present in the Fides consent object.
  * Uses the `in` operator (like GCM) to distinguish "key absent" (non-applicable, OMIT mode)
@@ -121,8 +123,6 @@ export const matomo = (options?: Partial<MatomoOptions>): void => {
   window._paq = window._paq ?? [];
   const paq = window._paq;
 
-  let requireConsentPushed = false;
-
   subscribeToConsent((consent) => {
     const key = findConsentKey(consent);
 
@@ -136,9 +136,9 @@ export const matomo = (options?: Partial<MatomoOptions>): void => {
     // On the first event where the consent key is present, put Matomo into
     // consent-required mode. The grant/revoke that follows immediately after
     // ensures there is no tracking gap.
-    if (!requireConsentPushed) {
+    if (!paqsWithRequireConsent.has(paq)) {
       pushRequireConsent(paq, opts.consentMode);
-      requireConsentPushed = true;
+      paqsWithRequireConsent.add(paq);
     }
 
     const granted = processExternalConsentValue(consent[key]);

--- a/clients/fides-js/src/integrations/matomo.ts
+++ b/clients/fides-js/src/integrations/matomo.ts
@@ -46,6 +46,13 @@ const DEFAULT_CONSENT_KEYS = ["analytics", "performance"];
 
 const paqsWithRequireConsent = new WeakSet<unknown[][]>();
 
+const consentModeChecks = (consentMode: MatomoConsentMode) => ({
+  isTracking: () =>
+    consentMode === "tracking" || consentMode === "both",
+  isCookie: () =>
+    consentMode === "cookie" || consentMode === "both",
+});
+
 /**
  * Find the first consent key present in the Fides consent object.
  * Uses the `in` operator (like GCM) to distinguish "key absent" (non-applicable, OMIT mode)
@@ -61,11 +68,12 @@ const pushRequireConsent = (
   paq: unknown[][],
   consentMode: MatomoConsentMode,
 ): void => {
-  if (consentMode === "tracking" || consentMode === "both") {
+  const mode = consentModeChecks(consentMode);
+  if (mode.isTracking()) {
     paq.push(["requireConsent"]);
     fidesDebugger("[Fides Matomo] Pushed requireConsent");
   }
-  if (consentMode === "cookie" || consentMode === "both") {
+  if (mode.isCookie()) {
     paq.push(["requireCookieConsent"]);
     fidesDebugger("[Fides Matomo] Pushed requireCookieConsent");
   }
@@ -80,30 +88,31 @@ const pushConsentUpdate = (
   rememberConsent: boolean,
   granted: boolean,
 ): void => {
-  if (consentMode === "tracking" || consentMode === "both") {
-    if (granted) {
+  if (granted) {
+    const mode = consentModeChecks(consentMode);
+    if (mode.isTracking()) {
       const command = rememberConsent
         ? "rememberConsentGiven"
         : "setConsentGiven";
       paq.push([command]);
       fidesDebugger(`[Fides Matomo] Pushed ${command}`);
-    } else {
-      paq.push(["forgetConsentGiven"]);
-      fidesDebugger("[Fides Matomo] Pushed forgetConsentGiven");
     }
-  }
-
-  if (consentMode === "cookie" || consentMode === "both") {
-    if (granted) {
+    if (mode.isCookie()) {
       const command = rememberConsent
         ? "rememberCookieConsentGiven"
         : "setCookieConsentGiven";
       paq.push([command]);
       fidesDebugger(`[Fides Matomo] Pushed ${command}`);
-    } else {
-      paq.push(["forgetCookieConsentGiven"]);
-      fidesDebugger("[Fides Matomo] Pushed forgetCookieConsentGiven");
     }
+  } else {
+    // Always revoke both consent types regardless of consentMode to clean up
+    // stale consent cookies (e.g. if a site switches from "both" to "cookie",
+    // tracking consent must still be revoked). These are safe no-ops in Matomo
+    // when consent was never granted.
+    paq.push(["forgetConsentGiven"]);
+    fidesDebugger("[Fides Matomo] Pushed forgetConsentGiven");
+    paq.push(["forgetCookieConsentGiven"]);
+    fidesDebugger("[Fides Matomo] Pushed forgetCookieConsentGiven");
   }
 };
 

--- a/clients/fides-js/src/integrations/matomo.ts
+++ b/clients/fides-js/src/integrations/matomo.ts
@@ -1,0 +1,151 @@
+/* eslint-disable no-underscore-dangle */
+/**
+ * Matomo integration for Fides
+ *
+ * Automatically syncs Fides consent with Matomo's tracking consent
+ * and/or cookie consent APIs via _paq.push().
+ *
+ * @see https://developer.matomo.org/guides/tracking-consent
+ */
+
+import { NoticeConsent } from "../lib/consent-types";
+import { processExternalConsentValue } from "../lib/shared-consent-utils";
+import { subscribeToConsent } from "./integration-utils";
+
+type MatomoConsentMode = "tracking" | "cookie" | "both";
+
+export interface MatomoOptions {
+  /**
+   * Which Matomo consent mechanism to manage.
+   * - "tracking": Controls Matomo's tracking consent (requireConsent / setConsentGiven)
+   * - "cookie": Controls Matomo's cookie consent (requireCookieConsent / setCookieConsentGiven)
+   * - "both": Controls both tracking and cookie consent together
+   */
+  consentMode: MatomoConsentMode;
+
+  /**
+   * Whether to use rememberConsentGiven() (persists to Matomo's mtm_consent cookie)
+   * vs setConsentGiven() (session-only). Defaults true so Matomo can resume tracking
+   * on page loads before Fides initializes.
+   */
+  rememberConsent: boolean;
+}
+
+declare global {
+  interface Window {
+    _paq?: unknown[][];
+  }
+}
+
+const DEFAULT_OPTIONS: MatomoOptions = {
+  consentMode: "tracking",
+  rememberConsent: true,
+};
+
+const DEFAULT_CONSENT_KEYS = ["analytics", "performance"];
+
+/**
+ * Find the first consent key present in the Fides consent object.
+ * Uses the `in` operator (like GCM) to distinguish "key absent" (non-applicable, OMIT mode)
+ * from "key present with falsy value" (user opted out).
+ */
+const findConsentKey = (consent: NoticeConsent): string | null =>
+  DEFAULT_CONSENT_KEYS.find((key) => key in consent) ?? null;
+
+/**
+ * Push requireConsent / requireCookieConsent to _paq based on consentMode.
+ */
+const pushRequireConsent = (
+  paq: unknown[][],
+  consentMode: MatomoConsentMode,
+): void => {
+  if (consentMode === "tracking" || consentMode === "both") {
+    paq.push(["requireConsent"]);
+    fidesDebugger("[Fides Matomo] Pushed requireConsent");
+  }
+  if (consentMode === "cookie" || consentMode === "both") {
+    paq.push(["requireCookieConsent"]);
+    fidesDebugger("[Fides Matomo] Pushed requireCookieConsent");
+  }
+};
+
+/**
+ * Push the appropriate grant or revoke command to _paq.
+ */
+const pushConsentUpdate = (
+  paq: unknown[][],
+  consentMode: MatomoConsentMode,
+  rememberConsent: boolean,
+  granted: boolean,
+): void => {
+  if (consentMode === "tracking" || consentMode === "both") {
+    if (granted) {
+      const command = rememberConsent
+        ? "rememberConsentGiven"
+        : "setConsentGiven";
+      paq.push([command]);
+      fidesDebugger(`[Fides Matomo] Pushed ${command}`);
+    } else {
+      paq.push(["forgetConsentGiven"]);
+      fidesDebugger("[Fides Matomo] Pushed forgetConsentGiven");
+    }
+  }
+
+  if (consentMode === "cookie" || consentMode === "both") {
+    if (granted) {
+      const command = rememberConsent
+        ? "rememberCookieConsentGiven"
+        : "setCookieConsentGiven";
+      paq.push([command]);
+      fidesDebugger(`[Fides Matomo] Pushed ${command}`);
+    } else {
+      paq.push(["forgetCookieConsentGiven"]);
+      fidesDebugger("[Fides Matomo] Pushed forgetCookieConsentGiven");
+    }
+  }
+};
+
+/**
+ * Initialize the Matomo consent integration.
+ *
+ * Automatically syncs Fides consent with Matomo's tracking consent and/or
+ * cookie consent APIs. Matomo is only put into consent-required mode when the
+ * relevant consent key (analytics or performance) is present in the Fides
+ * consent object, allowing free tracking in jurisdictions where consent is
+ * not applicable.
+ */
+export const matomo = (options?: Partial<MatomoOptions>): void => {
+  const opts: MatomoOptions = { ...DEFAULT_OPTIONS, ...options };
+
+  // Ensure _paq exists (Matomo's standard pre-load queue pattern)
+  window._paq = window._paq ?? [];
+
+  let requireConsentPushed = false;
+
+  subscribeToConsent((consent) => {
+    const key = findConsentKey(consent);
+
+    if (key === null) {
+      fidesDebugger(
+        "[Fides Matomo] No consent key found in Fides consent, skipping",
+      );
+      return;
+    }
+
+    // On the first event where the consent key is present, put Matomo into
+    // consent-required mode. The grant/revoke that follows immediately after
+    // ensures there is no tracking gap.
+    if (!requireConsentPushed) {
+      pushRequireConsent(window._paq!, opts.consentMode);
+      requireConsentPushed = true;
+    }
+
+    const granted = processExternalConsentValue(consent[key]);
+    pushConsentUpdate(
+      window._paq!,
+      opts.consentMode,
+      opts.rememberConsent,
+      granted,
+    );
+  });
+};

--- a/clients/fides-js/src/lib/consent-types.ts
+++ b/clients/fides-js/src/lib/consent-types.ts
@@ -8,6 +8,7 @@ import type { aep } from "../integrations/aep";
 import { blueconic } from "../integrations/blueconic";
 import type { gcm } from "../integrations/gcm";
 import type { gtm } from "../integrations/gtm";
+import type { matomo } from "../integrations/matomo";
 import type { meta } from "../integrations/meta";
 import type { shopify } from "../integrations/shopify";
 import type { FidesEventDetail } from "./events";
@@ -256,6 +257,7 @@ export interface FidesGlobal extends Omit<
   blueconic: typeof blueconic;
   gcm: typeof gcm;
   gtm: typeof gtm;
+  matomo: typeof matomo;
   init: (config?: FidesConfig) => Promise<void>;
   meta: typeof meta;
   onFidesEvent: (

--- a/clients/fides-js/src/lib/init-utils.ts
+++ b/clients/fides-js/src/lib/init-utils.ts
@@ -2,6 +2,7 @@ import { aep } from "../integrations/aep";
 import { blueconic } from "../integrations/blueconic";
 import { gcm } from "../integrations/gcm";
 import { gtm } from "../integrations/gtm";
+import { matomo } from "../integrations/matomo";
 import { meta } from "../integrations/meta";
 import { shopify } from "../integrations/shopify";
 import {
@@ -135,6 +136,7 @@ export const getCoreFides = ({
     blueconic,
     gcm,
     gtm,
+    matomo,
     meta,
     shopify,
     showModal: defaultShowModal,

--- a/clients/privacy-center/cypress/e2e/fides-js/consent-third-party.cy.ts
+++ b/clients/privacy-center/cypress/e2e/fides-js/consent-third-party.cy.ts
@@ -530,7 +530,7 @@ describe("Consent third party extensions", () => {
       cy.get("@FidesInitializing").should("have.been.calledOnce");
     });
 
-    it("pushes requireConsent on FidesReady when analytics key is present", () => {
+    it("does not push requireConsent on FidesReady when analytics key is absent", () => {
       cy.waitUntilFidesInitialized().then(() => {
         // The fixture has analytics_opt_out (not analytics), so Matomo should
         // NOT have pushed requireConsent since neither "analytics" nor

--- a/clients/privacy-center/cypress/e2e/fides-js/consent-third-party.cy.ts
+++ b/clients/privacy-center/cypress/e2e/fides-js/consent-third-party.cy.ts
@@ -518,4 +518,95 @@ describe("Consent third party extensions", () => {
       });
     });
   });
+
+  describe("Matomo integration", () => {
+    beforeEach(() => {
+      cy.getCookie(CONSENT_COOKIE_NAME).should("not.exist");
+      stubConfig({
+        options: {
+          isOverlayEnabled: true,
+        },
+      });
+      cy.get("@FidesInitializing").should("have.been.calledOnce");
+    });
+
+    it("pushes requireConsent and consent commands to _paq", () => {
+      cy.window().then((win) => {
+        expect(win).to.have.property("_paq").that.exist;
+      });
+    });
+
+    it("pushes requireConsent on FidesReady when analytics key is present", () => {
+      cy.waitUntilFidesInitialized().then(() => {
+        // The fixture has analytics_opt_out (not analytics), so Matomo should
+        // NOT have pushed requireConsent since neither "analytics" nor
+        // "performance" keys are present.
+        cy.get("@paqPush").should("not.have.been.called");
+      });
+    });
+
+    it("pushes consent commands when the analytics notice key is present", () => {
+      // Override the stub to use a config with an "analytics" notice key
+      stubConfig(
+        {
+          experience: {
+            privacy_notices: [
+              {
+                id: "pri_analytics",
+                origin: "pri_xxx",
+                created_at: "2024-01-01T12:00:00.000000+00:00",
+                updated_at: "2024-01-01T12:00:00.000000+00:00",
+                name: "Analytics",
+                notice_key: "analytics",
+                consent_mechanism: "opt_in" as any,
+                data_uses: ["analytics"],
+                enforcement_level: "frontend" as any,
+                disabled: false,
+                has_gpc_flag: false,
+                framework: null,
+                default_preference: "opt_out" as any,
+                cookies: [],
+                systems_applicable: true,
+                translations: [
+                  {
+                    language: "en",
+                    title: "Analytics",
+                    description: "We use analytics to improve our site.",
+                    privacy_notice_history_id: "pri_analytics_history",
+                  },
+                ],
+              },
+            ],
+          },
+          options: {
+            isOverlayEnabled: true,
+          },
+        },
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+      );
+      cy.waitUntilFidesInitialized().then(() => {
+        cy.get("@FidesUIShown").then(() => {
+          // On FidesReady, analytics defaults to opt_out (false), so Matomo
+          // should have pushed requireConsent + forgetConsentGiven
+          cy.get("@paqPush").should("have.been.calledWith", ["requireConsent"]);
+          cy.get("@paqPush").should("have.been.calledWith", [
+            "forgetConsentGiven",
+          ]);
+
+          // Now opt in via the banner
+          cy.get("div#fides-banner").within(() => {
+            cy.contains("button", "Opt in to all").should("be.visible").click();
+          });
+
+          // After opting in, Matomo should receive rememberConsentGiven
+          cy.get("@paqPush").should("have.been.calledWith", [
+            "rememberConsentGiven",
+          ]);
+        });
+      });
+    });
+  });
 });

--- a/clients/privacy-center/cypress/e2e/fides-js/consent-third-party.cy.ts
+++ b/clients/privacy-center/cypress/e2e/fides-js/consent-third-party.cy.ts
@@ -530,12 +530,6 @@ describe("Consent third party extensions", () => {
       cy.get("@FidesInitializing").should("have.been.calledOnce");
     });
 
-    it("pushes requireConsent and consent commands to _paq", () => {
-      cy.window().then((win) => {
-        expect(win).to.have.property("_paq").that.exist;
-      });
-    });
-
     it("pushes requireConsent on FidesReady when analytics key is present", () => {
       cy.waitUntilFidesInitialized().then(() => {
         // The fixture has analytics_opt_out (not analytics), so Matomo should

--- a/clients/privacy-center/cypress/e2e/fides-js/consent-third-party.cy.ts
+++ b/clients/privacy-center/cypress/e2e/fides-js/consent-third-party.cy.ts
@@ -530,12 +530,23 @@ describe("Consent third party extensions", () => {
       cy.get("@FidesInitializing").should("have.been.calledOnce");
     });
 
-    it("does not push requireConsent on FidesReady when analytics key is absent", () => {
+    it("pushes requireConsent synchronously and grants on FidesReady when analytics key is absent (OMIT mode)", () => {
       cy.waitUntilFidesInitialized().then(() => {
-        // The fixture has analytics_opt_out (not analytics), so Matomo should
-        // NOT have pushed requireConsent since neither "analytics" nor
-        // "performance" keys are present.
-        cy.get("@paqPush").should("not.have.been.called");
+        // Fides.matomo() pushes `requireConsent` synchronously at call time
+        // (before FidesReady fires) so Matomo enters consent-required mode
+        // before the site's Matomo tracker snippet queues trackPageView.
+        cy.get("@paqPush").should("have.been.calledWith", ["requireConsent"]);
+
+        // The fixture uses `analytics_opt_out`, not `analytics`/`performance`.
+        // In this OMIT mode the integration grants consent so Matomo isn't
+        // left stuck in consent-required mode with no grant.
+        cy.get("@paqPush").should("have.been.calledWith", [
+          "rememberConsentGiven",
+        ]);
+        // No revoke commands in OMIT mode
+        cy.get("@paqPush").should("not.have.been.calledWith", [
+          "forgetConsentGiven",
+        ]);
       });
     });
 
@@ -583,8 +594,10 @@ describe("Consent third party extensions", () => {
       );
       cy.waitUntilFidesInitialized().then(() => {
         cy.get("@FidesUIShown").then(() => {
-          // On FidesReady, analytics defaults to opt_out (false), so Matomo
-          // should have pushed requireConsent + forgetConsentGiven
+          // `requireConsent` is pushed synchronously at Fides.matomo() call
+          // time, regardless of consent state. Then on FidesReady, because
+          // analytics defaults to opt_out (false), the integration pushes
+          // forgetConsentGiven.
           cy.get("@paqPush").should("have.been.calledWith", ["requireConsent"]);
           cy.get("@paqPush").should("have.been.calledWith", [
             "forgetConsentGiven",

--- a/clients/privacy-center/cypress/support/commands.ts
+++ b/clients/privacy-center/cypress/support/commands.ts
@@ -170,6 +170,10 @@ Cypress.Commands.add(
         // Add GTM stub
         win.dataLayer = [];
         cy.stub(win.dataLayer, "push").as("dataLayerPush");
+
+        // Add Matomo stub
+        win._paq = [];
+        cy.stub(win._paq, "push").as("paqPush");
       },
     };
     if (!queryParams || !queryParams.disable_animations) {

--- a/clients/privacy-center/public/fides-js-components-demo.html
+++ b/clients/privacy-center/public/fides-js-components-demo.html
@@ -219,12 +219,8 @@
       };
       if (init !== "false") {
         window.Fides.init(fidesConfig);
-        Fides.gtm(
-          !!window.fides_overrides && window.fides_overrides.gtmOptions,
-        );
-        Fides.matomo(
-          !!window.fides_overrides && window.fides_overrides.matomoOptions,
-        );
+        Fides.gtm(window.fides_overrides?.gtmOptions);
+        Fides.matomo(window.fides_overrides?.matomoOptions);
       }
     </script>
 

--- a/clients/privacy-center/public/fides-js-components-demo.html
+++ b/clients/privacy-center/public/fides-js-components-demo.html
@@ -222,6 +222,9 @@
         Fides.gtm(
           !!window.fides_overrides && window.fides_overrides.gtmOptions,
         );
+        Fides.matomo(
+          !!window.fides_overrides && window.fides_overrides.matomoOptions,
+        );
       }
     </script>
 


### PR DESCRIPTION
Ticket [ENG-3295]

### Description Of Changes

New `Fides.matomo()` integration helper that automatically syncs Fides consent decisions with Matomo's tracking consent and cookie consent APIs via `_paq.push()`. Follows the same Gen 2 integration pattern as `Fides.gcm()`, `Fides.aep()`, and `Fides.blueconic()`.

**Key design decisions:**

- **Conditional `requireConsent`**: Rather than always calling Matomo's `requireConsent()` on init (which would block tracking for users in non-consent regions), the integration defers this call until the first consent event where the `analytics` or `performance` key is present in the Fides consent object. This follows GCM's `in` check pattern and correctly handles both `OMIT` (default) and `INCLUDE` non-applicable flag modes without any user configuration.
- **No `requireConsent` option**: Unlike the original PRD spec, this option was removed. All other Fides integrations (GCM, AEP, BlueConic, Shopify) let Fides handle jurisdiction awareness rather than exposing a toggle. The conditional activation approach achieves the same goal automatically.
- **`rememberConsent` defaults to `true`**: Uses Matomo's `rememberConsentGiven()` to persist consent via Matomo's `mtm_consent` cookie, so tracking can resume on page loads before Fides initializes.

**Public API:**
```js
Fides.matomo({
  consentMode: "tracking" | "cookie" | "both",  // default: "tracking"
  rememberConsent: true | false,                  // default: true
})
```

### Code Changes

* New `clients/fides-js/src/integrations/matomo.ts` - core integration
* New `clients/fides-js/__tests__/integrations/matomo.test.ts` - 26 unit tests
* Modified `clients/fides-js/src/lib/consent-types.ts` - add `matomo` to `FidesGlobal`
* Modified `clients/fides-js/src/lib/init-utils.ts` - wire `matomo` into `getCoreFides()`
* Modified `clients/fides-js/src/docs/fides.ts` - JSDoc for `Fides.matomo()`
* New Cypress E2E tests in `consent-third-party.cy.ts` for the Matomo integration
* Added `_paq` stub to Cypress `visitConsentDemo` command
* Added `Fides.matomo()` call to `fides-js-components-demo.html`

### Steps to Confirm

**Automated:**
1. `cd clients/fides-js && npx jest __tests__/integrations/matomo.test.ts` - 26 unit tests pass
2. `cd clients/fides-js && npm run check` - lint, format, typecheck all pass
3. `cd clients/fides-js && npm run build` - build succeeds
4. Cypress E2E: `consent-third-party.cy.ts` Matomo tests pass

**Manual (demo page):**
Use https://developer.matomo.org/guides/tracking-consent for reference

1. Start the local backend and privacy center
2. Visit `http://localhost:3001/fides-js-demo.html`
3. Open browser DevTools console
4. Call `Fides.matomo()` in the console
5. Inspect `window._paq` - should contain `["requireConsent"]` followed by a grant or revoke command depending on the default consent state
6. Interact with the consent banner (accept/reject) and re-inspect `window._paq` - should see `["rememberConsentGiven"]` after accepting or `["forgetConsentGiven"]` after rejecting
7. Test with options: `Fides.matomo({ consentMode: "both" })` - should see both tracking and cookie consent commands
8. Test with `Fides.matomo({ rememberConsent: false })` - should see `["setConsentGiven"]` instead of `["rememberConsentGiven"]`

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required

[ENG-3295]: https://ethyca.atlassian.net/browse/ENG-3295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ