### PR TITLE
Fix Jest failures caused by @ant-design/x ESM-only dep chain

### DIFF
--- a/clients/admin-ui/jest.config.js
+++ b/clients/admin-ui/jest.config.js
@@ -28,6 +28,10 @@ module.exports = {
     "^subject-request/(.*)$": "<rootDir>/src/features/subject-request/$1",
     "^user-management/(.*)$": "<rootDir>/src/features/user-management/$1",
     "^~/(.*)$": "<rootDir>/src/$1",
+
+    // @ant-design/x bundles ESM-only deps (refractor) that Jest can't handle.
+    // These components are not exercised in unit tests; mock them out entirely.
+    "@ant-design/x(.*)": "<rootDir>/src/__mocks__/antDesignX.ts",
   },
   // Add more setup options before each test is run
   setupFilesAfterEnv: ["<rootDir>/__tests__/jest.setup.ts"],

--- a/clients/admin-ui/src/__mocks__/antDesignX.ts
+++ b/clients/admin-ui/src/__mocks__/antDesignX.ts
@@ -1,0 +1,4 @@
+// Mock for @ant-design/x — its transitive dep (refractor) is ESM-only and
+// cannot be required by Jest. These components are not exercised in unit tests.
+export const Bubble = () => null;
+export const Sender = () => null;


### PR DESCRIPTION
## Summary

- `@ant-design/x` bundles `refractor` (via `react-syntax-highlighter`) which is ESM-only
- Jest's CJS loader hits a `SyntaxError: Cannot use import statement outside a module` on `refractor/lib/core.js` when any file imports from `fidesui` (which re-exports `Bubble`/`Sender` from `@ant-design/x/lib`)
- This broke all 32 test suites that import from `fidesui`
- Fix: mock `@ant-design/x` entirely in Jest — the components aren't exercised in unit tests anyway

## Test plan

- [ ] `npm run test` in `clients/admin-ui` — 69/69 suites pass
- [ ] `npm run lint:ci` in `clients/admin-ui` — 0 errors