### PR TITLE
ENG-3386: schema for regulatory reporting templates

### DIFF
--- a/.fides/db_dataset.yml
+++ b/.fides/db_dataset.yml
@@ -2522,6 +2522,16 @@ dataset:
       data_categories: [system.operations]
     - name: active
       data_categories: [system.operations]
+    - name: system_managed
+      data_categories: [system.operations]
+  - name: plus_reporting_template_custom_field
+    description: 'Association between system-managed CustomReports (regulatory reporting templates) and the CustomFieldDefinitions they reference'
+    data_categories: null
+    fields:
+    - name: custom_report_id
+      data_categories: [system.operations]
+    - name: custom_field_definition_id
+      data_categories: [system.operations]
   - name: plus_system_scans
     description: 'A table used to store results of a infrastructure system scan'
     data_categories: null
@@ -3546,6 +3556,10 @@ dataset:
       - name: created_at
         data_categories: [system.operations]
       - name: updated_at
+        data_categories: [system.operations]
+      - name: system_template_key
+        data_categories: [system.operations]
+      - name: location_code
         data_categories: [system.operations]
   - name: dbcache
     fields:

--- a/changelog/7999-system-managed-custom-field-definition.yaml
+++ b/changelog/7999-system-managed-custom-field-definition.yaml
@@ -1,0 +1,4 @@
+type: Added
+description: Added schema for regulatory reporting templates - `system_managed` flag on `CustomFieldDefinition`, `system_template_key` / `location_code` on `CustomReport`, and a `plus_reporting_template_custom_field` association table
+pr: 7999
+labels: []

--- a/src/fides/api/alembic/migrations/versions/xx_2026_04_22_1600_c8e9d3f7a2b4_reporting_templates_schema.py
+++ b/src/fides/api/alembic/migrations/versions/xx_2026_04_22_1600_c8e9d3f7a2b4_reporting_templates_schema.py
@@ -1,0 +1,86 @@
+"""Schema for regulatory reporting templates
+
+Adds:
+- ``plus_custom_field_definition.system_managed`` — boolean flag that marks a
+  field definition as platform-managed (e.g. seeded by the regulatory reporting
+  templates reconciler). System-managed fields have their lifecycle controlled
+  by that flow and are hidden from the standard custom-fields management UI.
+- ``plus_custom_report.system_template_key`` — stable key (e.g. "ico", "dpc",
+  "cnil") identifying the template that owns a system-managed CustomReport.
+- ``plus_custom_report.location_code`` — fides location that gates the template
+  (e.g. "gb", "ie", "fr"). Both columns are NULL for user-created reports.
+- ``plus_reporting_template_custom_field`` — M:N association between system-
+  managed CustomReports and the CustomFieldDefinitions they reference.
+
+Revision ID: c8e9d3f7a2b4
+Revises: d71c7d274c04
+Create Date: 2026-04-22 16:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "c8e9d3f7a2b4"
+down_revision = "d71c7d274c04"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "plus_custom_field_definition",
+        sa.Column(
+            "system_managed",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+    op.add_column(
+        "plus_custom_report",
+        sa.Column("system_template_key", sa.String(), nullable=True),
+    )
+    op.add_column(
+        "plus_custom_report",
+        sa.Column("location_code", sa.String(), nullable=True),
+    )
+    op.create_index(
+        "ix_plus_custom_report_system_template_key",
+        "plus_custom_report",
+        ["system_template_key"],
+    )
+    op.create_index(
+        "ix_plus_custom_report_location_code",
+        "plus_custom_report",
+        ["location_code"],
+    )
+
+    op.create_table(
+        "plus_reporting_template_custom_field",
+        sa.Column("custom_report_id", sa.String(), nullable=False),
+        sa.Column("custom_field_definition_id", sa.String(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["custom_report_id"], ["plus_custom_report.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["custom_field_definition_id"],
+            ["plus_custom_field_definition.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("custom_report_id", "custom_field_definition_id"),
+    )
+
+
+def downgrade():
+    op.drop_table("plus_reporting_template_custom_field")
+    op.drop_index(
+        "ix_plus_custom_report_location_code", table_name="plus_custom_report"
+    )
+    op.drop_index(
+        "ix_plus_custom_report_system_template_key", table_name="plus_custom_report"
+    )
+    op.drop_column("plus_custom_report", "location_code")
+    op.drop_column("plus_custom_report", "system_template_key")
+    op.drop_column("plus_custom_field_definition", "system_managed")

--- a/src/fides/api/models/custom_report.py
+++ b/src/fides/api/models/custom_report.py
@@ -1,10 +1,34 @@
-from sqlalchemy import Column, ForeignKey, String
+from sqlalchemy import Column, ForeignKey, String, Table
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.ext.mutable import MutableDict
+from sqlalchemy.orm import relationship
 
 from fides.api.db.base_class import Base  # type: ignore[attr-defined]
 from fides.api.models.fides_user import FidesUser
+from fides.api.models.sql_models import (  # type: ignore[attr-defined]
+    CustomFieldDefinition,
+)
+
+# Association between system-managed CustomReports (regulatory reporting
+# templates) and the CustomFieldDefinitions they reference. Populated by
+# the reporting-templates reconciler; not used for user-created reports.
+reporting_template_custom_field = Table(
+    "plus_reporting_template_custom_field",
+    Base.metadata,
+    Column(
+        "custom_report_id",
+        String,
+        ForeignKey("plus_custom_report.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    Column(
+        "custom_field_definition_id",
+        String,
+        ForeignKey(CustomFieldDefinition.id, ondelete="CASCADE"),
+        primary_key=True,
+    ),
+)
 
 
 class CustomReport(Base):
@@ -20,3 +44,15 @@ class CustomReport(Base):
         nullable=True,
     )
     config = Column(MutableDict.as_mutable(JSONB))
+    # Populated only for system-managed reporting templates.
+    # ``system_template_key`` is the stable template identifier (e.g. "ico",
+    # "dpc", "cnil"); ``location_code`` is the fides location that gates the
+    # template's visibility (e.g. "gb", "ie", "fr"). Both are NULL for
+    # user-created reports.
+    system_template_key = Column(String, nullable=True, index=True)
+    location_code = Column(String, nullable=True, index=True)
+
+    custom_field_definitions = relationship(
+        CustomFieldDefinition,
+        secondary=reporting_template_custom_field,
+    )

--- a/src/fides/api/models/sql_models.py
+++ b/src/fides/api/models/sql_models.py
@@ -929,6 +929,10 @@ class CustomFieldDefinition(Base):
         back_populates="custom_field_definition",
     )
     active = Column(BOOLEAN, nullable=False, default=True)
+    # True when the row was created by a platform-managed flow (e.g. the
+    # regulatory reporting templates reconciler). System-managed fields
+    # have their lifecycle controlled by that flow rather than by users.
+    system_managed = Column(BOOLEAN, nullable=False, default=False, server_default="f")
 
     @classmethod
     def create(

--- a/tests/ctl/core/test_custom_field_models.py
+++ b/tests/ctl/core/test_custom_field_models.py
@@ -142,3 +142,34 @@ def test_custom_field_definition_duplicate_name_rejected_update(db):
     # assert update did not go through
     db.refresh(definition2)
     assert definition2.name == "Test 1"
+
+
+def test_custom_field_definition_system_managed_defaults_false(db):
+    """system_managed defaults to False for user-created definitions."""
+    definition = CustomFieldDefinition.create(
+        db=db,
+        data={
+            "name": "user_created",
+            "description": "test",
+            "field_type": "string",
+            "resource_type": "system",
+            "field_definition": "string",
+        },
+    )
+    assert definition.system_managed is False
+
+
+def test_custom_field_definition_system_managed_settable(db):
+    """system_managed can be set True when a platform flow seeds a definition."""
+    definition = CustomFieldDefinition.create(
+        db=db,
+        data={
+            "name": "platform_seeded",
+            "description": "test",
+            "field_type": "string",
+            "resource_type": "system",
+            "field_definition": "string",
+            "system_managed": True,
+        },
+    )
+    assert definition.system_managed is True


### PR DESCRIPTION
Ticket [ENG-3386]

> **Companion PRs:** [fidesplus#3407](https://github.com/ethyca/fidesplus/pull/3407) (backend reconciler — depends on this PR) and [fides#7910](https://github.com/ethyca/fides/pull/7910) (FE popover). Merge this PR first.

### Description Of Changes

Schema-only PR that adds the columns and association table needed to support the **location-gated regulatory reporting templates** feature implemented in fidesplus#3407. The business logic (reconciler, location-change hook, route guards) lives in fidesplus; this PR only extends the shared data model.

### Code Changes

**Model (`src/fides/api/models/`)**

- `sql_models.py:CustomFieldDefinition` — adds `system_managed: bool` (NOT NULL, default `False`). Marks field definitions whose lifecycle is controlled by a platform flow (the fidesplus reporting-templates reconciler). User-created fields default to `False` and are untouched by that flow.
- `custom_report.py:CustomReport` — adds `system_template_key: Optional[str]` and `location_code: Optional[str]`, both indexed, both NULL for user-created reports. The reconciler populates them for the system-owned ICO/DPC/CNIL templates.
- `custom_report.py:reporting_template_custom_field` — new M:N association table between `CustomReport` and `CustomFieldDefinition`, cascade-delete on both sides. Exposed on the ORM via `CustomReport.custom_field_definitions`. Used by the reconciler to track "which gap fields does this template reference" and to drive the orphan-deactivation pass when a location is deselected.

**Migration**

- `xx_2026_04_22_1600_c8e9d3f7a2b4_reporting_templates_schema.py` — revises `d71c7d274c04` (current head on main). Adds the three columns, the two indexes, and the association table. `downgrade()` is a clean reverse.

**Tests**

- `tests/ctl/core/test_custom_field_models.py` — two tests: `system_managed` defaults to `False`, `system_managed` is settable to `True` via the creation API. The broader semantics (lifecycle, reconciliation) are covered in fidesplus.

### Steps to Confirm

1. Run the unit tests:
   ```bash
   nox -s pytest -- tests/ctl/core/test_custom_field_models.py -v
   ```
   **Expected:** existing tests + two new `system_managed` tests pass.

2. Apply migrations against a fresh DB and confirm schema:
   ```bash
   docker exec <db-container> psql -U postgres -d fides -c "\d plus_custom_field_definition" | grep system_managed
   docker exec <db-container> psql -U postgres -d fides -c "\d plus_custom_report" | grep -E "system_template_key|location_code"
   docker exec <db-container> psql -U postgres -d fides -c "\d plus_reporting_template_custom_field"
   ```
   **Expected:** `system_managed boolean NOT NULL DEFAULT false`, both new CustomReport columns (nullable, indexed), association table with composite PK + CASCADE FKs.

3. Confirm `alembic heads` returns a single head after upgrade:
   ```bash
   alembic heads
   ```
   **Expected:** `c8e9d3f7a2b4 (head)`.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [ ] No documentation updates required (feature docs tracked in fidesplus#3407)
  * [x] No new client scopes
* [x] No new high-risk changes
* [x] Update `CHANGELOG.md` — changelog fragment added at `changelog/system-managed-custom-field-definition.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ENG-3386]: https://ethyca.atlassian.net/browse/ENG-3386