### PR TITLE
ENG-3579: Hide Jira tickets section when no Jira integration is configured

### DIFF
--- a/changelog/8003-hide-jira-section-no-integration.yaml
+++ b/changelog/8003-hide-jira-section-no-integration.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Hide Jira tickets section in request details when no Jira integration is configured
+pr: 8003
+labels: []

--- a/clients/admin-ui/src/features/privacy-requests/jira-tickets/RequestJiraTickets.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/jira-tickets/RequestJiraTickets.tsx
@@ -120,14 +120,16 @@ const RequestJiraTickets = ({ subjectRequest }: RequestJiraTicketsProps) => {
     connection_type: [ConnectionType.JIRA_TICKET],
     size: 1,
   });
+  const hasJiraConnection = !!jiraConnections?.total;
 
   const [isLinkModalOpen, setIsLinkModalOpen] = useState(false);
   const [isForceCloseModalOpen, setIsForceCloseModalOpen] = useState(false);
   const message = useMessage();
 
-  const { data: tickets, isLoading } = useGetJiraTicketsQuery({
-    privacy_request_id: subjectRequest.id,
-  });
+  const { data: tickets, isLoading } = useGetJiraTicketsQuery(
+    { privacy_request_id: subjectRequest.id },
+    { skip: !hasJiraConnection },
+  );
 
   const [retryJiraTicket, { isLoading: isRetrying, originalArgs: retryArgs }] =
     useRetryJiraTicketMutation();
@@ -136,7 +138,7 @@ const RequestJiraTickets = ({ subjectRequest }: RequestJiraTicketsProps) => {
     { isLoading: isRefreshing, originalArgs: refreshArgs },
   ] = useRefreshJiraTicketMutation();
 
-  if (!jiraConnections?.total) {
+  if (!hasJiraConnection) {
     return null;
   }
 

--- a/clients/admin-ui/src/features/privacy-requests/jira-tickets/RequestJiraTickets.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/jira-tickets/RequestJiraTickets.tsx
@@ -13,8 +13,9 @@ import {
 import { useState } from "react";
 
 import { getErrorMessage } from "~/features/common/helpers";
+import { useGetAllDatastoreConnectionsQuery } from "~/features/datastore-connections/datastore-connection.slice";
 import { PrivacyRequestEntity } from "~/features/privacy-requests/types";
-import { PrivacyRequestStatus, StatusType } from "~/types/api";
+import { ConnectionType, PrivacyRequestStatus, StatusType } from "~/types/api";
 import { RTKErrorResult } from "~/types/errors/api";
 
 import ForceCloseModal from "./ForceCloseModal";
@@ -115,6 +116,11 @@ interface RequestJiraTicketsProps {
 }
 
 const RequestJiraTickets = ({ subjectRequest }: RequestJiraTicketsProps) => {
+  const { data: jiraConnections } = useGetAllDatastoreConnectionsQuery({
+    connection_type: [ConnectionType.JIRA_TICKET],
+    size: 1,
+  });
+
   const [isLinkModalOpen, setIsLinkModalOpen] = useState(false);
   const [isForceCloseModalOpen, setIsForceCloseModalOpen] = useState(false);
   const message = useMessage();
@@ -129,6 +135,10 @@ const RequestJiraTickets = ({ subjectRequest }: RequestJiraTicketsProps) => {
     refreshJiraTicket,
     { isLoading: isRefreshing, originalArgs: refreshArgs },
   ] = useRefreshJiraTicketMutation();
+
+  if (!jiraConnections?.total) {
+    return null;
+  }
 
   const handleRetry = async (ticket: JiraTicketResult) => {
     if (!ticket.instance_id) {


### PR DESCRIPTION
Ticket [ENG-3579]

### Description Of Changes

The Jira tickets section in Request Details was appearing whenever the `jiraIntegration` feature flag was enabled, regardless of whether an actual Jira connection was configured. This caused users without Jira integrations to see an empty "Jira tickets" section with "No Jira tickets linked" text, a "Link ticket" button, and a "Force close" button — none of which are useful without a configured integration.

Added a check in `RequestJiraTickets` that queries for existing Jira connections and hides the entire section when none exist.

### Code Changes

* Added `useGetAllDatastoreConnectionsQuery` call in `RequestJiraTickets` filtered to `ConnectionType.JIRA_TICKET` with `size: 1`
* Return `null` early when no Jira connections exist, hiding the section entirely

### Steps to Confirm

1. Enable the `jiraIntegration` feature flag with **no** Jira connection configured
2. Navigate to a privacy request's detail page
3. Confirm the "Jira tickets" section does **not** appear
4. Configure a Jira connection
5. Confirm the "Jira tickets" section now appears as expected

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] ~~Add a db-migration label~~
  * [ ] ~~Add a high-risk label~~
  * [ ] ~~Updates unreleased work already in Changelog~~
* UX feedback:
  * [x] No UX review needed
* Followup issues:
  * [x] No followup issues
* Database migrations:
  * [x] No migrations
* Documentation:
  * [x] No documentation updates required

[ENG-3579]: https://ethyca.atlassian.net/browse/ENG-3579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ