### PR TITLE
ENG-3516: BE: Condition validation for new custom fileds: checkbox, checkbox_group, textarea

### DIFF
--- a/changelog/8026-display-condition-validation.yaml
+++ b/changelog/8026-display-condition-validation.yaml
@@ -1,0 +1,4 @@
+type: Added
+description: Added save-time validation of display_condition rules on custom Privacy Center fields
+pr: 8026
+labels: []

--- a/src/fides/api/schemas/custom_field_display_validator.py
+++ b/src/fides/api/schemas/custom_field_display_validator.py
@@ -1,0 +1,150 @@
+"""Save-time validation of ``display_condition`` rules on
+``custom_privacy_request_fields``."""
+
+from typing import Iterator, Optional
+
+from fides.api.schemas.privacy_center_field_base import BaseCustomPrivacyRequestField
+from fides.api.task.conditional_dependencies.schemas import (
+    Condition,
+    ConditionGroup,
+    ConditionLeaf,
+    GroupOperator,
+    Operator,
+)
+
+
+def _iter_leaves(condition: Condition) -> Iterator[ConditionLeaf]:
+    if isinstance(condition, ConditionLeaf):
+        yield condition
+        return
+    if isinstance(condition, ConditionGroup):
+        for inner in condition.conditions:
+            yield from _iter_leaves(inner)
+
+
+def _iter_group_operators(condition: Condition) -> Iterator[GroupOperator]:
+    if isinstance(condition, ConditionGroup):
+        yield condition.logical_operator
+        for inner in condition.conditions:
+            yield from _iter_group_operators(inner)
+
+
+class DisplayConditionValidator:
+    """Save-time checker for ``display_condition`` rules. Raises
+    ``ValueError`` on first failure; callers translate to 422.
+    """
+
+    ALLOWED_DISPLAY_OPERATORS: set[Operator] = {
+        Operator.eq,
+        Operator.neq,
+        Operator.exists,
+        Operator.not_exists,
+        Operator.list_contains,
+    }
+
+    OPERATORS_BY_TARGET_TYPE: dict[str, set[Operator]] = {
+        "text": {Operator.eq, Operator.neq, Operator.exists, Operator.not_exists},
+        "textarea": {Operator.eq, Operator.neq, Operator.exists, Operator.not_exists},
+        "select": {Operator.eq, Operator.neq, Operator.exists, Operator.not_exists},
+        "location": {Operator.eq, Operator.neq, Operator.exists, Operator.not_exists},
+        "checkbox": {Operator.eq, Operator.neq, Operator.exists},
+        "checkbox_group": {
+            Operator.list_contains,
+            Operator.exists,
+            Operator.not_exists,
+        },
+        "multiselect": {
+            Operator.list_contains,
+            Operator.exists,
+            Operator.not_exists,
+        },
+        "file": {Operator.exists, Operator.not_exists},
+    }
+
+    VALUELESS_OPERATORS: set[Operator] = {
+        Operator.exists,
+        Operator.not_exists,
+    }
+
+    def __init__(self, fields: dict[str, BaseCustomPrivacyRequestField]) -> None:
+        self.fields = fields
+
+    def validate(self) -> None:
+        for field_key, field in self.fields.items():
+            condition = field.display_condition
+            if condition is None:
+                continue
+
+            for group_op in _iter_group_operators(condition):
+                if group_op not in (GroupOperator.and_, GroupOperator.or_):
+                    raise ValueError(f"'{field_key}': unsupported group operator")
+
+            for leaf in _iter_leaves(condition):
+                self._validate_leaf(field_key, leaf)
+
+    def _validate_leaf(self, field_key: str, leaf: ConditionLeaf) -> None:
+        if leaf.operator not in self.ALLOWED_DISPLAY_OPERATORS:
+            raise ValueError(
+                f"'{field_key}': unsupported operator '{leaf.operator.value}'"
+            )
+
+        referenced = leaf.field_address
+        if referenced not in self.fields:
+            raise ValueError(f"'{field_key}': references unknown field '{referenced}'")
+
+        target_type = getattr(self.fields[referenced], "field_type", None)
+
+        if target_type is not None:
+            allowed = self.OPERATORS_BY_TARGET_TYPE.get(target_type)
+            if allowed is not None and leaf.operator not in allowed:
+                raise ValueError(
+                    f"'{field_key}': operator '{leaf.operator.value}' not allowed against '{referenced}' ({target_type})"
+                )
+
+        self._validate_value_for_target(field_key, leaf, target_type)
+
+    def _validate_value_for_target(
+        self,
+        field_key: str,
+        leaf: ConditionLeaf,
+        target_type: Optional[str],
+    ) -> None:
+        if leaf.operator in self.VALUELESS_OPERATORS:
+            if leaf.value is not None:
+                raise ValueError(
+                    f"'{field_key}': operator '{leaf.operator.value}' must not have a value"
+                )
+            return
+
+        value = leaf.value
+        if value is None:
+            raise ValueError(
+                f"'{field_key}': missing value for operator '{leaf.operator.value}'"
+            )
+
+        if target_type == "checkbox":
+            if not isinstance(value, bool):
+                raise ValueError(
+                    f"'{field_key}': checkbox '{leaf.field_address}' requires a bool value"
+                )
+            return
+
+        if target_type in ("checkbox_group", "multiselect"):
+            if isinstance(value, list):
+                if not all(isinstance(v, str) for v in value):
+                    raise ValueError(
+                        f"'{field_key}': list value for '{leaf.field_address}' must contain only strings"
+                    )
+                return
+            if isinstance(value, str):
+                return
+            raise ValueError(
+                f"'{field_key}': '{leaf.field_address}' ({target_type}) requires a string or list of strings"
+            )
+
+        if target_type in ("text", "textarea", "select", "location") and not isinstance(
+            value, str
+        ):
+            raise ValueError(
+                f"'{field_key}': '{leaf.field_address}' ({target_type}) requires a string value"
+            )

--- a/src/fides/api/schemas/privacy_center_config.py
+++ b/src/fides/api/schemas/privacy_center_config.py
@@ -1,5 +1,4 @@
 import copy
-from abc import ABC
 from typing import Annotated, Any, Dict, List, Literal, Optional, Union
 
 from pydantic import (
@@ -13,6 +12,10 @@ from pydantic import (
 
 from fides.api.models.location_regulation_selections import PrivacyNoticeRegion
 from fides.api.schemas.base_class import FidesSchema
+from fides.api.schemas.custom_field_display_validator import (
+    DisplayConditionValidator,
+)
+from fides.api.schemas.privacy_center_field_base import BaseCustomPrivacyRequestField
 
 RequiredType = Literal["optional", "required"]
 
@@ -56,29 +59,6 @@ class IdentityInputs(FidesSchema):
                         '(e.g. {"label": "Field label"})'
                     )
         super().__init__(**data)
-
-
-class BaseCustomPrivacyRequestField(FidesSchema, ABC):
-    """Abstract base class for all custom privacy request fields"""
-
-    label: str
-    required: Optional[bool] = True
-    default_value: Optional[str] = None
-    hidden: Optional[bool] = False
-    query_param_key: Optional[str] = None
-
-    @model_validator(mode="before")
-    @classmethod
-    def validate_default_value(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        if (
-            values.get("hidden")
-            and values.get("default_value") is None
-            and values.get("query_param_key") is None
-        ):
-            raise ValueError(
-                "default_value or query_param_key are required when hidden is True"
-            )
-        return values
 
 
 class CustomPrivacyRequestField(BaseCustomPrivacyRequestField):
@@ -149,7 +129,20 @@ CustomPrivacyRequestFieldUnion = Annotated[
 ]
 
 
-class PrivacyRequestOption(FidesSchema):
+class _HasDisplayConditions:
+    """Mixin giving any schema that carries ``custom_privacy_request_fields``
+    a save-time validator over attached ``display_condition`` rules.
+    """
+
+    @model_validator(mode="after")
+    def validate_display_conditions(self) -> "_HasDisplayConditions":
+        fields = getattr(self, "custom_privacy_request_fields", None)
+        if fields:
+            DisplayConditionValidator(fields).validate()
+        return self
+
+
+class PrivacyRequestOption(_HasDisplayConditions, FidesSchema):
     locations: Optional[Union[List[PrivacyNoticeRegion], Literal["fallback"]]] = None
     policy_key: Optional[str] = None
     icon_path: str
@@ -164,7 +157,7 @@ class PrivacyRequestOption(FidesSchema):
     ] = None
 
 
-class ConsentConfigButton(FidesSchema):
+class ConsentConfigButton(_HasDisplayConditions, FidesSchema):
     description: str
     description_subtext: Optional[List[str]] = None
     confirm_button_text: Optional[str] = Field(alias="confirmButtonText", default=None)
@@ -270,7 +263,7 @@ class PrivacyCenterConfig(FidesSchema):
         return v
 
 
-class PartialPrivacyRequestOption(FidesSchema):
+class PartialPrivacyRequestOption(_HasDisplayConditions, FidesSchema):
     policy_key: str
     title: str
     identity_inputs: Optional[IdentityInputs] = None

--- a/src/fides/api/schemas/privacy_center_field_base.py
+++ b/src/fides/api/schemas/privacy_center_field_base.py
@@ -1,0 +1,38 @@
+"""Abstract base for ``custom_privacy_request_fields`` entries.
+
+Lives in its own module so helpers (validator, evaluator) can depend on
+the field shape without importing ``privacy_center_config`` and
+introducing a circular import.
+"""
+
+from abc import ABC
+from typing import Any, Optional
+
+from pydantic import model_validator
+
+from fides.api.schemas.base_class import FidesSchema
+from fides.api.task.conditional_dependencies.schemas import Condition
+
+
+class BaseCustomPrivacyRequestField(FidesSchema, ABC):
+    """Abstract base class for all custom privacy request fields"""
+
+    label: str
+    required: Optional[bool] = True
+    default_value: Optional[str] = None
+    hidden: Optional[bool] = False
+    query_param_key: Optional[str] = None
+    display_condition: Optional[Condition] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_default_value(cls, values: dict[str, Any]) -> dict[str, Any]:
+        if (
+            values.get("hidden")
+            and values.get("default_value") is None
+            and values.get("query_param_key") is None
+        ):
+            raise ValueError(
+                "default_value or query_param_key are required when hidden is True"
+            )
+        return values

--- a/tests/ops/schemas/test_custom_field_display_validator.py
+++ b/tests/ops/schemas/test_custom_field_display_validator.py
@@ -1,0 +1,274 @@
+"""Tests for :class:`DisplayConditionValidator`."""
+
+import pytest
+from pydantic import ValidationError
+
+from fides.api.schemas.custom_field_display_validator import (
+    DisplayConditionValidator,
+)
+from fides.api.schemas.privacy_center_config import (
+    ConsentConfigButton,
+    CustomPrivacyRequestField,
+    IdentityInputs,
+    LocationCustomPrivacyRequestField,
+    PartialPrivacyRequestOption,
+    PrivacyRequestOption,
+)
+from fides.api.task.conditional_dependencies.schemas import (
+    ConditionGroup,
+    ConditionLeaf,
+    GroupOperator,
+    Operator,
+)
+
+
+def _leaf(field_address, operator, value=None):
+    return ConditionLeaf(field_address=field_address, operator=operator, value=value)
+
+
+def _fields(target, *, detail_condition=None, detail_field="detail"):
+    base = dict(target)
+    base[detail_field] = CustomPrivacyRequestField(
+        label="Detail", field_type="textarea", display_condition=detail_condition
+    )
+    return base
+
+
+def _target(key, field_type, **kwargs):
+    return {
+        key: CustomPrivacyRequestField(label="Target", field_type=field_type, **kwargs)
+    }
+
+
+VALID_CASES = [
+    pytest.param(
+        {
+            "a": CustomPrivacyRequestField(label="A", field_type="text"),
+            "b": CustomPrivacyRequestField(label="B", field_type="checkbox"),
+        },
+        id="no_display_conditions",
+    ),
+    pytest.param(
+        _fields(
+            _target("reason", "select"),
+            detail_condition=_leaf("reason", Operator.eq, "other"),
+        ),
+        id="select_target_string_value",
+    ),
+    pytest.param(
+        _fields(
+            _target("cats", "checkbox_group", options=["a", "b"]),
+            detail_condition=_leaf("cats", Operator.list_contains, "a"),
+        ),
+        id="checkbox_group_string_value",
+    ),
+    pytest.param(
+        _fields(
+            _target("agree", "checkbox"),
+            detail_condition=_leaf("agree", Operator.eq, True),
+        ),
+        id="checkbox_bool_value",
+    ),
+    pytest.param(
+        _fields(
+            _target("reason", "text"),
+            detail_condition=_leaf("reason", Operator.exists),
+        ),
+        id="exists_needs_no_value",
+    ),
+    pytest.param(
+        _fields(
+            {"country": LocationCustomPrivacyRequestField(label="Country")},
+            detail_condition=_leaf("country", Operator.eq, "US"),
+        ),
+        id="location_target_string_value",
+    ),
+    pytest.param(
+        _fields(
+            _target("tags", "multiselect", options=["a", "b"]),
+            detail_condition=_leaf("tags", Operator.list_contains, "a"),
+        ),
+        id="multiselect_list_contains",
+    ),
+    pytest.param(
+        _fields(
+            _target("cats", "checkbox_group", options=["a", "b"]),
+            detail_condition=_leaf("cats", Operator.list_contains, ["a", "b"]),
+        ),
+        id="list_value_of_strings",
+    ),
+]
+
+
+INVALID_CASES = [
+    pytest.param(
+        {
+            "detail": CustomPrivacyRequestField(
+                label="Detail",
+                field_type="textarea",
+                display_condition=_leaf("reason", Operator.eq, "other"),
+            ),
+        },
+        "references unknown field 'reason'",
+        id="references_unknown_field",
+    ),
+    pytest.param(
+        _fields(
+            _target("a", "text"),
+            detail_condition=_leaf("a", Operator.contains, "x"),
+        ),
+        "unsupported operator 'contains'",
+        id="disallowed_operator",
+    ),
+    pytest.param(
+        _fields(
+            _target("agree", "checkbox"),
+            detail_condition=_leaf("agree", Operator.list_contains, "x"),
+        ),
+        "operator 'list_contains' not allowed against 'agree' \\(checkbox\\)",
+        id="operator_target_mismatch",
+    ),
+    pytest.param(
+        _fields(
+            _target("agree", "checkbox"),
+            detail_condition=_leaf("agree", Operator.eq, "true"),
+        ),
+        "checkbox 'agree' requires a bool value",
+        id="checkbox_requires_bool",
+    ),
+    pytest.param(
+        _fields(
+            _target("reason", "text"),
+            detail_condition=_leaf("reason", Operator.eq, 42),
+        ),
+        "'reason' \\(text\\) requires a string value",
+        id="text_target_non_string",
+    ),
+    pytest.param(
+        _fields(
+            _target("reason", "text"),
+            detail_condition=_leaf("reason", Operator.eq),
+        ),
+        "missing value for operator 'eq'",
+        id="eq_without_value",
+    ),
+    pytest.param(
+        _fields(
+            _target("agree", "checkbox"),
+            detail_condition=ConditionGroup(
+                logical_operator=GroupOperator.and_,
+                conditions=[
+                    _leaf("agree", Operator.eq, True),
+                    _leaf("missing", Operator.exists),  # bad leaf
+                ],
+            ),
+        ),
+        "references unknown field 'missing'",
+        id="group_condition_bad_leaf",
+    ),
+    pytest.param(
+        _fields(
+            _target("cats", "checkbox_group", options=["a", "b"]),
+            detail_condition=_leaf("cats", Operator.list_contains, [1, 2]),
+        ),
+        "list value for 'cats' must contain only strings",
+        id="list_value_with_non_string",
+    ),
+    pytest.param(
+        _fields(
+            _target("cats", "checkbox_group", options=["a", "b"]),
+            detail_condition=_leaf("cats", Operator.list_contains, 42),
+        ),
+        "'cats' \\(checkbox_group\\) requires a string or list of strings",
+        id="checkbox_group_non_string_non_list",
+    ),
+    pytest.param(
+        _fields(
+            _target("agree", "checkbox"),
+            detail_condition=ConditionGroup.model_construct(
+                logical_operator="xor",
+                conditions=[_leaf("agree", Operator.exists)],
+            ),
+        ),
+        "unsupported group operator",
+        id="unknown_group_operator",
+    ),
+    pytest.param(
+        _fields(
+            _target("reason", "text"),
+            detail_condition=_leaf("reason", Operator.exists, "x"),
+        ),
+        "operator 'exists' must not have a value",
+        id="exists_with_value",
+    ),
+]
+
+
+class TestValidateDisplayConditions:
+    @pytest.mark.parametrize("fields", VALID_CASES)
+    def test_valid(self, fields):
+        DisplayConditionValidator(fields).validate()
+
+    @pytest.mark.parametrize("fields, match", INVALID_CASES)
+    def test_invalid(self, fields, match):
+        with pytest.raises(ValueError, match=match):
+            DisplayConditionValidator(fields).validate()
+
+
+_VALID_FIELDS = _fields(
+    _target("reason", "select"),
+    detail_condition=_leaf("reason", Operator.eq, "other"),
+)
+_INVALID_FIELDS = {
+    "orphan": CustomPrivacyRequestField(
+        label="Orphan",
+        field_type="textarea",
+        display_condition=_leaf("does_not_exist", Operator.eq, "x"),
+    ),
+}
+
+
+def _pro(fields):
+    return PrivacyRequestOption(
+        policy_key="k",
+        icon_path="/x",
+        title="t",
+        description="d",
+        custom_privacy_request_fields=fields,
+    )
+
+
+def _ccb(fields):
+    return ConsentConfigButton(
+        description="d",
+        icon_path="/x",
+        identity_inputs=IdentityInputs(email="required"),
+        title="t",
+        custom_privacy_request_fields=fields,
+    )
+
+
+def _partial(fields):
+    return PartialPrivacyRequestOption(
+        policy_key="k", title="t", custom_privacy_request_fields=fields
+    )
+
+
+@pytest.fixture(
+    params=[_pro, _ccb, _partial],
+    ids=["PrivacyRequestOption", "ConsentConfigButton", "PartialPrivacyRequestOption"],
+)
+def builder(request):
+    return request.param
+
+
+class TestDisplayConditionMixinWiring:
+    def test_mixin_accepts_valid_fields(self, builder):
+        assert builder(_VALID_FIELDS).custom_privacy_request_fields is not None
+
+    def test_mixin_rejects_invalid_fields(self, builder):
+        with pytest.raises(ValidationError, match="references unknown field"):
+            builder(_INVALID_FIELDS)
+
+    def test_mixin_skips_when_fields_absent(self, builder):
+        assert builder(None).custom_privacy_request_fields is None

--- a/tests/ops/schemas/test_privacy_center_config.py
+++ b/tests/ops/schemas/test_privacy_center_config.py
@@ -4,7 +4,6 @@ import pytest
 from pydantic import ValidationError
 
 from fides.api.schemas.privacy_center_config import (
-    BaseCustomPrivacyRequestField,
     ConsentConfigPage,
     CustomPrivacyRequestField,
     IdentityInputs,
@@ -13,6 +12,7 @@ from fides.api.schemas.privacy_center_config import (
     get_field_type_discriminator,
     reorder_custom_privacy_request_fields,
 )
+from fides.api.schemas.privacy_center_field_base import BaseCustomPrivacyRequestField
 from fides.api.util.saas_util import load_as_string
 
 


### PR DESCRIPTION
Ticket [ENG-3516]

### Description Of Changes

Add save-time validation of `display_condition` rules on custom Privacy Center fields. Catches misconfigured rules (unknown references, type-incompatible operators, malformed values) when config is saved instead of at render time. Supports the new field types `checkbox`, `checkbox_group`, `textarea`.

Validation runs as a Pydantic `model_validator(mode="after")` on every schema carrying `custom_privacy_request_fields` (`PrivacyRequestOption`, `ConsentConfigButton`, `PartialPrivacyRequestOption`) via a shared `_HasDisplayConditions` mixin. Failures raise `ValueError`, surfaced as 422.

### Code Changes

* New `src/fides/api/schemas/privacy_center_field_base.py` — extracted `BaseCustomPrivacyRequestField` to its own module to avoid circular import between config schema and validator.
* New `src/fides/api/schemas/custom_field_display_validator.py` — `DisplayConditionValidator` traverses `Condition` tree and enforces:
  * Group operator allowed (`and`/`or`).
  * Leaf operator in allowed set (`eq`, `neq`, `exists`, `not_exists`, `list_contains`).
  * Leaf `field_address` references a known field.
  * Operator compatible with target `field_type` (per-type allowlist).
  * `exists`/`not_exists` carry no value; other operators carry typed value (bool for `checkbox`, str/list[str] for `checkbox_group`/`multiselect`, str for `text`/`textarea`/`select`/`location`).
* `privacy_center_config.py` — wire `_HasDisplayConditions` mixin into the three config schemas, drop now-relocated `BaseCustomPrivacyRequestField`.
* `display_condition: Optional[Condition]` added to `BaseCustomPrivacyRequestField`.
* Tests: `tests/ops/schemas/test_custom_field_display_validator.py` (274 lines, full operator/type matrix).
* Changelog entry.

### Steps to Confirm

1. POST a Privacy Center config containing a custom field with a `display_condition` referencing an unknown field key — expect 422.
2. POST a config where a `checkbox`-targeted leaf uses `list_contains` — expect 422 (operator/type mismatch).
3. POST a config where a `checkbox_group`-targeted leaf uses `eq` with a string value — expect 422.
4. POST a valid config (e.g. `checkbox_group` field gated behind `eq` on a `select` field) — expect 200.
5. Confirm `exists`/`not_exists` reject any `value` payload.


### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [x] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [x] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required

[ENG-3516]: https://ethyca.atlassian.net/browse/ENG-3516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ