### PR TITLE
ENG-3528: BE support for privacy request disclosure metrics

### DIFF
--- a/clients/admin-ui/src/features/seed-data/SeedDataPanel.tsx
+++ b/clients/admin-ui/src/features/seed-data/SeedDataPanel.tsx
@@ -110,6 +110,12 @@ const SEED_SCENARIOS: SeedScenario[] = [
     description:
       "Populate the landing page dashboard with privacy requests, system coverage metrics, audit activity, staged resources, and 30 days of trend history.",
   },
+  {
+    key: "disclosure_metrics",
+    label: "Disclosure Metrics (CCPA/CPRA)",
+    description:
+      "Seed historical privacy requests from the previous calendar year for the CCPA/CPRA disclosure metrics page. Includes access, erasure, and consent opt-out requests with locations and response times.",
+  },
 ];
 
 const ALL_TASK_KEYS = SEED_SCENARIOS.map((s) => s.key);

--- a/clients/admin-ui/src/features/seed-data/seed-data.slice.ts
+++ b/clients/admin-ui/src/features/seed-data/seed-data.slice.ts
@@ -15,6 +15,7 @@ export interface SeedTasksConfig {
   discovery_monitors?: boolean;
   pbac?: boolean;
   dashboard?: boolean;
+  disclosure_metrics?: boolean;
 }
 
 export interface SeedProfileDetail {

--- a/clients/privacy-center/app/privacy-request-metrics/page.tsx
+++ b/clients/privacy-center/app/privacy-request-metrics/page.tsx
@@ -4,6 +4,7 @@ import {
   getPageMetadata,
   getPrivacyCenterEnvironmentCached,
 } from "~/app/server-utils";
+import fetchLocationsFromApi from "~/app/server-utils/fetchLocationsFromApi";
 import LoadServerEnvironmentIntoStores from "~/components/LoadServerEnvironmentIntoStores";
 import PageLayout from "~/components/PageLayout";
 import { PrivacyRequestMetrics } from "~/components/privacy-request-metrics/PrivacyRequestMetrics";
@@ -16,14 +17,19 @@ const PrivacyRequestMetricsPage = async ({
 }: {
   searchParams: NextSearchParams;
 }) => {
-  const serverEnvironment = await getPrivacyCenterEnvironmentCached({
-    searchParams,
-  });
+  const [serverEnvironment, locationsData] = await Promise.all([
+    getPrivacyCenterEnvironmentCached({ searchParams }),
+    fetchLocationsFromApi(),
+  ]);
+
+  const locationGroups = (locationsData?.location_groups ?? [])
+    .filter((g) => g.selected)
+    .sort((a, b) => a.name.localeCompare(b.name));
 
   return (
     <LoadServerEnvironmentIntoStores serverEnvironment={serverEnvironment}>
       <PageLayout>
-        <PrivacyRequestMetrics />
+        <PrivacyRequestMetrics locationGroups={locationGroups} />
       </PageLayout>
     </LoadServerEnvironmentIntoStores>
   );

--- a/clients/privacy-center/app/privacy-request-metrics/page.tsx
+++ b/clients/privacy-center/app/privacy-request-metrics/page.tsx
@@ -25,7 +25,10 @@ const PrivacyRequestMetricsPage = async ({
   return (
     <LoadServerEnvironmentIntoStores serverEnvironment={serverEnvironment}>
       <PageLayout>
-        <PrivacyRequestMetrics locationOptions={locationOptions} />
+        <PrivacyRequestMetrics
+          locationOptions={locationOptions}
+          currentGeo={serverEnvironment.location?.location}
+        />
       </PageLayout>
     </LoadServerEnvironmentIntoStores>
   );

--- a/clients/privacy-center/app/privacy-request-metrics/page.tsx
+++ b/clients/privacy-center/app/privacy-request-metrics/page.tsx
@@ -17,19 +17,15 @@ const PrivacyRequestMetricsPage = async ({
 }: {
   searchParams: NextSearchParams;
 }) => {
-  const [serverEnvironment, locationsData] = await Promise.all([
+  const [serverEnvironment, locationOptions] = await Promise.all([
     getPrivacyCenterEnvironmentCached({ searchParams }),
     fetchLocationsFromApi(),
   ]);
 
-  const locationGroups = (locationsData?.location_groups ?? [])
-    .filter((g) => g.selected)
-    .sort((a, b) => a.name.localeCompare(b.name));
-
   return (
     <LoadServerEnvironmentIntoStores serverEnvironment={serverEnvironment}>
       <PageLayout>
-        <PrivacyRequestMetrics locationGroups={locationGroups} />
+        <PrivacyRequestMetrics locationOptions={locationOptions} />
       </PageLayout>
     </LoadServerEnvironmentIntoStores>
   );

--- a/clients/privacy-center/app/server-environment.ts
+++ b/clients/privacy-center/app/server-environment.ts
@@ -75,6 +75,7 @@ export type PrivacyCenterClientSettings = Pick<
   | "ATTRIBUTION_ANCHOR_TEXT"
   | "ATTRIBUTION_DESTINATION_URL"
   | "ATTRIBUTION_NOFOLLOW"
+  | "PRIVACY_REQUEST_DISCLOSURE_ENABLED"
 >;
 
 export type Styles = string;
@@ -278,6 +279,8 @@ export const getClientSettings = (): PrivacyCenterClientSettings => {
     ATTRIBUTION_ANCHOR_TEXT: settings.ATTRIBUTION_ANCHOR_TEXT,
     ATTRIBUTION_DESTINATION_URL: settings.ATTRIBUTION_DESTINATION_URL,
     ATTRIBUTION_NOFOLLOW: settings.ATTRIBUTION_NOFOLLOW,
+    PRIVACY_REQUEST_DISCLOSURE_ENABLED:
+      settings.PRIVACY_REQUEST_DISCLOSURE_ENABLED,
   };
 
   return clientSettings;

--- a/clients/privacy-center/app/server-utils/PrivacyCenterSettings.ts
+++ b/clients/privacy-center/app/server-utils/PrivacyCenterSettings.ts
@@ -41,6 +41,7 @@ export interface PrivacyCenterSettings {
   MISSING_EXPERIENCE_BEHAVIOR: MissingExperienceBehaviors; // (optional) controls what Privacy Center does when the api call to fetch an experience fails
   LOG_LEVEL: LogLevels; // (optional) controls the log level of the Privacy Center. Defaults to info.
   ENABLE_EXTERNAL_TASK_PORTAL: boolean; // whether the external task portal is enabled
+  PRIVACY_REQUEST_DISCLOSURE_ENABLED: boolean; // whether to show the privacy request disclosure metrics page and footer link
   SECURITY_HEADERS_MODE: "none" | "recommended"; // (optional) controls what security headers are included in Privacy Center responses.
 
   // Fides.js options

--- a/clients/privacy-center/app/server-utils/fetchLocationsFromApi.ts
+++ b/clients/privacy-center/app/server-utils/fetchLocationsFromApi.ts
@@ -1,0 +1,35 @@
+"use server";
+
+import { addCommonHeaders } from "~/common/CommonHeaders";
+import { LocationRegulationResponse } from "~/types/api";
+
+import { getFidesApiUrl } from "../server-environment";
+import { createLogger } from "./logger";
+
+const fetchLocationsFromApi =
+  async (): Promise<LocationRegulationResponse | null> => {
+    const log = createLogger();
+    const headers = new Headers();
+    addCommonHeaders(headers);
+
+    try {
+      const url = `${getFidesApiUrl()}/plus/locations`;
+      log.debug(`Fetching locations from API: ${url}`);
+
+      const response = await fetch(url, {
+        method: "GET",
+        headers,
+      });
+      if (response.ok) {
+        return await response.json();
+      }
+      log.debug(
+        `Failed to fetch locations from API: ${response.status} ${response.statusText}`,
+      );
+    } catch (e) {
+      log.debug(`Error fetching locations from API: ${e}`);
+    }
+    return null;
+  };
+
+export default fetchLocationsFromApi;

--- a/clients/privacy-center/app/server-utils/fetchLocationsFromApi.ts
+++ b/clients/privacy-center/app/server-utils/fetchLocationsFromApi.ts
@@ -1,35 +1,38 @@
 "use server";
 
 import { addCommonHeaders } from "~/common/CommonHeaders";
-import { LocationRegulationResponse } from "~/types/api";
 
 import { getFidesApiUrl } from "../server-environment";
 import { createLogger } from "./logger";
 
-const fetchLocationsFromApi =
-  async (): Promise<LocationRegulationResponse | null> => {
-    const log = createLogger();
-    const headers = new Headers();
-    addCommonHeaders(headers);
+export interface LocationOption {
+  id: string;
+  name: string;
+}
 
-    try {
-      const url = `${getFidesApiUrl()}/plus/locations`;
-      log.debug(`Fetching locations from API: ${url}`);
+const fetchLocationsFromApi = async (): Promise<LocationOption[]> => {
+  const log = createLogger();
+  const headers = new Headers();
+  addCommonHeaders(headers);
 
-      const response = await fetch(url, {
-        method: "GET",
-        headers,
-      });
-      if (response.ok) {
-        return await response.json();
-      }
-      log.debug(
-        `Failed to fetch locations from API: ${response.status} ${response.statusText}`,
-      );
-    } catch (e) {
-      log.debug(`Error fetching locations from API: ${e}`);
+  try {
+    const url = `${getFidesApiUrl()}/plus/privacy-request-metrics/locations`;
+    log.debug(`Fetching disclosure locations from API: ${url}`);
+
+    const response = await fetch(url, {
+      method: "GET",
+      headers,
+    });
+    if (response.ok) {
+      return await response.json();
     }
-    return null;
-  };
+    log.debug(
+      `Failed to fetch disclosure locations: ${response.status} ${response.statusText}`,
+    );
+  } catch (e) {
+    log.debug(`Error fetching disclosure locations: ${e}`);
+  }
+  return [];
+};
 
 export default fetchLocationsFromApi;

--- a/clients/privacy-center/app/server-utils/loadEnvironmentVariables.ts
+++ b/clients/privacy-center/app/server-utils/loadEnvironmentVariables.ts
@@ -93,6 +93,9 @@ const loadEnvironmentVariables = () => {
     ),
     ENABLE_EXTERNAL_TASK_PORTAL:
       process.env.FIDES_PRIVACY_CENTER__ENABLE_EXTERNAL_TASK_PORTAL === "true",
+    PRIVACY_REQUEST_DISCLOSURE_ENABLED:
+      process.env.FIDES_PRIVACY_CENTER__PRIVACY_REQUEST_DISCLOSURE_ENABLED ===
+      "true", // default: false
 
     // Overlay options
     DEBUG: process.env.FIDES_PRIVACY_CENTER__DEBUG

--- a/clients/privacy-center/components/HomePage.tsx
+++ b/clients/privacy-center/components/HomePage.tsx
@@ -84,7 +84,11 @@ const HomePage: NextPage = () => {
   let isConsentModalOpen = isConsentModalOpenConst;
   const getIdVerificationConfigQuery = useGetIdVerificationConfigQuery();
 
-  const { SHOW_BRAND_LINK, ALLOW_HTML_DESCRIPTION } = useSettings();
+  const {
+    SHOW_BRAND_LINK,
+    ALLOW_HTML_DESCRIPTION,
+    PRIVACY_REQUEST_DISCLOSURE_ENABLED,
+  } = useSettings();
 
   const policyLinks = getEffectivePrivacyCenterLinks(config);
 
@@ -257,16 +261,18 @@ const HomePage: NextPage = () => {
                   {label}
                 </Link>
               ))}
-              <Link
-                fontSize={["small", "medium"]}
-                fontWeight="medium"
-                textAlign="center"
-                textDecoration="underline"
-                color="gray.800"
-                href="/privacy-request-metrics"
-              >
-                Privacy request disclosures
-              </Link>
+              {PRIVACY_REQUEST_DISCLOSURE_ENABLED && (
+                <Link
+                  fontSize={["small", "medium"]}
+                  fontWeight="medium"
+                  textAlign="center"
+                  textDecoration="underline"
+                  color="gray.800"
+                  href="/privacy-request-metrics"
+                >
+                  Privacy request disclosures
+                </Link>
+              )}
             </Flex>
             <BrandLink isHomePage position="absolute" right={6} bottom={0} />
           </Box>

--- a/clients/privacy-center/components/privacy-request-metrics/PrivacyRequestMetrics.tsx
+++ b/clients/privacy-center/components/privacy-request-metrics/PrivacyRequestMetrics.tsx
@@ -17,7 +17,7 @@ import {
 import type { RequestTypeMetrics } from "~/features/privacy-request-metrics/types";
 import { useGetPrivacyRequestMetrics } from "~/features/privacy-request-metrics/useGetPrivacyRequestMetrics";
 import { selectConsentState } from "~/features/consent/consent.slice";
-import type { LocationGroup } from "~/types/api";
+import type { LocationOption } from "~/app/server-utils/fetchLocationsFromApi";
 
 const ALL_LOCATIONS_VALUE = "";
 
@@ -51,22 +51,22 @@ function formatValue(value: number | null, key: string): string {
 }
 
 interface PrivacyRequestMetricsProps {
-  locationGroups: LocationGroup[];
+  locationOptions: LocationOption[];
 }
 
 export const PrivacyRequestMetrics = ({
-  locationGroups,
+  locationOptions,
 }: PrivacyRequestMetricsProps) => {
   const { location: currentGeo } = useSelector(selectConsentState);
 
-  // Determine the default: current geo if it exists in the location groups list
+  // Determine the default: current geo if it exists in the location options list
   const currentGeoLocationId = currentGeo
     ? isoToLocationId(currentGeo)
     : undefined;
-  const geoMatchesGroup = currentGeoLocationId
-    ? locationGroups.some((g) => g.id === currentGeoLocationId)
+  const geoMatchesOption = currentGeoLocationId
+    ? locationOptions.some((o) => o.id === currentGeoLocationId)
     : false;
-  const defaultLocation = geoMatchesGroup
+  const defaultLocation = geoMatchesOption
     ? currentGeoLocationId!
     : ALL_LOCATIONS_VALUE;
 
@@ -95,7 +95,7 @@ export const PrivacyRequestMetrics = ({
         </Text>
       </Stack>
 
-      {locationGroups.length > 0 && (
+      {locationOptions.length > 0 && (
         <Flex w="100%" maxWidth={960} justifyContent="flex-end">
           <Box
             as="select"
@@ -115,9 +115,9 @@ export const PrivacyRequestMetrics = ({
             _hover={{ borderColor: "gray.300" }}
           >
             <option value={ALL_LOCATIONS_VALUE}>All locations</option>
-            {locationGroups.map((group) => (
-              <option key={group.id} value={group.id}>
-                {group.name}
+            {locationOptions.map((option) => (
+              <option key={option.id} value={option.id}>
+                {option.name}
               </option>
             ))}
           </Box>

--- a/clients/privacy-center/components/privacy-request-metrics/PrivacyRequestMetrics.tsx
+++ b/clients/privacy-center/components/privacy-request-metrics/PrivacyRequestMetrics.tsx
@@ -8,10 +8,8 @@ import {
   ChakraText as Text,
 } from "fidesui";
 import { useState } from "react";
-import { useSelector } from "react-redux";
 
 import type { LocationOption } from "~/app/server-utils/fetchLocationsFromApi";
-import { selectConsentState } from "~/features/consent/consent.slice";
 import {
   METRIC_COLUMNS,
   REQUEST_TYPE_LABELS,
@@ -35,20 +33,20 @@ function formatValue(value: number | null, key: string): string {
 
 interface PrivacyRequestMetricsProps {
   locationOptions: LocationOption[];
+  currentGeo?: string;
 }
 
 export const PrivacyRequestMetrics = ({
   locationOptions,
+  currentGeo,
 }: PrivacyRequestMetricsProps) => {
-  // currentGeo from the store is already in underscore format (e.g., "us_ca"),
-  // matching location option IDs. The BE's normalize_location_code() accepts
-  // either format, so no FE conversion is needed.
-  const { location: currentGeo } = useSelector(selectConsentState);
-
-  const geoMatchesOption = currentGeo
-    ? locationOptions.some((o) => o.id === currentGeo)
-    : false;
-  const defaultLocation = geoMatchesOption ? currentGeo! : ALL_LOCATIONS_VALUE;
+  // currentGeo is passed as a server-side prop in underscore format (e.g., "US_CA").
+  // Location option IDs are lowercase (e.g., "us_ca"), so normalize to lowercase.
+  const normalizedGeo = currentGeo?.toLowerCase();
+  const matchedOption = normalizedGeo
+    ? locationOptions.find((o) => o.id === normalizedGeo)
+    : undefined;
+  const defaultLocation = matchedOption ? matchedOption.id : ALL_LOCATIONS_VALUE;
 
   const [selectedLocation, setSelectedLocation] =
     useState<string>(defaultLocation);

--- a/clients/privacy-center/components/privacy-request-metrics/PrivacyRequestMetrics.tsx
+++ b/clients/privacy-center/components/privacy-request-metrics/PrivacyRequestMetrics.tsx
@@ -16,6 +16,7 @@ import {
   METRIC_COLUMNS,
   REQUEST_TYPE_LABELS,
   REQUEST_TYPE_ORDER,
+  STATIC_ZERO_REQUEST_TYPES,
 } from "~/features/privacy-request-metrics/constants";
 import type { RequestTypeMetrics } from "~/features/privacy-request-metrics/types";
 import { useGetPrivacyRequestMetrics } from "~/features/privacy-request-metrics/useGetPrivacyRequestMetrics";
@@ -83,14 +84,17 @@ export const PrivacyRequestMetrics = ({
     return null;
   }
 
+  // Merge API response with static zero rows (e.g., "limit" has no BE equivalent)
+  const mergedTypes = { ...STATIC_ZERO_REQUEST_TYPES, ...data.request_types };
+
   // Order request types according to REQUEST_TYPE_ORDER, appending any extras
-  const allKeys = Object.keys(data.request_types);
+  const allKeys = Object.keys(mergedTypes);
   const orderedKeys = [
     ...REQUEST_TYPE_ORDER.filter((k) => allKeys.includes(k)),
     ...allKeys.filter((k) => !REQUEST_TYPE_ORDER.includes(k)),
   ];
   const requestTypes = orderedKeys.map(
-    (k) => [k, data.request_types[k]] as [string, RequestTypeMetrics],
+    (k) => [k, mergedTypes[k]] as [string, RequestTypeMetrics],
   );
 
   return (

--- a/clients/privacy-center/components/privacy-request-metrics/PrivacyRequestMetrics.tsx
+++ b/clients/privacy-center/components/privacy-request-metrics/PrivacyRequestMetrics.tsx
@@ -46,7 +46,9 @@ export const PrivacyRequestMetrics = ({
   const matchedOption = normalizedGeo
     ? locationOptions.find((o) => o.id === normalizedGeo)
     : undefined;
-  const defaultLocation = matchedOption ? matchedOption.id : ALL_LOCATIONS_VALUE;
+  const defaultLocation = matchedOption
+    ? matchedOption.id
+    : ALL_LOCATIONS_VALUE;
 
   const [selectedLocation, setSelectedLocation] =
     useState<string>(defaultLocation);

--- a/clients/privacy-center/components/privacy-request-metrics/PrivacyRequestMetrics.tsx
+++ b/clients/privacy-center/components/privacy-request-metrics/PrivacyRequestMetrics.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import {
   ChakraBox as Box,
   ChakraFlex as Flex,
@@ -8,16 +7,17 @@ import {
   ChakraStack as Stack,
   ChakraText as Text,
 } from "fidesui";
+import { useState } from "react";
 import { useSelector } from "react-redux";
 
+import type { LocationOption } from "~/app/server-utils/fetchLocationsFromApi";
+import { selectConsentState } from "~/features/consent/consent.slice";
 import {
   METRIC_COLUMNS,
   REQUEST_TYPE_LABELS,
 } from "~/features/privacy-request-metrics/constants";
 import type { RequestTypeMetrics } from "~/features/privacy-request-metrics/types";
 import { useGetPrivacyRequestMetrics } from "~/features/privacy-request-metrics/useGetPrivacyRequestMetrics";
-import { selectConsentState } from "~/features/consent/consent.slice";
-import type { LocationOption } from "~/app/server-utils/fetchLocationsFromApi";
 
 const ALL_LOCATIONS_VALUE = "";
 
@@ -167,13 +167,7 @@ export const PrivacyRequestMetrics = ({
                 borderColor="gray.100"
                 _hover={{ bg: "gray.50" }}
               >
-                <Box
-                  as="td"
-                  py={3}
-                  px={3}
-                  fontWeight="medium"
-                  color="gray.800"
-                >
+                <Box as="td" py={3} px={3} fontWeight="medium" color="gray.800">
                   {REQUEST_TYPE_LABELS[typeKey] ?? typeKey}
                 </Box>
                 {METRIC_COLUMNS.map((col) => (

--- a/clients/privacy-center/components/privacy-request-metrics/PrivacyRequestMetrics.tsx
+++ b/clients/privacy-center/components/privacy-request-metrics/PrivacyRequestMetrics.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import {
   ChakraBox as Box,
   ChakraFlex as Flex,
@@ -7,6 +8,7 @@ import {
   ChakraStack as Stack,
   ChakraText as Text,
 } from "fidesui";
+import { useSelector } from "react-redux";
 
 import {
   METRIC_COLUMNS,
@@ -14,6 +16,29 @@ import {
 } from "~/features/privacy-request-metrics/constants";
 import type { RequestTypeMetrics } from "~/features/privacy-request-metrics/types";
 import { useGetPrivacyRequestMetrics } from "~/features/privacy-request-metrics/useGetPrivacyRequestMetrics";
+import { useGetLocationsQuery } from "~/features/common/locations.slice";
+import { selectConsentState } from "~/features/consent/consent.slice";
+
+const ALL_LOCATIONS_VALUE = "";
+
+/**
+ * Convert a location ID from the locations API format (e.g. "us_ca")
+ * to the ISO format used by the metrics API (e.g. "US-CA").
+ */
+function locationIdToIso(id: string): string {
+  const parts = id.split("_");
+  if (parts.length === 1) {
+    return parts[0].toUpperCase();
+  }
+  return `${parts[0].toUpperCase()}-${parts.slice(1).join("_").toUpperCase()}`;
+}
+
+/**
+ * Convert an ISO location (e.g. "US-CA") to the locations API format (e.g. "us_ca").
+ */
+function isoToLocationId(iso: string): string {
+  return iso.toLowerCase().replace(/-/g, "_");
+}
 
 function formatValue(value: number | null, key: string): string {
   if (value === null) {
@@ -26,7 +51,29 @@ function formatValue(value: number | null, key: string): string {
 }
 
 export const PrivacyRequestMetrics = () => {
-  const { data, isLoading } = useGetPrivacyRequestMetrics();
+  const { location: currentGeo } = useSelector(selectConsentState);
+  const { data: locationsData } = useGetLocationsQuery();
+
+  // Build the list of configured location groups
+  const locationGroups = (locationsData?.location_groups ?? [])
+    .filter((g) => g.selected)
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  // Determine the default: current geo if it exists in the location groups list
+  const currentGeoLocationId = currentGeo
+    ? isoToLocationId(currentGeo)
+    : undefined;
+  const geoMatchesGroup = currentGeoLocationId
+    ? locationGroups.some((g) => g.id === currentGeoLocationId)
+    : false;
+  const defaultLocation = geoMatchesGroup ? currentGeoLocationId! : ALL_LOCATIONS_VALUE;
+
+  const [selectedLocation, setSelectedLocation] = useState<string>(defaultLocation);
+
+  const locationParam = selectedLocation
+    ? locationIdToIso(selectedLocation)
+    : undefined;
+  const { data, isLoading } = useGetPrivacyRequestMetrics(locationParam);
 
   if (isLoading || !data) {
     return null;
@@ -44,6 +91,33 @@ export const PrivacyRequestMetrics = () => {
           Reporting period: {data.reporting_period}
         </Text>
       </Stack>
+
+      <Flex w="100%" maxWidth={960} justifyContent="flex-end">
+        <Box
+          as="select"
+          value={selectedLocation}
+          onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+            setSelectedLocation(e.target.value)
+          }
+          px={3}
+          py={2}
+          borderWidth="1px"
+          borderColor="gray.200"
+          borderRadius="md"
+          fontSize="sm"
+          color="gray.700"
+          bg="white"
+          cursor="pointer"
+          _hover={{ borderColor: "gray.300" }}
+        >
+          <option value={ALL_LOCATIONS_VALUE}>All locations</option>
+          {locationGroups.map((group) => (
+            <option key={group.id} value={group.id}>
+              {group.name}
+            </option>
+          ))}
+        </Box>
+      </Flex>
 
       <Box w="100%" maxWidth={960} overflowX="auto">
         <Box

--- a/clients/privacy-center/components/privacy-request-metrics/PrivacyRequestMetrics.tsx
+++ b/clients/privacy-center/components/privacy-request-metrics/PrivacyRequestMetrics.tsx
@@ -16,8 +16,8 @@ import {
 } from "~/features/privacy-request-metrics/constants";
 import type { RequestTypeMetrics } from "~/features/privacy-request-metrics/types";
 import { useGetPrivacyRequestMetrics } from "~/features/privacy-request-metrics/useGetPrivacyRequestMetrics";
-import { useGetLocationsQuery } from "~/features/common/locations.slice";
 import { selectConsentState } from "~/features/consent/consent.slice";
+import type { LocationGroup } from "~/types/api";
 
 const ALL_LOCATIONS_VALUE = "";
 
@@ -50,14 +50,14 @@ function formatValue(value: number | null, key: string): string {
   return value.toLocaleString();
 }
 
-export const PrivacyRequestMetrics = () => {
-  const { location: currentGeo } = useSelector(selectConsentState);
-  const { data: locationsData } = useGetLocationsQuery();
+interface PrivacyRequestMetricsProps {
+  locationGroups: LocationGroup[];
+}
 
-  // Build the list of configured location groups
-  const locationGroups = (locationsData?.location_groups ?? [])
-    .filter((g) => g.selected)
-    .sort((a, b) => a.name.localeCompare(b.name));
+export const PrivacyRequestMetrics = ({
+  locationGroups,
+}: PrivacyRequestMetricsProps) => {
+  const { location: currentGeo } = useSelector(selectConsentState);
 
   // Determine the default: current geo if it exists in the location groups list
   const currentGeoLocationId = currentGeo
@@ -66,9 +66,12 @@ export const PrivacyRequestMetrics = () => {
   const geoMatchesGroup = currentGeoLocationId
     ? locationGroups.some((g) => g.id === currentGeoLocationId)
     : false;
-  const defaultLocation = geoMatchesGroup ? currentGeoLocationId! : ALL_LOCATIONS_VALUE;
+  const defaultLocation = geoMatchesGroup
+    ? currentGeoLocationId!
+    : ALL_LOCATIONS_VALUE;
 
-  const [selectedLocation, setSelectedLocation] = useState<string>(defaultLocation);
+  const [selectedLocation, setSelectedLocation] =
+    useState<string>(defaultLocation);
 
   const locationParam = selectedLocation
     ? locationIdToIso(selectedLocation)
@@ -92,32 +95,34 @@ export const PrivacyRequestMetrics = () => {
         </Text>
       </Stack>
 
-      <Flex w="100%" maxWidth={960} justifyContent="flex-end">
-        <Box
-          as="select"
-          value={selectedLocation}
-          onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
-            setSelectedLocation(e.target.value)
-          }
-          px={3}
-          py={2}
-          borderWidth="1px"
-          borderColor="gray.200"
-          borderRadius="md"
-          fontSize="sm"
-          color="gray.700"
-          bg="white"
-          cursor="pointer"
-          _hover={{ borderColor: "gray.300" }}
-        >
-          <option value={ALL_LOCATIONS_VALUE}>All locations</option>
-          {locationGroups.map((group) => (
-            <option key={group.id} value={group.id}>
-              {group.name}
-            </option>
-          ))}
-        </Box>
-      </Flex>
+      {locationGroups.length > 0 && (
+        <Flex w="100%" maxWidth={960} justifyContent="flex-end">
+          <Box
+            as="select"
+            value={selectedLocation}
+            onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+              setSelectedLocation(e.target.value)
+            }
+            px={3}
+            py={2}
+            borderWidth="1px"
+            borderColor="gray.200"
+            borderRadius="md"
+            fontSize="sm"
+            color="gray.700"
+            bg="white"
+            cursor="pointer"
+            _hover={{ borderColor: "gray.300" }}
+          >
+            <option value={ALL_LOCATIONS_VALUE}>All locations</option>
+            {locationGroups.map((group) => (
+              <option key={group.id} value={group.id}>
+                {group.name}
+              </option>
+            ))}
+          </Box>
+        </Flex>
+      )}
 
       <Box w="100%" maxWidth={960} overflowX="auto">
         <Box
@@ -162,7 +167,13 @@ export const PrivacyRequestMetrics = () => {
                 borderColor="gray.100"
                 _hover={{ bg: "gray.50" }}
               >
-                <Box as="td" py={3} px={3} fontWeight="medium" color="gray.800">
+                <Box
+                  as="td"
+                  py={3}
+                  px={3}
+                  fontWeight="medium"
+                  color="gray.800"
+                >
                   {REQUEST_TYPE_LABELS[typeKey] ?? typeKey}
                 </Box>
                 {METRIC_COLUMNS.map((col) => (

--- a/clients/privacy-center/components/privacy-request-metrics/PrivacyRequestMetrics.tsx
+++ b/clients/privacy-center/components/privacy-request-metrics/PrivacyRequestMetrics.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import {
   ChakraBox as Box,
   ChakraFlex as Flex,
@@ -57,24 +57,21 @@ interface PrivacyRequestMetricsProps {
 export const PrivacyRequestMetrics = ({
   locationOptions,
 }: PrivacyRequestMetricsProps) => {
-  // currentGeo is already in underscore format from the server (e.g., "us_ca")
   const { location: currentGeo } = useSelector(selectConsentState);
 
-  const [selectedLocation, setSelectedLocation] =
-    useState<string>(ALL_LOCATIONS_VALUE);
-  const [hasAutoSelected, setHasAutoSelected] = useState(false);
+  // Determine the default: current geo if it exists in the location options list
+  const currentGeoLocationId = currentGeo
+    ? isoToLocationId(currentGeo)
+    : undefined;
+  const geoMatchesOption = currentGeoLocationId
+    ? locationOptions.some((o) => o.id === currentGeoLocationId)
+    : false;
+  const defaultLocation = geoMatchesOption
+    ? currentGeoLocationId!
+    : ALL_LOCATIONS_VALUE;
 
-  // Auto-select the user's geo when it becomes available (after hydration)
-  useEffect(() => {
-    if (hasAutoSelected || !currentGeo) {
-      return;
-    }
-    const matchesOption = locationOptions.some((o) => o.id === currentGeo);
-    if (matchesOption) {
-      setSelectedLocation(currentGeo);
-    }
-    setHasAutoSelected(true);
-  }, [currentGeo, locationOptions, hasAutoSelected]);
+  const [selectedLocation, setSelectedLocation] =
+    useState<string>(defaultLocation);
 
   const locationParam = selectedLocation
     ? locationIdToIso(selectedLocation)

--- a/clients/privacy-center/components/privacy-request-metrics/PrivacyRequestMetrics.tsx
+++ b/clients/privacy-center/components/privacy-request-metrics/PrivacyRequestMetrics.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   ChakraBox as Box,
   ChakraFlex as Flex,
@@ -57,21 +57,24 @@ interface PrivacyRequestMetricsProps {
 export const PrivacyRequestMetrics = ({
   locationOptions,
 }: PrivacyRequestMetricsProps) => {
+  // currentGeo is already in underscore format from the server (e.g., "us_ca")
   const { location: currentGeo } = useSelector(selectConsentState);
 
-  // Determine the default: current geo if it exists in the location options list
-  const currentGeoLocationId = currentGeo
-    ? isoToLocationId(currentGeo)
-    : undefined;
-  const geoMatchesOption = currentGeoLocationId
-    ? locationOptions.some((o) => o.id === currentGeoLocationId)
-    : false;
-  const defaultLocation = geoMatchesOption
-    ? currentGeoLocationId!
-    : ALL_LOCATIONS_VALUE;
-
   const [selectedLocation, setSelectedLocation] =
-    useState<string>(defaultLocation);
+    useState<string>(ALL_LOCATIONS_VALUE);
+  const [hasAutoSelected, setHasAutoSelected] = useState(false);
+
+  // Auto-select the user's geo when it becomes available (after hydration)
+  useEffect(() => {
+    if (hasAutoSelected || !currentGeo) {
+      return;
+    }
+    const matchesOption = locationOptions.some((o) => o.id === currentGeo);
+    if (matchesOption) {
+      setSelectedLocation(currentGeo);
+    }
+    setHasAutoSelected(true);
+  }, [currentGeo, locationOptions, hasAutoSelected]);
 
   const locationParam = selectedLocation
     ? locationIdToIso(selectedLocation)

--- a/clients/privacy-center/components/privacy-request-metrics/PrivacyRequestMetrics.tsx
+++ b/clients/privacy-center/components/privacy-request-metrics/PrivacyRequestMetrics.tsx
@@ -28,7 +28,7 @@ function formatValue(value: number | null, key: string): string {
 export const PrivacyRequestMetrics = () => {
   const { data, isLoading } = useGetPrivacyRequestMetrics();
 
-  if (isLoading) {
+  if (isLoading || !data) {
     return null;
   }
 

--- a/clients/privacy-center/components/privacy-request-metrics/PrivacyRequestMetrics.tsx
+++ b/clients/privacy-center/components/privacy-request-metrics/PrivacyRequestMetrics.tsx
@@ -23,25 +23,6 @@ import { useGetPrivacyRequestMetrics } from "~/features/privacy-request-metrics/
 
 const ALL_LOCATIONS_VALUE = "";
 
-/**
- * Convert a location ID from the locations API format (e.g. "us_ca")
- * to the ISO format used by the metrics API (e.g. "US-CA").
- */
-function locationIdToIso(id: string): string {
-  const parts = id.split("_");
-  if (parts.length === 1) {
-    return parts[0].toUpperCase();
-  }
-  return `${parts[0].toUpperCase()}-${parts.slice(1).join("_").toUpperCase()}`;
-}
-
-/**
- * Convert an ISO location (e.g. "US-CA") to the locations API format (e.g. "us_ca").
- */
-function isoToLocationId(iso: string): string {
-  return iso.toLowerCase().replace(/-/g, "_");
-}
-
 function formatValue(value: number | null, key: string): string {
   if (value === null) {
     return "N/A";
@@ -59,26 +40,22 @@ interface PrivacyRequestMetricsProps {
 export const PrivacyRequestMetrics = ({
   locationOptions,
 }: PrivacyRequestMetricsProps) => {
+  // currentGeo from the store is already in underscore format (e.g., "us_ca"),
+  // matching location option IDs. The BE's normalize_location_code() accepts
+  // either format, so no FE conversion is needed.
   const { location: currentGeo } = useSelector(selectConsentState);
 
-  // Determine the default: current geo if it exists in the location options list
-  const currentGeoLocationId = currentGeo
-    ? isoToLocationId(currentGeo)
-    : undefined;
-  const geoMatchesOption = currentGeoLocationId
-    ? locationOptions.some((o) => o.id === currentGeoLocationId)
+  const geoMatchesOption = currentGeo
+    ? locationOptions.some((o) => o.id === currentGeo)
     : false;
-  const defaultLocation = geoMatchesOption
-    ? currentGeoLocationId!
-    : ALL_LOCATIONS_VALUE;
+  const defaultLocation = geoMatchesOption ? currentGeo! : ALL_LOCATIONS_VALUE;
 
   const [selectedLocation, setSelectedLocation] =
     useState<string>(defaultLocation);
 
-  const locationParam = selectedLocation
-    ? locationIdToIso(selectedLocation)
-    : undefined;
-  const { data, isLoading } = useGetPrivacyRequestMetrics(locationParam);
+  const { data, isLoading } = useGetPrivacyRequestMetrics(
+    selectedLocation || undefined,
+  );
 
   if (isLoading || !data) {
     return null;

--- a/clients/privacy-center/components/privacy-request-metrics/PrivacyRequestMetrics.tsx
+++ b/clients/privacy-center/components/privacy-request-metrics/PrivacyRequestMetrics.tsx
@@ -15,6 +15,7 @@ import { selectConsentState } from "~/features/consent/consent.slice";
 import {
   METRIC_COLUMNS,
   REQUEST_TYPE_LABELS,
+  REQUEST_TYPE_ORDER,
 } from "~/features/privacy-request-metrics/constants";
 import type { RequestTypeMetrics } from "~/features/privacy-request-metrics/types";
 import { useGetPrivacyRequestMetrics } from "~/features/privacy-request-metrics/useGetPrivacyRequestMetrics";
@@ -82,7 +83,15 @@ export const PrivacyRequestMetrics = ({
     return null;
   }
 
-  const requestTypes = Object.entries(data.request_types);
+  // Order request types according to REQUEST_TYPE_ORDER, appending any extras
+  const allKeys = Object.keys(data.request_types);
+  const orderedKeys = [
+    ...REQUEST_TYPE_ORDER.filter((k) => allKeys.includes(k)),
+    ...allKeys.filter((k) => !REQUEST_TYPE_ORDER.includes(k)),
+  ];
+  const requestTypes = orderedKeys.map(
+    (k) => [k, data.request_types[k]] as [string, RequestTypeMetrics],
+  );
 
   return (
     <Stack align="center" py={["6", "16"]} px={5} spacing={10}>

--- a/clients/privacy-center/cypress/e2e/privacy-center/privacy-request-disclosure.cy.ts
+++ b/clients/privacy-center/cypress/e2e/privacy-center/privacy-request-disclosure.cy.ts
@@ -1,0 +1,28 @@
+describe("Privacy Request Disclosure", () => {
+  describe("footer link visibility", () => {
+    it("shows the disclosure link when PRIVACY_REQUEST_DISCLOSURE_ENABLED is true", () => {
+      cy.visit("/");
+      cy.getByTestId("home");
+      cy.overrideSettings({ PRIVACY_REQUEST_DISCLOSURE_ENABLED: true });
+
+      cy.contains("a", "Privacy request disclosures")
+        .should("be.visible")
+        .and("have.attr", "href", "/privacy-request-metrics");
+    });
+
+    it("hides the disclosure link when PRIVACY_REQUEST_DISCLOSURE_ENABLED is false", () => {
+      cy.visit("/");
+      cy.getByTestId("home");
+      cy.overrideSettings({ PRIVACY_REQUEST_DISCLOSURE_ENABLED: false });
+
+      cy.contains("a", "Privacy request disclosures").should("not.exist");
+    });
+
+    it("hides the disclosure link by default when setting is not provided", () => {
+      cy.visit("/");
+      cy.getByTestId("home");
+
+      cy.contains("a", "Privacy request disclosures").should("not.exist");
+    });
+  });
+});

--- a/clients/privacy-center/features/privacy-request-metrics/constants.ts
+++ b/clients/privacy-center/features/privacy-request-metrics/constants.ts
@@ -12,11 +12,7 @@ export const REQUEST_TYPE_LABELS: Record<string, string> = {
  * Display order for request types in the metrics table.
  * Types not in this list are appended at the end.
  */
-export const REQUEST_TYPE_ORDER = [
-  "erasure",
-  "access",
-  "consent_opt_out",
-];
+export const REQUEST_TYPE_ORDER = ["erasure", "access", "consent_opt_out"];
 
 /**
  * Column headers for the metrics table, matching the legal disclosure format.

--- a/clients/privacy-center/features/privacy-request-metrics/constants.ts
+++ b/clients/privacy-center/features/privacy-request-metrics/constants.ts
@@ -1,14 +1,22 @@
 /**
- * Display labels for CCPA/CPRA request types.
- * Keys match the `request_types` keys from the API response.
+ * Map API action type keys to CCPA/CPRA display labels.
+ * The BE returns internal action types; the FE maps them to legal terminology.
  */
 export const REQUEST_TYPE_LABELS: Record<string, string> = {
-  delete: "Requests to delete",
-  correct: "Requests to correct",
-  know: "Requests to know",
-  opt_out: "Requests to opt-out of sale/sharing",
-  limit: "Requests to limit",
+  erasure: "Requests to delete",
+  access: "Requests to know",
+  consent_opt_out: "Requests to opt-out of sale/sharing",
 };
+
+/**
+ * Display order for request types in the metrics table.
+ * Types not in this list are appended at the end.
+ */
+export const REQUEST_TYPE_ORDER = [
+  "erasure",
+  "access",
+  "consent_opt_out",
+];
 
 /**
  * Column headers for the metrics table, matching the legal disclosure format.

--- a/clients/privacy-center/features/privacy-request-metrics/constants.ts
+++ b/clients/privacy-center/features/privacy-request-metrics/constants.ts
@@ -1,18 +1,42 @@
+import type { RequestTypeMetrics } from "./types";
+
 /**
  * Map API action type keys to CCPA/CPRA display labels.
  * The BE returns internal action types; the FE maps them to legal terminology.
  */
 export const REQUEST_TYPE_LABELS: Record<string, string> = {
   erasure: "Requests to delete",
+  update: "Requests to correct",
   access: "Requests to know",
   consent_opt_out: "Requests to opt-out of sale/sharing",
+  limit: "Requests to limit",
 };
 
 /**
  * Display order for request types in the metrics table.
  * Types not in this list are appended at the end.
  */
-export const REQUEST_TYPE_ORDER = ["erasure", "access", "consent_opt_out"];
+export const REQUEST_TYPE_ORDER = [
+  "erasure",
+  "update",
+  "access",
+  "consent_opt_out",
+  "limit",
+];
+
+/**
+ * Request types that the FE always shows even if the BE doesn't return them.
+ * These are CCPA-required categories without a current BE equivalent.
+ */
+export const STATIC_ZERO_REQUEST_TYPES: Record<string, RequestTypeMetrics> = {
+  limit: {
+    received: 0,
+    complied_with: 0,
+    denied: 0,
+    mean_days_to_respond: null,
+    median_days_to_respond: null,
+  },
+};
 
 /**
  * Column headers for the metrics table, matching the legal disclosure format.

--- a/clients/privacy-center/features/privacy-request-metrics/mock-data.ts
+++ b/clients/privacy-center/features/privacy-request-metrics/mock-data.ts
@@ -10,6 +10,13 @@ export const MOCK_METRICS: PrivacyRequestMetricsResponse = {
       mean_days_to_respond: 8.3,
       median_days_to_respond: 6,
     },
+    update: {
+      received: 312,
+      complied_with: 289,
+      denied: 14,
+      mean_days_to_respond: 5.7,
+      median_days_to_respond: 4,
+    },
     access: {
       received: 876,
       complied_with: 831,

--- a/clients/privacy-center/features/privacy-request-metrics/mock-data.ts
+++ b/clients/privacy-center/features/privacy-request-metrics/mock-data.ts
@@ -3,40 +3,26 @@ import type { PrivacyRequestMetricsResponse } from "./types";
 export const MOCK_METRICS: PrivacyRequestMetricsResponse = {
   reporting_period: "January 1, 2025 – December 31, 2025",
   request_types: {
-    delete: {
+    erasure: {
       received: 1243,
       complied_with: 1104,
       denied: 87,
       mean_days_to_respond: 8.3,
       median_days_to_respond: 6,
     },
-    correct: {
-      received: 312,
-      complied_with: 289,
-      denied: 14,
-      mean_days_to_respond: 5.7,
-      median_days_to_respond: 4,
-    },
-    know: {
+    access: {
       received: 876,
       complied_with: 831,
       denied: 29,
       mean_days_to_respond: 10.1,
       median_days_to_respond: 8,
     },
-    opt_out: {
+    consent_opt_out: {
       received: 2104,
       complied_with: 2067,
       denied: 12,
       mean_days_to_respond: 3.2,
       median_days_to_respond: 2,
-    },
-    limit: {
-      received: 418,
-      complied_with: 397,
-      denied: 8,
-      mean_days_to_respond: 4.5,
-      median_days_to_respond: 3,
     },
   },
 };

--- a/clients/privacy-center/features/privacy-request-metrics/privacy-request-metrics.slice.ts
+++ b/clients/privacy-center/features/privacy-request-metrics/privacy-request-metrics.slice.ts
@@ -1,0 +1,19 @@
+import { baseApi } from "~/features/common/api.slice";
+
+import type { PrivacyRequestMetricsResponse } from "./types";
+
+export const privacyRequestMetricsApi = baseApi.injectEndpoints({
+  endpoints: (build) => ({
+    getPrivacyRequestMetrics: build.query<
+      PrivacyRequestMetricsResponse,
+      { location?: string } | void
+    >({
+      query: (params) => ({
+        url: `plus/privacy-request-metrics`,
+        params: params || undefined,
+      }),
+    }),
+  }),
+});
+
+export const { useGetPrivacyRequestMetricsQuery } = privacyRequestMetricsApi;

--- a/clients/privacy-center/features/privacy-request-metrics/privacy-request-metrics.slice.ts
+++ b/clients/privacy-center/features/privacy-request-metrics/privacy-request-metrics.slice.ts
@@ -2,15 +2,21 @@ import { baseApi } from "~/features/common/api.slice";
 
 import type { PrivacyRequestMetricsResponse } from "./types";
 
+interface PrivacyRequestMetricsParams {
+  start_date: string;
+  end_date: string;
+  location?: string;
+}
+
 export const privacyRequestMetricsApi = baseApi.injectEndpoints({
   endpoints: (build) => ({
     getPrivacyRequestMetrics: build.query<
       PrivacyRequestMetricsResponse,
-      { location?: string } | void
+      PrivacyRequestMetricsParams
     >({
       query: (params) => ({
         url: `plus/privacy-request-metrics`,
-        params: params || undefined,
+        params,
       }),
     }),
   }),

--- a/clients/privacy-center/features/privacy-request-metrics/useGetPrivacyRequestMetrics.ts
+++ b/clients/privacy-center/features/privacy-request-metrics/useGetPrivacyRequestMetrics.ts
@@ -1,13 +1,14 @@
-import { MOCK_METRICS } from "./mock-data";
+import { useGetPrivacyRequestMetricsQuery } from "./privacy-request-metrics.slice";
 import type { PrivacyRequestMetricsResponse } from "./types";
 
 interface UseGetPrivacyRequestMetricsResult {
-  data: PrivacyRequestMetricsResponse;
+  data: PrivacyRequestMetricsResponse | undefined;
   isLoading: boolean;
   isError: boolean;
 }
 
 export const useGetPrivacyRequestMetrics =
   (): UseGetPrivacyRequestMetricsResult => {
-    return { data: MOCK_METRICS, isLoading: false, isError: false };
+    const { data, isLoading, isError } = useGetPrivacyRequestMetricsQuery();
+    return { data, isLoading, isError };
   };

--- a/clients/privacy-center/features/privacy-request-metrics/useGetPrivacyRequestMetrics.ts
+++ b/clients/privacy-center/features/privacy-request-metrics/useGetPrivacyRequestMetrics.ts
@@ -7,8 +7,11 @@ interface UseGetPrivacyRequestMetricsResult {
   isError: boolean;
 }
 
-export const useGetPrivacyRequestMetrics =
-  (): UseGetPrivacyRequestMetricsResult => {
-    const { data, isLoading, isError } = useGetPrivacyRequestMetricsQuery();
-    return { data, isLoading, isError };
-  };
+export const useGetPrivacyRequestMetrics = (
+  location?: string,
+): UseGetPrivacyRequestMetricsResult => {
+  const { data, isLoading, isError } = useGetPrivacyRequestMetricsQuery(
+    location ? { location } : undefined,
+  );
+  return { data, isLoading, isError };
+};

--- a/clients/privacy-center/features/privacy-request-metrics/useGetPrivacyRequestMetrics.ts
+++ b/clients/privacy-center/features/privacy-request-metrics/useGetPrivacyRequestMetrics.ts
@@ -1,6 +1,17 @@
 import { useGetPrivacyRequestMetricsQuery } from "./privacy-request-metrics.slice";
 import type { PrivacyRequestMetricsResponse } from "./types";
 
+/**
+ * Get the previous calendar year date range for CCPA/CPRA reporting.
+ */
+function getPreviousCalendarYear() {
+  const year = new Date().getFullYear() - 1;
+  return {
+    start_date: `${year}-01-01`,
+    end_date: `${year}-12-31`,
+  };
+}
+
 interface UseGetPrivacyRequestMetricsResult {
   data: PrivacyRequestMetricsResponse | undefined;
   isLoading: boolean;
@@ -10,8 +21,10 @@ interface UseGetPrivacyRequestMetricsResult {
 export const useGetPrivacyRequestMetrics = (
   location?: string,
 ): UseGetPrivacyRequestMetricsResult => {
-  const { data, isLoading, isError } = useGetPrivacyRequestMetricsQuery(
-    location ? { location } : undefined,
-  );
+  const dateRange = getPreviousCalendarYear();
+  const { data, isLoading, isError } = useGetPrivacyRequestMetricsQuery({
+    ...dateRange,
+    ...(location ? { location } : {}),
+  });
   return { data, isLoading, isError };
 };

--- a/src/fides/api/schemas/privacy_center_config.py
+++ b/src/fides/api/schemas/privacy_center_config.py
@@ -236,7 +236,6 @@ class PrivacyCenterConfig(FidesSchema):
     privacy_policy_url_text: Optional[str] = None
     links: List[PrivacyCenterLink] = []
     policy_unavailable_messages: Optional[PolicyUnavailableMessages] = None
-    privacy_request_disclosure_enabled: Optional[bool] = False
 
     @field_validator(
         "server_url_development",

--- a/src/fides/api/schemas/privacy_center_config.py
+++ b/src/fides/api/schemas/privacy_center_config.py
@@ -236,6 +236,7 @@ class PrivacyCenterConfig(FidesSchema):
     privacy_policy_url_text: Optional[str] = None
     links: List[PrivacyCenterLink] = []
     policy_unavailable_messages: Optional[PolicyUnavailableMessages] = None
+    privacy_request_disclosure_enabled: Optional[bool] = False
 
     @field_validator(
         "server_url_development",


### PR DESCRIPTION
❗ test alongside https://github.com/ethyca/fidesplus/pull/3455

## Summary
- Add `FIDES_PRIVACY_CENTER__PRIVACY_REQUEST_DISCLOSURE_ENABLED` env var to toggle the disclosure link in the privacy center footer
- Swap FE hook from mock data to real API call (`GET /plus/privacy-request-metrics`)
- Add RTK Query endpoint for metrics API
- Add geo filter dropdown (server-side fetched location options, auto-selects current geo)
- Add `disclosure_metrics` seed scenario to admin UI seed panel

Depends on fidesplus PR for the backend endpoint.

## Test plan
- [ ] Set `FIDES_PRIVACY_CENTER__PRIVACY_REQUEST_DISCLOSURE_ENABLED=true` and verify footer link appears
- [ ] Seed disclosure metrics data via Admin UI seed panel
- [ ] Visit `/privacy-request-metrics` and verify table shows real data
- [ ] Test geo filter with `?geolocation=US-CA` query param
- [ ] Verify footer link is hidden when env var is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)