### PR TITLE
Widen turbopack chunk filename allowlist (defensive)

### DIFF
--- a/changelog/8018-turbopack-chunk-dotted-suffix.yaml
+++ b/changelog/8018-turbopack-chunk-dotted-suffix.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Widen the turbopack chunk filename allowlist so static assets with dotted suffixes (e.g. `0~9kfdw7..yey.js`, `0te-shorr2._..js`) are served as JS rather than being routed through the admin UI index fallback.
+pr: 8018
+labels: []

--- a/src/fides/api/main.py
+++ b/src/fides/api/main.py
@@ -65,9 +65,13 @@ from fides.config import CONFIG, check_required_webserver_config_values
 from fides.service.jira.polling_task import initiate_jira_ticket_polling
 
 NEXT_JS_CATCH_ALL_SEGMENTS_RE = r"^\[{1,2}\.\.\.\w+\]{1,2}"  # https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes#catch-all-segments
-# Turbopack (Next.js 16+) chunk filenames can embed ".." before the extension,
-# e.g. "0y3j4e~tvxaz..js". These are benign static assets, not traversal.
-TURBOPACK_CHUNK_RE = re.compile(r"^[\w~-]+\.\.[a-z]+$")
+# Turbopack (Next.js 16+) chunk filenames can embed ".." surrounded by dots on
+# either side, e.g. "0y3j4e~tvxaz..js", "0~9kfdw7..yey.js", or
+# "0te-shorr2._..js". Allow word chars, tildes, dots, and hyphens on both
+# sides of the "..", but require a non-dot first character. That keeps "..",
+# "...", "....", "..foo", "foo..", and overlong-UTF-8 variants rejected while
+# admitting the turbopack filename shape.
+TURBOPACK_CHUNK_RE = re.compile(r"^[\w~-][\w~.-]*\.\.[\w~.-]+$")
 
 VERSION = fides.__version__
 

--- a/tests/ops/util/test_api_router.py
+++ b/tests/ops/util/test_api_router.py
@@ -125,6 +125,13 @@ class TestApiRouter:
             # extension. These must not be flagged as traversal attempts.
             ("/_next/static/chunks/0y3j4e~tvxaz..js", False),
             ("/_next/static/chunks/foo_bar~baz..js", False),
+            # Turbopack chunks may also include further dots after the "..",
+            # e.g. when the trailing segment itself contains multiple parts.
+            ("/_next/static/chunks/0~9kfdw7..yey.js", False),
+            ("/_next/static/chunks/abc-123..part.min.js", False),
+            # Turbopack chunks can include dots *before* the ".." too.
+            ("/_next/static/chunks/0te-shorr2._..js", False),
+            ("/_next/static/chunks/a.b.c..js", False),
             ("../../../../../../../../../etc/passwd", True),
             ("..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2f..%2fetc/passwd", True),
             (


### PR DESCRIPTION
Ticket [no-ticket]

### Description Of Changes

Follow-up to [#8005](https://github.com/ethyca/fides/pull/8005). The allowlist regex introduced there matched only a single alphanumeric extension after the `..`, so chunks like `0~9kfdw7..yey.js`, `0te-shorr2._..js`, and `abc-123..part.min.js` still tripped `sanitise_url_path` and got routed through the admin UI index fallback.

admin-ui has since been reverted to `next build --webpack`, so this regex isn't currently fixing a live bug — webpack-built chunks don't contain `..` in the first place. But keeping the allowlist in shape is cheap defensive insurance for the eventual turbopack migration (once the upstream Next.js static-export issues settle down), and it plugs a gap in what #8005 claimed to cover.

Widen the trailing character class to allow word chars, dots, tildes, and hyphens on *both* sides of the `..`. The first character is still constrained to a non-dot, which keeps `..`, `...`, `....`, `..foo`, `foo..`, and overlong-UTF-8 variants (e.g. `..\xc0`) out of the allowlist and subject to the existing substring guard.

### Code Changes

* `src/fides/api/main.py` — widen `TURBOPACK_CHUNK_RE` from `^[\w~-]+\.\.[a-z]+$` to `^[\w~-][\w~.-]*\.\.[\w~.-]+$`
* `tests/ops/util/test_api_router.py` — add turbopack cases with dotted segments on either side of the `..`

### Steps to Confirm

1. `pytest tests/ops/util/test_api_router.py::TestApiRouter::test_sanitise_url_path` — all cases pass (existing malicious rejections preserved, new turbopack cases accepted).
2. Manual spot check: `python -c "from fides.api.main import sanitise_url_path, MalisciousUrlException; [sanitise_url_path(p) for p in ['/_next/static/chunks/0y3j4e~tvxaz..js', '/_next/static/chunks/0~9kfdw7..yey.js', '/_next/static/chunks/0te-shorr2._..js', '/_next/static/chunks/abc-123..part.min.js']]"` returns without raising.

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [x] Followup issues created — root-cause turbopack's missing `_clientMiddlewareManifest.js` in CI before the eventual turbopack migration
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required