### PR TITLE
feat: monitor steward inheritance [ENG-3330]

### DIFF
--- a/changelog/8015-monitor-steward-inheritance.yaml
+++ b/changelog/8015-monitor-steward-inheritance.yaml
@@ -1,0 +1,4 @@
+type: Added # One of: Added, Changed, Developer Experience, Deprecated, Docs, Fixed, Removed, Security
+description: Monitor steward inheritance option to config forms
+pr: 8015 # PR number
+labels: [] # Optional: ["high-risk", "db-migration"]

--- a/clients/admin-ui/src/features/integrations/configure-monitor/ConfigureMonitorForm.tsx
+++ b/clients/admin-ui/src/features/integrations/configure-monitor/ConfigureMonitorForm.tsx
@@ -2,7 +2,15 @@ import { skipToken } from "@reduxjs/toolkit/query";
 import type { Dayjs } from "dayjs";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
-import { Button, DatePicker, Form, FormInstance, Input, Select } from "fidesui";
+import {
+  Button,
+  DatePicker,
+  Form,
+  FormInstance,
+  Input,
+  Select,
+  Switch,
+} from "fidesui";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
 
@@ -33,6 +41,7 @@ interface MonitorConfigFormValues {
   llm_model_override?: string;
   prompt_template?: ClassifyLlmPromptTemplateOptions;
   content_classification_enabled?: boolean;
+  inherit_system_stewards?: boolean;
   stewards?: string[];
 }
 
@@ -109,47 +118,46 @@ const ConfigureMonitorForm = ({
     : router.query.id;
 
   const handleNextClicked = (values: MonitorConfigFormValues) => {
-    const executionInfo =
-      values.execution_frequency !== MonitorFrequency.NOT_SCHEDULED
-        ? {
-            execution_frequency: values.execution_frequency,
-            execution_start_date: values.execution_start_date
-              .utc()
-              .format("YYYY-MM-DD[T]HH:mm:ss[Z]"),
-          }
-        : {
-            execution_frequency: MonitorFrequency.NOT_SCHEDULED,
-            execution_start_date: undefined,
-          };
+    const connectionConfigKey = monitor?.connection_config_key ?? integrationId;
 
-    const classifyParams = getClassifyParams(isEditing, monitor, values);
-    const payload: EditableMonitorConfig = isEditing
-      ? {
-          ...monitor,
-          ...executionInfo,
-          name: values.name,
-          shared_config_id: values.shared_config_id,
-          classify_params: classifyParams,
-          stewards: values.stewards,
-        }
-      : {
-          ...executionInfo,
-          name: values.name,
-          shared_config_id: values.shared_config_id,
-          connection_config_key: integrationId!,
-          classify_params: classifyParams,
-          stewards: values.stewards,
-        };
+    // Something has gone wrong if you are able to submit without a config key
+    if (connectionConfigKey) {
+      const executionInfo =
+        values.execution_frequency !== MonitorFrequency.NOT_SCHEDULED
+          ? {
+              execution_frequency: values.execution_frequency,
+              execution_start_date: values.execution_start_date
+                .utc()
+                .format("YYYY-MM-DD[T]HH:mm:ss[Z]"),
+            }
+          : {
+              execution_frequency: MonitorFrequency.NOT_SCHEDULED,
+              execution_start_date: undefined,
+            };
 
-    if (integrationOption.identifier === ConnectionType.DYNAMODB) {
-      payload.datasource_params = {
-        single_dataset: false,
+      const classifyParams = getClassifyParams(isEditing, monitor, values);
+      const payload: EditableMonitorConfig = {
+        ...(monitor ?? {}),
+        ...executionInfo,
+        connection_config_key: connectionConfigKey,
+        name: values.name,
+        shared_config_id: values.shared_config_id,
+        classify_params: classifyParams,
+        inherit_system_stewards: values.inherit_system_stewards,
+        stewards: values.stewards,
       };
-    }
-    if (databasesAvailable) {
-      onAdvance(payload);
-    } else {
-      onSubmit(payload);
+
+      if (integrationOption.identifier === ConnectionType.DYNAMODB) {
+        payload.datasource_params = {
+          single_dataset: false,
+        };
+      }
+
+      if (databasesAvailable) {
+        onAdvance(payload);
+      } else {
+        onSubmit(payload);
+      }
     }
   };
 
@@ -201,8 +209,10 @@ const ConfigureMonitorForm = ({
     content_classification_enabled: !monitorUsesLlmClassifier
       ? monitor?.classify_params?.content_classification_enabled
       : undefined, // for now, content classification is always disabled for LLM classification
-    stewards:
-      monitor?.stewards ?? systemData?.data_stewards?.map(({ id }) => id),
+    inherit_system_stewards: isEditing
+      ? monitor?.inherit_system_stewards
+      : true,
+    stewards: monitor?.stewards,
   } as const;
 
   return (
@@ -222,13 +232,24 @@ const ConfigureMonitorForm = ({
       >
         <Input data-testid="input-name" />
       </Form.Item>
+
+      <Form.Item
+        label="Inherit system stewards"
+        name="inherit_system_stewards"
+        tooltip={`When enabled, stewards assigned to the ${systemData?.name} system will automatically be assigned as a steward of this monitor`}
+      >
+        <Switch data-testid="input-inherit_system_stewards" />
+      </Form.Item>
       <Form.Item label="Stewards" name="stewards">
         <Select
           mode="multiple"
           aria-label="Select stewards"
           data-testid="controlled-select-stewards"
           options={dataStewardOptions}
-          optionFilterProp="label"
+          showSearch={{
+            optionFilterProp: "label",
+          }}
+          allowClear
         />
       </Form.Item>
       <Form.Item

--- a/clients/admin-ui/src/features/integrations/configure-monitor/ConfigureWebsiteMonitorForm.tsx
+++ b/clients/admin-ui/src/features/integrations/configure-monitor/ConfigureWebsiteMonitorForm.tsx
@@ -12,6 +12,7 @@ import {
   isoCodesToOptions,
   LocationSelect,
   Select,
+  Switch,
   Text,
 } from "fidesui";
 import { useRouter } from "next/router";
@@ -51,6 +52,7 @@ interface WebsiteMonitorConfigFormValues {
   datasource_params?: WebsiteMonitorParams;
   execution_start_date: Dayjs;
   shared_config_id?: string;
+  inherit_system_stewards?: boolean;
   stewards?: string[];
   use_llm_classifier: boolean;
   llm_model_override?: string;
@@ -135,8 +137,10 @@ const ConfigureWebsiteMonitorForm = ({
       locations: [],
       exclude_domains: [],
     },
-    stewards:
-      monitor?.stewards ?? systemData?.data_stewards?.map(({ id }) => id),
+    stewards: monitor?.stewards,
+    inherit_system_stewards: monitor
+      ? Boolean(monitor.inherit_system_stewards)
+      : true,
     use_llm_classifier: monitorUsesLlmClassifier,
     llm_model_override: monitor?.classify_params?.llm_model_override ?? "",
   };
@@ -214,13 +218,24 @@ const ConfigureWebsiteMonitorForm = ({
         >
           <Input data-testid="input-name" />
         </Form.Item>
+
+        <Form.Item
+          label="Inherit system stewards"
+          name="inherit_system_stewards"
+          tooltip={`When enabled, stewards assigned to the ${systemData?.name} system will automatically be assigned as a steward of this monitor`}
+        >
+          <Switch data-testid="input-inherit_system_stewards" />
+        </Form.Item>
         <Form.Item label="Stewards" name="stewards">
           <Select
             mode="multiple"
             aria-label="Select stewards"
             data-testid="controlled-select-stewards"
             options={dataStewardOptions}
-            optionFilterProp="label"
+            showSearch={{
+              optionFilterProp: "label",
+            }}
+            allowClear
           />
         </Form.Item>
         <Form.Item

--- a/clients/admin-ui/src/types/api/models/EditableMonitorConfig.ts
+++ b/clients/admin-ui/src/types/api/models/EditableMonitorConfig.ts
@@ -82,4 +82,5 @@ export type EditableMonitorConfig = {
    * List of user IDs to set as stewards for this monitor
    */
   stewards?: Array<string>;
+  inherit_system_stewards?: boolean | null;
 };


### PR DESCRIPTION
Ticket [ENG-3330] <!-- simply paste the ticket number between the brackets and it will auto-convert to a link -->

### Description Of Changes

Adds a toggle to the monitor configuration form that allows for inheritance of stewards assigned to linked systems.
Requires BE change https://github.com/ethyca/fidesplus/pull/3394 to test

### Code Changes

* <!-- list your code changes -->

### Steps to Confirm

1. Go to an integration open the monitor creation modal
2. Confirm that the new toggle to inherit stewards exists and is toggled in the "on" position by default
3. After creating the new monitor, confirm that stewards assigned to an associated system are included as stewards by going to the action center and viewing the stewards
4. Edit the monitor to no longer inherit stewards
5. Confirm that the setting saves correctly and that the setting is applied to the stewards

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-3330]: https://ethyca.atlassian.net/browse/ENG-3330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ