### PR TITLE
ENG-3603: Fix custom field updates on privacy declarations

### DIFF
--- a/changelog/8024-fix-custom-field-upsert.yaml
+++ b/changelog/8024-fix-custom-field-upsert.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Fix custom field updates on privacy declarations failing with duplicate key or null ID constraint violations
+pr: 8024
+labels: []

--- a/clients/admin-ui/src/features/data-use/useSystemDataUseCrud.ts
+++ b/clients/admin-ui/src/features/data-use/useSystemDataUseCrud.ts
@@ -31,16 +31,15 @@ const buildCustomFieldsPayload = (
 ): BulkCustomFieldRequest => {
   const payloadUpsert: CustomFieldWithId[] = [];
   const payloadDelete: string[] = [];
-  Object.entries(customFieldValues).forEach(([id, value]) => {
+  Object.entries(customFieldValues).forEach(([definitionId, value]) => {
     if (value) {
       payloadUpsert.push({
-        id,
         value,
         resource_id: resourceId,
-        custom_field_definition_id: id,
+        custom_field_definition_id: definitionId,
       });
     } else {
-      payloadDelete.push(id);
+      payloadDelete.push(definitionId);
     }
   });
   return {
@@ -60,7 +59,9 @@ const useSystemDataUseCrud = (system: SystemResponse) => {
   const declarationAlreadyExists = (values: PrivacyDeclaration) => {
     if (
       system.privacy_declarations.find(
-        (d) => d.data_use === values.data_use && d.name === values.name,
+        (d) =>
+          d.data_use === values.data_use &&
+          (d.name ?? "") === (values.name ?? ""),
       )
     ) {
       message.error(
@@ -102,6 +103,7 @@ const useSystemDataUseCrud = (system: SystemResponse) => {
     isDelete?: boolean,
     customFieldValues?: Record<string, any>,
     updatedDeclarationDataUse?: string,
+    updatedDeclarationName?: string,
   ) => {
     // The API can return a null name, but cannot receive a null name,
     // so do an additional transform here (fides#3862)
@@ -122,7 +124,9 @@ const useSystemDataUseCrud = (system: SystemResponse) => {
     // its custom fields if provided
     if (customFieldValues && updatedDeclarationDataUse) {
       const newDeclaration = systemResult?.data?.privacy_declarations?.find(
-        (d) => d.data_use === updatedDeclarationDataUse,
+        (d) =>
+          d.data_use === updatedDeclarationDataUse &&
+          (d.name ?? "") === (updatedDeclarationName ?? ""),
       );
       if (newDeclaration) {
         const customFieldsPayload = buildCustomFieldsPayload(
@@ -159,6 +163,7 @@ const useSystemDataUseCrud = (system: SystemResponse) => {
       false,
       customFieldValues,
       newDeclaration.data_use,
+      newDeclaration.name ?? "",
     );
   };
 
@@ -183,6 +188,7 @@ const useSystemDataUseCrud = (system: SystemResponse) => {
       false,
       customFieldValues,
       updatedDeclaration.data_use,
+      updatedDeclaration.name ?? "",
     );
   };
 


### PR DESCRIPTION
Ticket [ENG-3603]

### Description Of Changes

Fixes a bug where updating custom fields on privacy declarations would fail with either a "duplicate key value violates unique constraint" or "null value in column id violates not-null constraint" error.

**Root cause:** `buildCustomFieldsPayload` in `useSystemDataUseCrud.ts` was incorrectly using the custom field **definition ID** as the custom field **record ID** in the upsert payload. Since definition IDs are shared across all declarations, the second declaration's custom fields would collide with the first's on the primary key. Additionally, the declaration matching after save only checked `data_use`, not `name`, which could target the wrong declaration when multiple share the same data use.

**Companion PR:** Requires ethyca/fidesplus PR (linked in ENG-3603) for the backend fix that strips `id` from the bulk update dict to prevent `SET id=NULL` when the frontend omits the field.

### Code Changes

* Removed `id` from the upsert payload in `buildCustomFieldsPayload` — the backend finds existing records by `(resource_id, custom_field_definition_id)` and auto-generates UUIDs for new ones
* Fixed declaration matching in `patchDataUses` to use both `data_use` and `name`, consistent with the backend's `privacy_declaration_logical_id`
* Normalized null/empty name comparison in `declarationAlreadyExists` to match backend behavior (`null` and `""` treated as equivalent)

### Steps to Confirm

1. Create a system with two privacy declarations that have different data uses
2. Add custom field definitions for the "privacy declaration" resource type
3. Set custom field values on the first declaration — should save without error
4. Set custom field values on the second declaration — should save without error (previously failed with duplicate key violation)
5. Edit a custom field value on one declaration — should only change that declaration, not the other

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] ~Add a db-migration label~
  * [ ] ~Add a high-risk label~
  * [ ] ~Updates unreleased work already in Changelog~
* UX feedback:
  * [x] No UX review needed
* Followup issues:
  * [x] No followup issues
* Database migrations:
  * [x] No migrations
* Documentation:
  * [x] No documentation updates required

[ENG-3603]: https://ethyca.atlassian.net/browse/ENG-3603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ