### PR TITLE
ENG-3528: Update FE to match BE disclosure metrics API contract

### DIFF
--- a/changelog/8025-privacy-request-disclosure-metrics-be.yaml
+++ b/changelog/8025-privacy-request-disclosure-metrics-be.yaml
@@ -1,4 +1,4 @@
 type: Added
-description: Connect privacy request disclosure metrics page to the BE endpoint for CCPA/CPRA annual reporting
+description: Update FE to match BE disclosure metrics API contract for CCPA/CPRA annual reporting
 pr: 8025
 labels: []

--- a/changelog/8025-privacy-request-disclosure-metrics-be.yaml
+++ b/changelog/8025-privacy-request-disclosure-metrics-be.yaml
@@ -1,0 +1,4 @@
+type: Added
+description: Connect privacy request disclosure metrics page to the BE endpoint for CCPA/CPRA annual reporting
+pr: 8025
+labels: []

--- a/clients/privacy-center/components/privacy-request-metrics/PrivacyRequestMetrics.tsx
+++ b/clients/privacy-center/components/privacy-request-metrics/PrivacyRequestMetrics.tsx
@@ -6,6 +6,7 @@ import {
   ChakraStack as Stack,
   ChakraText as Text,
 } from "fidesui";
+
 import {
   METRIC_COLUMNS,
   REQUEST_TYPE_LABELS,

--- a/clients/privacy-center/components/privacy-request-metrics/PrivacyRequestMetrics.tsx
+++ b/clients/privacy-center/components/privacy-request-metrics/PrivacyRequestMetrics.tsx
@@ -6,8 +6,6 @@ import {
   ChakraStack as Stack,
   ChakraText as Text,
 } from "fidesui";
-import { useMemo } from "react";
-
 import {
   METRIC_COLUMNS,
   REQUEST_TYPE_LABELS,
@@ -28,17 +26,7 @@ function formatValue(value: number | null, key: string): string {
 }
 
 export const PrivacyRequestMetrics = () => {
-  const queryParams = useMemo(() => {
-    const year = new Date().getFullYear() - 1;
-    return {
-      start_date: `${year}-01-01`,
-      end_date: `${year}-12-31`,
-      location: "us_ca",
-    };
-  }, []);
-
-  const { data, isLoading, isError } =
-    useGetPrivacyRequestMetricsQuery(queryParams);
+  const { data, isLoading, isError } = useGetPrivacyRequestMetricsQuery();
 
   if (isError) {
     return (

--- a/clients/privacy-center/features/privacy-request-metrics/privacy-request-metrics.slice.ts
+++ b/clients/privacy-center/features/privacy-request-metrics/privacy-request-metrics.slice.ts
@@ -4,10 +4,7 @@ import type { PrivacyRequestMetricsResponse } from "./types";
 
 export const privacyRequestMetricsApi = baseApi.injectEndpoints({
   endpoints: (build) => ({
-    getPrivacyRequestMetrics: build.query<
-      PrivacyRequestMetricsResponse,
-      void
-    >({
+    getPrivacyRequestMetrics: build.query<PrivacyRequestMetricsResponse, void>({
       query: () => ({
         url: `plus/privacy-request-metrics`,
       }),

--- a/clients/privacy-center/features/privacy-request-metrics/privacy-request-metrics.slice.ts
+++ b/clients/privacy-center/features/privacy-request-metrics/privacy-request-metrics.slice.ts
@@ -2,21 +2,14 @@ import { baseApi } from "~/features/common/api.slice";
 
 import type { PrivacyRequestMetricsResponse } from "./types";
 
-interface PrivacyRequestMetricsParams {
-  start_date: string;
-  end_date: string;
-  location?: string;
-}
-
 export const privacyRequestMetricsApi = baseApi.injectEndpoints({
   endpoints: (build) => ({
     getPrivacyRequestMetrics: build.query<
       PrivacyRequestMetricsResponse,
-      PrivacyRequestMetricsParams
+      void
     >({
-      query: (params) => ({
+      query: () => ({
         url: `plus/privacy-request-metrics`,
-        params,
       }),
     }),
   }),


### PR DESCRIPTION
## Summary
- Update FE to match simplified BE API contract — `GET /plus/privacy-request-metrics` now takes no query params (BE hardcodes previous calendar year + California filtering)
- Remove date range and location params from RTK Query endpoint and component

Depends on [fidesplus PR #3455](https://github.com/ethyca/fidesplus/pull/3455) for the backend endpoint.

## Code Changes
- `privacy-request-metrics.slice.ts` — RTK Query endpoint now takes `void` (no params)
- `PrivacyRequestMetrics.tsx` — Remove query param construction, call hook with no args

## Steps to Confirm
1. Set `FIDES_PRIVACY_CENTER__PRIVACY_REQUEST_DISCLOSURE_ENABLED=true`
2. Seed disclosure metrics data via Admin UI seed panel
3. Visit `/privacy-request-metrics` — table should show real data from the API
4. Verify footer link is hidden when env var is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)