### PR TITLE
Allow turbopack chunk filenames through URL traversal guard

### DIFF
--- a/changelog/8005-turbopack-chunk-sanitise-url.yaml
+++ b/changelog/8005-turbopack-chunk-sanitise-url.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Admin UI no longer served a blank screen when the backend receives requests for Next.js 16 turbopack chunk filenames containing `..`.
+pr: 8005
+labels: []

--- a/src/fides/api/main.py
+++ b/src/fides/api/main.py
@@ -65,6 +65,9 @@ from fides.config import CONFIG, check_required_webserver_config_values
 from fides.service.jira.polling_task import initiate_jira_ticket_polling
 
 NEXT_JS_CATCH_ALL_SEGMENTS_RE = r"^\[{1,2}\.\.\.\w+\]{1,2}"  # https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes#catch-all-segments
+# Turbopack (Next.js 16+) chunk filenames can embed ".." before the extension,
+# e.g. "0y3j4e~tvxaz..js". These are benign static assets, not traversal.
+TURBOPACK_CHUNK_RE = re.compile(r"^[\w~-]+\.\.[a-z]+$")
 
 VERSION = fides.__version__
 
@@ -136,7 +139,10 @@ def sanitise_url_path(path: str) -> str:
     path = os.path.normpath(path)
 
     for token in path.split("/"):
-        if ".." in token and not re.search(NEXT_JS_CATCH_ALL_SEGMENTS_RE, token):
+        if ".." in token and not (
+            re.search(NEXT_JS_CATCH_ALL_SEGMENTS_RE, token)
+            or TURBOPACK_CHUNK_RE.match(token)
+        ):
             logger.warning(
                 f"Potentially dangerous use of URL hierarchy in path: {path}"
             )

--- a/tests/ops/util/test_api_router.py
+++ b/tests/ops/util/test_api_router.py
@@ -121,6 +121,10 @@ class TestApiRouter:
                 "[datasetName]/[collectionName]/[[...subFields]]-js/../../../../etc/passwd",
                 True,
             ),
+            # Turbopack (Next.js 16+) chunk filenames can embed ".." before the
+            # extension. These must not be flagged as traversal attempts.
+            ("/_next/static/chunks/0y3j4e~tvxaz..js", False),
+            ("/_next/static/chunks/foo_bar~baz..js", False),
             ("../../../../../../../../../etc/passwd", True),
             ("..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2fetc/passwd", True),
             (


### PR DESCRIPTION
Ticket [no-ticket]

### Description Of Changes

Next.js 16's turbopack produces static chunk filenames that embed `..` before the extension (e.g. `0y3j4e~tvxaz..js`). The existing `sanitise_url_path` check in the admin UI catchall route flagged any path token containing `..` as a substring as a potential traversal attempt, rerouted the request to the admin index, and served HTML in place of the JS file. The browser then choked with `Uncaught SyntaxError: expected expression, got '<'` and the page rendered blank.

The fix keeps the broad substring guard (which is still doing useful work against encoded traversal patterns like `..%c0%2f` and triple-dot variants covered by the existing test suite) and adds a narrow allowlist for the specific turbopack filename shape.

### Code Changes

* `src/fides/api/main.py` — add `TURBOPACK_CHUNK_RE` allowlist carve-out in `sanitise_url_path`
* `tests/ops/util/test_api_router.py` — add two turbopack chunk filename cases to the existing parametrized `test_sanitise_url_path` suite (existing malicious cases still blocked)

### Steps to Confirm

1. Build admin UI with turbopack: `cd clients/admin-ui && npm run prod-export`
2. Serve via fides (any path that gets you the admin UI through the backend; e.g. fidesplus `nox -s 'build(slim)' -- with-ui` + `nox -s 'dev(slim)' -- dev fides-pkg`)
3. Open `http://localhost:8080/` in a browser. Before this fix: blank screen, console shows `Uncaught SyntaxError: expected expression, got '<'` for a `/_next/static/chunks/*..js` URL. After: admin UI loads normally.
4. Verify `curl -sI 'http://localhost:8080/_next/static/chunks/<some-chunk-with-double-dot>..js'` returns `content-type: text/javascript` (not `text/html`).
5. Run `pytest tests/ops/util/test_api_router.py::TestApiRouter::test_sanitise_url_path` — all existing malicious cases still blocked, new turbopack cases pass.

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required