### PR TITLE
Fix nightly build: invalidate Docker Next.js cache on dependency changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -137,12 +137,37 @@ ENV IS_TEST=$IS_TEST
 COPY --from=backend /fides/version.json ./version.json
 
 # Builds and exports admin-ui
+# Build caches are kept across builds for speed, but are invalidated
+# automatically when package-lock.json changes (e.g. bundler upgrade).
 RUN --mount=type=cache,target=/fides/clients/node_modules/.cache \
     --mount=type=cache,target=/fides/clients/admin-ui/.next/cache \
+    LOCK_HASH=$(sha256sum package-lock.json | cut -c1-16) && \
+    if [ -f node_modules/.cache/.lock_hash ] && [ "$(cat node_modules/.cache/.lock_hash)" = "$LOCK_HASH" ]; then \
+      echo "node_modules cache valid (lock hash: $LOCK_HASH)"; \
+    else \
+      echo "Invalidating node_modules cache (lock hash changed to: $LOCK_HASH)" && \
+      rm -rf node_modules/.cache && mkdir -p node_modules/.cache && \
+      echo "$LOCK_HASH" > node_modules/.cache/.lock_hash; \
+    fi && \
+    if [ -f admin-ui/.next/cache/.lock_hash ] && [ "$(cat admin-ui/.next/cache/.lock_hash)" = "$LOCK_HASH" ]; then \
+      echo "Next.js cache valid (lock hash: $LOCK_HASH)"; \
+    else \
+      echo "Invalidating Next.js cache (lock hash changed to: $LOCK_HASH)" && \
+      rm -rf admin-ui/.next/cache && mkdir -p admin-ui/.next/cache && \
+      echo "$LOCK_HASH" > admin-ui/.next/cache/.lock_hash; \
+    fi && \
     npm run export-admin-ui
 # Builds privacy-center
 RUN --mount=type=cache,target=/fides/clients/node_modules/.cache \
     --mount=type=cache,target=/fides/clients/privacy-center/.next/cache \
+    LOCK_HASH=$(sha256sum package-lock.json | cut -c1-16) && \
+    if [ -f privacy-center/.next/cache/.lock_hash ] && [ "$(cat privacy-center/.next/cache/.lock_hash)" = "$LOCK_HASH" ]; then \
+      echo "Next.js cache valid (lock hash: $LOCK_HASH)"; \
+    else \
+      echo "Invalidating Next.js cache (lock hash changed to: $LOCK_HASH)" && \
+      rm -rf privacy-center/.next/cache && mkdir -p privacy-center/.next/cache && \
+      echo "$LOCK_HASH" > privacy-center/.next/cache/.lock_hash; \
+    fi && \
     npm run build-privacy-center
 
 ###############################

--- a/changelog/7907-upgrade-nextjs-14-to-16.yaml
+++ b/changelog/7907-upgrade-nextjs-14-to-16.yaml
@@ -1,4 +1,4 @@
 type: Changed
 description: Upgraded Admin UI from Next.js 14 to 16 (React 18 to 19)
 pr: 7907
-labels: []
+labels: ["high-risk"]

--- a/changelog/7956-drop-palette-sass-export.yaml
+++ b/changelog/7956-drop-palette-sass-export.yaml
@@ -1,4 +1,4 @@
 type: Developer Experience
-description: Replace Sass :export with TS palette module, remove --webpack flags, enable Turbopack builds
+description: Build using Turbopack instead of Webpack, replace Sass :export with TS palette module
 pr: 7956
-labels: []
+labels: ["high-risk"]

--- a/changelog/8000-fix-docker-next-cache.yaml
+++ b/changelog/8000-fix-docker-next-cache.yaml
@@ -1,0 +1,4 @@
+type: Developer Experience
+description: Fix nightly build blank page by invalidating stale Next.js Docker build cache when dependencies change
+pr: 8000
+labels: []


### PR DESCRIPTION
Ticket: N/A (hotfix for nightly build breakage)

### Description Of Changes

The nightly build started serving a blank page after #7956 (webpack → Turbopack switch) merged. The browser console showed `Uncaught SyntaxError: Unexpected token '<'` on JS chunk requests — the backend's catch-all route was returning `index.html` instead of the chunk file because the chunk hashes in the HTML didn't match what was on disk.

**Root cause:** The Docker build uses `--mount=type=cache` for `.next/cache` and `node_modules/.cache`. After the bundler switch, stale webpack cache artifacts persisted across builds, producing an inconsistent output where HTML referenced chunk hashes that Turbopack never emitted.

**Fix:** Hash `package-lock.json` at build time and store it in the cache mount. On subsequent builds, if the hash differs (dependency upgrade, bundler change, etc.), the cache is cleared before the Next.js build runs. This covers `.next/cache` for both admin-ui and privacy-center, and `node_modules/.cache` (Turbo/eslint).

Also retroactively marks #7907 (Next.js 14→16) and #7956 (Turbopack switch) changelog entries as `high-risk`.

### Code Changes

* `Dockerfile` — added `package-lock.json` hash check before each Next.js build step; clears `.next/cache` and `node_modules/.cache` when the hash changes
* `changelog/7907-upgrade-nextjs-14-to-16.yaml` — added `high-risk` label
* `changelog/7956-drop-palette-sass-export.yaml` — fixed truncated description, added `high-risk` label

### Steps to Confirm

1. Build the `built_frontend` Docker stage:
   ```bash
   docker buildx build --target built_frontend --progress=plain -f Dockerfile .
   ```
   **Expected:** build succeeds, logs show `Invalidating Next.js cache (lock hash changed to: ...)` on first run

2. Rebuild without changing `package-lock.json`:
   ```bash
   docker buildx build --target built_frontend --progress=plain -f Dockerfile .
   ```
   **Expected:** layer is cached (fast), or if forced to re-run, logs show `Next.js cache valid (lock hash: ...)`

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [x] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [x] No UX review needed
* Followup issues:
  * [x] No followup issues
* Database migrations:
  * [x] No migrations
* Documentation:
  * [x] No documentation updates required