### PR TITLE
fix sass warning

### DIFF
--- a/clients/admin-ui/src/features/privacy-requests/events-and-logs/ActivityTimelineEntry.module.scss
+++ b/clients/admin-ui/src/features/privacy-requests/events-and-logs/ActivityTimelineEntry.module.scss
@@ -73,6 +73,7 @@ $horizontal-padding: 20px;
 .title {
   font-weight: 600;
   flex-shrink: 1;
+  width: auto;
 
   &--error {
     color: var(--fidesui-error);
@@ -85,8 +86,6 @@ $horizontal-padding: 20px;
   &--polling {
     color: var(--fidesui-warning);
   }
-
-  width: auto;
 }
 
 .timestamp {


### PR DESCRIPTION
### Description Of Changes

fixes an annoying sass warning during NextJS builds

### Code Changes

* re-order style to be above the & extensions in `ActivityTimelineEntry.module.scss`

### Steps to Confirm

1. NextJS build no longer shows a warning on line 88 of `ActivityTimelineEntry.module.scss`

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [x] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required
