### PR TITLE
ENG-3516: BE: Submission-time resolution of display_condition rules

### DIFF
--- a/changelog/8027-display-condition-submission.yaml
+++ b/changelog/8027-display-condition-submission.yaml
@@ -1,0 +1,4 @@
+type: Added
+description: Added submission-time resolution and enforcement of display_condition rules on custom Privacy Center fields
+pr: 8027
+labels: []

--- a/src/fides/service/privacy_request/custom_field_display_evaluator.py
+++ b/src/fides/service/privacy_request/custom_field_display_evaluator.py
@@ -1,0 +1,108 @@
+"""Submission-time evaluation of ``display_condition`` rules attached to
+``custom_privacy_request_fields``. One public entry point —
+:func:`evaluate_submission` — resolves which fields are applicable given
+the submission and raises :class:`DisplayConditionViolation` on the first
+contract violation. Callers translate the exception to whatever type
+their layer expects (HTTP error, ``PrivacyRequestError``, etc.).
+"""
+
+from typing import Any
+
+from fides.api.schemas.privacy_center_field_base import BaseCustomPrivacyRequestField
+from fides.api.schemas.redis_cache import CustomPrivacyRequestField
+from fides.api.task.conditional_dependencies.evaluator import ConditionEvaluator
+
+
+class DisplayConditionViolation(ValueError):
+    """A submission violates the display_condition contract — either a
+    gated-off field was submitted or a required-applicable field is missing.
+    """
+
+
+def evaluate_submission(
+    fields: dict[str, BaseCustomPrivacyRequestField],
+    submitted: dict[str, CustomPrivacyRequestField],
+    condition_evaluator: ConditionEvaluator,
+) -> None:
+    """Resolve which fields are applicable given ``submitted`` and raise
+    :class:`DisplayConditionViolation` on the first contract breach:
+
+    * a field gated off by its ``display_condition`` must not be submitted;
+    * a required field that is applicable must have a value.
+    """
+    applicable = _resolve_applicable(fields, submitted, condition_evaluator)
+    _enforce_visibility(fields, submitted, applicable)
+
+
+def _resolve_applicable(
+    fields: dict[str, BaseCustomPrivacyRequestField],
+    submitted_values: dict[str, CustomPrivacyRequestField],
+    evaluator: ConditionEvaluator,
+) -> set[str]:
+    """Fixed-point: keep filtering until the applicable set stops shrinking."""
+    normalised = {k: v.value for k, v in submitted_values.items()}
+    applicable: set[str] = set(fields.keys())
+    previous: set[str] = set()
+    while previous != applicable:
+        previous = applicable
+        data_view = {k: normalised.get(k) for k in applicable}
+        applicable = {
+            k for k in applicable if _is_applicable(fields[k], data_view, evaluator)
+        }
+    return applicable
+
+
+def _enforce_visibility(
+    fields: dict[str, BaseCustomPrivacyRequestField],
+    submitted_values: dict[str, CustomPrivacyRequestField],
+    applicable: set[str],
+) -> None:
+    """Reject gated-off submissions + missing required-applicable values."""
+    for key, raw in submitted_values.items():
+        if key in fields and key not in applicable and _submitted_has_value(raw):
+            raise DisplayConditionViolation(
+                f"Field '{key}' is gated off by its display_condition and "
+                "must not be submitted"
+            )
+    for key, field in fields.items():
+        if (
+            key in applicable
+            and bool(field.required)
+            and not _submitted_has_value(submitted_values.get(key))
+        ):
+            raise DisplayConditionViolation(f"Required field '{key}' is missing")
+
+
+def _is_applicable(
+    field: BaseCustomPrivacyRequestField,
+    data_view: dict[str, Any],
+    evaluator: ConditionEvaluator,
+) -> bool:
+    """True if ``field`` has no display_condition or it evaluates true.
+    Evaluator errors → hide the field (can't prove applicability)."""
+    condition = field.display_condition
+    if condition is None:
+        return True
+    try:
+        return bool(evaluator.evaluate_rule(condition, data_view).result)
+    except Exception:  # pylint: disable=broad-except
+        return False
+
+
+def _extract_submitted_value(raw: Any) -> Any:
+    if isinstance(raw, dict) and "value" in raw:
+        return raw["value"]
+    if hasattr(raw, "value"):
+        return raw.value
+    return raw
+
+
+def _submitted_has_value(raw: Any) -> bool:
+    value = _extract_submitted_value(raw)
+    if value is None:
+        return False
+    if isinstance(value, str) and value == "":
+        return False
+    if isinstance(value, list) and len(value) == 0:
+        return False
+    return True

--- a/src/fides/service/privacy_request/privacy_request_service.py
+++ b/src/fides/service/privacy_request/privacy_request_service.py
@@ -34,11 +34,13 @@ from fides.api.schemas.messaging.messaging import MessagingActionType
 from fides.api.schemas.policy import ActionType, CurrentStep
 from fides.api.schemas.privacy_center_config import (
     LocationCustomPrivacyRequestField,
+    PrivacyRequestOption,
     reorder_custom_privacy_request_fields,
 )
 from fides.api.schemas.privacy_center_config import (
     PrivacyCenterConfig as PrivacyCenterConfigSchema,
 )
+from fides.api.schemas.privacy_center_field_base import BaseCustomPrivacyRequestField
 from fides.api.schemas.privacy_request import (
     BULK_PRIVACY_REQUEST_BATCH_SIZE,
     BulkPostPrivacyRequests,
@@ -58,6 +60,7 @@ from fides.api.service.privacy_request.request_service import (
     build_required_privacy_request_kwargs,
     cache_data,
 )
+from fides.api.task.conditional_dependencies.evaluator import ConditionEvaluator
 from fides.api.tasks import DSR_QUEUE_NAME
 from fides.api.util.cache import cache_task_tracking_key
 from fides.api.util.enums import ColumnSort
@@ -68,6 +71,10 @@ from fides.service.messaging.messaging_service import (
     MessagingService,
     check_and_dispatch_error_notifications,
     send_privacy_request_receipt_message_to_user,
+)
+from fides.service.privacy_request.custom_field_display_evaluator import (
+    DisplayConditionViolation,
+    evaluate_submission,
 )
 from fides.service.privacy_request.privacy_request_csv_download import (
     privacy_request_csv_download,
@@ -200,19 +207,7 @@ class PrivacyRequestService:
         if privacy_request_data.location:
             return
 
-        config_dict = self._resolve_privacy_center_config_dict(
-            privacy_request_data.property_id
-        )
-        if not config_dict:
-            return
-
-        privacy_center_config = self._parse_privacy_center_config(config_dict)
-        if not privacy_center_config:
-            return
-
-        action = self._get_matching_action(
-            privacy_center_config, privacy_request_data.policy_key
-        )
+        action = self._resolve_action_for_request(privacy_request_data)
         if not action or not action.custom_privacy_request_fields:
             return
 
@@ -290,22 +285,73 @@ class PrivacyRequestService:
     @staticmethod
     def _get_matching_action(
         privacy_center_config: PrivacyCenterConfigSchema, policy_key: str
-    ) -> Optional[Any]:
+    ) -> Optional[PrivacyRequestOption]:
         """Return the action entry matching the given policy key, if any."""
         for action in privacy_center_config.actions:
             if action.policy_key == policy_key:
                 return action
         return None
 
+    def _resolve_action_for_request(
+        self, privacy_request_data: PrivacyRequestCreate
+    ) -> Optional[PrivacyRequestOption]:
+        """Walk config dict → parsed schema → matching action; return
+        ``None`` at the first step that yields nothing."""
+        property_id = privacy_request_data.property_id
+        policy_key = privacy_request_data.policy_key
+        config_dict = self._resolve_privacy_center_config_dict(property_id)
+        if not config_dict:
+            logger.debug("No privacy center config for property_id={}", property_id)
+            return None
+
+        privacy_center_config = self._parse_privacy_center_config(config_dict)
+        if not privacy_center_config:
+            logger.debug("Config failed to parse for property_id={}", property_id)
+            return None
+
+        action = self._get_matching_action(privacy_center_config, policy_key)
+        if not action or not action.custom_privacy_request_fields:
+            logger.debug("No matching action with fields for policy_key={}", policy_key)
+            return None
+
+        return action
+
+    def _validate_field_visibility(
+        self, privacy_request_data: PrivacyRequestCreate
+    ) -> None:
+        """Reject payloads that violate the action's display_condition
+        contract; translate :class:`DisplayConditionViolation` to ``PrivacyRequestError``."""
+        action = self._resolve_action_for_request(privacy_request_data)
+        if not action or not action.custom_privacy_request_fields:
+            return
+
+        # Location fields validated separately in ``_validate_required_location_fields``.
+        fields: dict[str, BaseCustomPrivacyRequestField] = {
+            key: cfg
+            for key, cfg in action.custom_privacy_request_fields.items()
+            if not isinstance(cfg, LocationCustomPrivacyRequestField)
+        }
+        if not fields:
+            return
+
+        try:
+            evaluate_submission(
+                fields=fields,
+                submitted=privacy_request_data.custom_privacy_request_fields or {},
+                condition_evaluator=ConditionEvaluator(self.db),
+            )
+        except DisplayConditionViolation as exc:
+            raise PrivacyRequestError(
+                str(exc), privacy_request_data.model_dump(mode="json")
+            ) from exc
+
     @staticmethod
     def _is_required_location_missing(
-        action: Any, privacy_request_data: PrivacyRequestCreate
+        action: PrivacyRequestOption, privacy_request_data: PrivacyRequestCreate
     ) -> bool:
         """Check if any required location fields exist without values in the request."""
-        if not getattr(action, "custom_privacy_request_fields", None):
-            return False
-
-        custom_fields = action.custom_privacy_request_fields
+        # Caller already guards against ``None``/empty; ``or {}`` narrows for mypy.
+        custom_fields = action.custom_privacy_request_fields or {}
         for field_name, field_config in custom_fields.items():
             if not isinstance(field_config, LocationCustomPrivacyRequestField):
                 continue
@@ -368,6 +414,9 @@ class PrivacyRequestService:
 
         # Validate location is provided for required location fields
         self._validate_required_location_fields(privacy_request_data)
+
+        # Validate display_condition visibility: no gated-off fields submitted,
+        self._validate_field_visibility(privacy_request_data)
 
         policy = Policy.get_by(
             db=self.db,

--- a/tests/service/privacy_request/test_custom_field_display_evaluator.py
+++ b/tests/service/privacy_request/test_custom_field_display_evaluator.py
@@ -1,0 +1,156 @@
+"""Tests for :func:`evaluate_submission` — submission-time visibility
+check on ``custom_privacy_request_fields``."""
+
+import pytest
+
+from fides.api.schemas.privacy_center_config import CustomPrivacyRequestField
+from fides.api.schemas.redis_cache import (
+    CustomPrivacyRequestField as SubmittedField,
+)
+from fides.api.task.conditional_dependencies.evaluator import ConditionEvaluator
+from fides.api.task.conditional_dependencies.schemas import ConditionLeaf, Operator
+from fides.service.privacy_request.custom_field_display_evaluator import (
+    DisplayConditionViolation,
+    _submitted_has_value,
+    evaluate_submission,
+)
+
+
+def _leaf(field_address, operator, value=None):
+    return ConditionLeaf(field_address=field_address, operator=operator, value=value)
+
+
+def _cprf(label, **kw):
+    return CustomPrivacyRequestField(label=label, **kw)
+
+
+def _sv(value, label="x"):
+    """Build a submitted ``CustomPrivacyRequestField`` (runtime model with
+    ``.value``) — what callers actually pass to ``evaluate_submission``.
+    """
+    return SubmittedField(label=label, value=value)
+
+
+def _agree_detail(detail_condition=None, *, agree_kw=None, detail_kw=None):
+    """checkbox ``agree`` + textarea ``detail`` (both ``required=False`` by
+    default to keep tests focused on visibility, not the required-check)."""
+    agree = {"field_type": "checkbox", "required": False, **(agree_kw or {})}
+    detail = {
+        "field_type": "textarea",
+        "required": False,
+        "display_condition": detail_condition,
+        **(detail_kw or {}),
+    }
+    return {"agree": _cprf("Agree", **agree), "detail": _cprf("Detail", **detail)}
+
+
+@pytest.fixture
+def evaluator():
+    return ConditionEvaluator(None)
+
+
+_AGREE_TRUE = _leaf("agree", Operator.eq, True)
+
+
+class TestEvaluateSubmission:
+    @pytest.mark.parametrize(
+        "fields, submitted",
+        [
+            pytest.param(
+                {
+                    "a": _cprf("A", field_type="text", required=False),
+                    "b": _cprf("B", field_type="checkbox", required=False),
+                },
+                {},
+                id="no_conditions",
+            ),
+            pytest.param(
+                _agree_detail(_AGREE_TRUE),
+                {"agree": _sv(True), "detail": _sv("text")},
+                id="condition_true",
+            ),
+            pytest.param(
+                _agree_detail(_AGREE_TRUE),
+                {"agree": _sv(False)},
+                id="condition_false_nothing_submitted",
+            ),
+            pytest.param(
+                _agree_detail(_leaf("agree", Operator.exists)),
+                {},
+                id="exists_with_no_submission",
+            ),
+        ],
+    )
+    def test_valid_submissions_pass(self, evaluator, fields, submitted):
+        evaluate_submission(fields, submitted, evaluator)
+
+    def test_gated_off_submission_raises(self, evaluator):
+        # detail's condition is false (agree=False) but a value was submitted.
+        with pytest.raises(DisplayConditionViolation, match="'detail' is gated off"):
+            evaluate_submission(
+                _agree_detail(_AGREE_TRUE),
+                {"agree": _sv(False), "detail": _sv("x")},
+                evaluator,
+            )
+
+    def test_required_applicable_missing_raises(self, evaluator):
+        fields = {"reason": _cprf("Reason", field_type="text", required=True)}
+        with pytest.raises(DisplayConditionViolation, match="Required field 'reason'"):
+            evaluate_submission(fields, {}, evaluator)
+
+    def test_required_non_applicable_passes(self, evaluator):
+        # required=True is ignored when the field is not applicable.
+        fields = _agree_detail(_AGREE_TRUE, detail_kw={"required": True})
+        evaluate_submission(fields, {"agree": _sv(False)}, evaluator)
+
+    def test_unknown_submitted_key_ignored(self, evaluator):
+        fields = {"agree": _cprf("Agree", field_type="checkbox", required=False)}
+        evaluate_submission(fields, {"stray": _sv("x")}, evaluator)
+
+    def test_transitive_hide_through_fixed_point(self, evaluator):
+        # b depends on a; c depends on b. Hiding a cascades to c.
+        fields = {
+            "a": _cprf("A", field_type="checkbox"),
+            "b": _cprf(
+                "B", field_type="text", display_condition=_leaf("a", Operator.eq, True)
+            ),
+            "c": _cprf(
+                "C", field_type="text", display_condition=_leaf("b", Operator.exists)
+            ),
+        }
+        with pytest.raises(DisplayConditionViolation, match="'b' is gated off"):
+            evaluate_submission(
+                fields,
+                {"a": _sv(False), "b": _sv("x"), "c": _sv("y")},
+                evaluator,
+            )
+
+    def test_evaluator_exception_hides_field(self, evaluator, monkeypatch):
+        # Defensive: evaluator blowup hides the field; submitting it then raises.
+        def boom(*a, **kw):
+            raise RuntimeError("evaluator exploded")
+
+        monkeypatch.setattr(evaluator, "evaluate_rule", boom)
+        with pytest.raises(DisplayConditionViolation, match="'detail' is gated off"):
+            evaluate_submission(
+                _agree_detail(_AGREE_TRUE),
+                {"agree": _sv(True), "detail": _sv("text")},
+                evaluator,
+            )
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("", False),
+        (None, False),
+        ([], False),
+        ("x", True),
+        (0, True),
+        (False, True),
+        ({"label": "x", "value": None}, False),
+        ({"label": "x", "value": "y"}, True),
+    ],
+)
+def test_submitted_has_value(raw, expected):
+    assert _submitted_has_value(raw) is expected

--- a/tests/service/privacy_request/test_privacy_request_service.py
+++ b/tests/service/privacy_request/test_privacy_request_service.py
@@ -1,6 +1,6 @@
+from contextlib import contextmanager
 from datetime import datetime, timezone
-from typing import List
-from unittest.mock import create_autospec, patch
+from unittest.mock import MagicMock, create_autospec, patch
 
 import pytest
 from sqlalchemy.orm import Session
@@ -19,8 +19,11 @@ from fides.api.models.property import Property
 from fides.api.models.worker_task import ExecutionLogStatus
 from fides.api.oauth.roles import APPROVER
 from fides.api.schemas.policy import ActionType
+from fides.api.schemas.privacy_center_config import (
+    CustomPrivacyRequestField,
+    LocationCustomPrivacyRequestField,
+)
 from fides.api.schemas.privacy_request import (
-    BulkUpdateFailed,
     PrivacyRequestCreate,
     PrivacyRequestSource,
     PrivacyRequestStatus,
@@ -1478,3 +1481,161 @@ class TestPrivacyRequestService:
             expected_batch = request_ids[start_idx : start_idx + len(batch)]
             assert batch == expected_batch
             start_idx += len(batch)
+
+
+def _make_action(custom_fields):
+    a = MagicMock()
+    a.custom_privacy_request_fields = custom_fields
+    return a
+
+
+@contextmanager
+def _stub_lookups(svc, *, config_dict={"x": 1}, parsed=True, action=True):
+    """Patch the three DB-backed lookups; ``True`` → non-None default."""
+    parsed_v = MagicMock() if parsed is True else parsed
+    action_v = MagicMock() if action is True else action
+    with (
+        patch.object(
+            svc, "_resolve_privacy_center_config_dict", return_value=config_dict
+        ),
+        patch.object(svc, "_parse_privacy_center_config", return_value=parsed_v),
+        patch.object(svc, "_get_matching_action", return_value=action_v),
+    ):
+        yield
+
+
+def _svc():
+    return PrivacyRequestService(MagicMock(), MagicMock(), MagicMock())
+
+
+def _req(custom_fields=None, **kw):
+    return PrivacyRequestCreate(
+        identity=Identity(email="jane@example.com"),
+        policy_key="default_access_policy",
+        custom_privacy_request_fields=custom_fields,
+        **kw,
+    )
+
+
+@pytest.mark.unit
+class TestValidateFieldVisibility:
+    """Branch-by-branch coverage of ``_validate_field_visibility`` via mocks."""
+
+    @pytest.mark.parametrize(
+        "stub_kwargs",
+        [
+            pytest.param({"config_dict": None}, id="no_config"),
+            pytest.param({"parsed": None}, id="unparseable_config"),
+            pytest.param({"action": None}, id="no_matching_action"),
+            pytest.param(
+                {"action": _make_action(None)}, id="action_without_custom_fields"
+            ),
+            pytest.param(
+                {
+                    "action": _make_action(
+                        {"country": LocationCustomPrivacyRequestField(label="Country")}
+                    )
+                },
+                id="only_location_fields_after_filter",
+            ),
+        ],
+    )
+    def test_short_circuit_paths(self, stub_kwargs):
+        svc = _svc()
+        with _stub_lookups(svc, **stub_kwargs):
+            svc._validate_field_visibility(_req())
+
+    @pytest.mark.parametrize(
+        "submitted, raises",
+        [
+            pytest.param(None, True, id="missing_required_raises"),
+            pytest.param(
+                {"reason": {"label": "Reason", "value": "just because"}},
+                False,
+                id="provided_passes",
+            ),
+        ],
+    )
+    def test_resolver_invocation(self, submitted, raises):
+        svc = _svc()
+        action = _make_action(
+            {
+                "reason": CustomPrivacyRequestField(
+                    label="Reason", field_type="text", required=True
+                )
+            }
+        )
+        with _stub_lookups(svc, action=action):
+            req = _req(custom_fields=submitted)
+            if raises:
+                with pytest.raises(
+                    PrivacyRequestError, match="Required field 'reason' is missing"
+                ):
+                    svc._validate_field_visibility(req)
+            else:
+                svc._validate_field_visibility(req)
+
+    def test_create_privacy_request_invokes_validate_field_visibility(self):
+        # Covers the call site inside ``create_privacy_request``. Stub the
+        # method itself + Policy.get_by so the request fails at the next
+        # check (``location`` short-circuits the prior location validator).
+        svc = _svc()
+        req = _req(location="US-CA")
+        req.policy_key = "missing-policy"
+        with (
+            patch.object(svc, "_validate_field_visibility") as visibility,
+            patch(
+                "fides.service.privacy_request.privacy_request_service.Policy.get_by",
+                return_value=None,
+            ),
+            pytest.raises(PrivacyRequestError, match="does not exist"),
+        ):
+            svc.create_privacy_request(req, authenticated=True)
+        visibility.assert_called_once_with(req)
+
+
+@pytest.mark.unit
+class TestValidateRequiredLocationFields:
+    @pytest.mark.parametrize(
+        "stub_kwargs",
+        [
+            pytest.param({"config_dict": None}, id="no_config"),
+            pytest.param({"parsed": None}, id="unparseable_config"),
+            pytest.param({"action": None}, id="no_matching_action"),
+            pytest.param(
+                {"action": _make_action(None)}, id="action_without_custom_fields"
+            ),
+            pytest.param(
+                {
+                    "action": _make_action(
+                        {
+                            "reason": CustomPrivacyRequestField(
+                                label="Reason", field_type="text", required=True
+                            )
+                        }
+                    )
+                },
+                id="non_location_required_field_ignored",
+            ),
+        ],
+    )
+    def test_short_circuit_paths(self, stub_kwargs):
+        svc = _svc()
+        with _stub_lookups(svc, **stub_kwargs):
+            svc._validate_required_location_fields(_req())
+
+    def test_missing_required_location_raises(self):
+        svc = _svc()
+        action = _make_action(
+            {
+                "country": LocationCustomPrivacyRequestField(
+                    label="Country", required=True
+                )
+            }
+        )
+        with _stub_lookups(svc, action=action):
+            with pytest.raises(
+                PrivacyRequestError,
+                match="Location is required for field 'country'",
+            ):
+                svc._validate_required_location_fields(_req())


### PR DESCRIPTION
Ticket [ENG-3516]

### Description Of Changes

Add submission-time resolution and enforcement of `display_condition` rules on custom Privacy Center fields. Builds on `DisplayConditionValidator` (PR #8026, save-time): once a config is known to be well-formed, this PR resolves which fields are *applicable* given the submitted values and enforces the contract on incoming privacy request payloads.

Two enforced rules:
* a field gated off by its `display_condition` must not be submitted;
* a required field that is applicable must have a non-empty value.

Wired into `PrivacyRequestService.create_privacy_request` so both public and authenticated creation paths reject violating payloads with 422 (via `PrivacyRequestError`).

### Code Changes

* New `src/fides/api/schemas/custom_field_display_evaluator.py`:
  * `DisplayConditionViolation(ValueError)` — raised on first contract breach; callers translate to layer-appropriate error.
  * `evaluate_submission(fields, submitted, condition_evaluator)` — single public entry point.
  * `_resolve_applicable` runs a fixed-point: keep filtering the applicable set until it stops shrinking (handles chained conditions where field B's visibility depends on field A's, and A is itself gated off).
  * `_extract_submitted_value` normalises raw JSON dicts, `CustomPrivacyRequestField` Pydantic instances, and bare values into a single comparable shape.
  * Evaluator errors fail closed — field treated as not applicable when applicability can't be proven.
* `src/fides/service/privacy_request/privacy_request_service.py`:
  * New `_validate_field_visibility` resolves config + action for the request, filters out `LocationCustomPrivacyRequestField` entries (location handled separately), and calls `evaluate_submission` with a `ConditionEvaluator(self.db)`.
  * Hooked into `create_privacy_request` next to the existing required-location validation.
  * `DisplayConditionViolation` is translated to `PrivacyRequestError`.

### Steps to Confirm

1. With a Privacy Center action that has a custom field gated by `display_condition`, POST a privacy request submitting that field with a value while the gating condition is *false* — expect 422 ("gated off … must not be submitted").
2. With a required custom field whose `display_condition` evaluates *true*, POST a privacy request omitting it — expect 422 ("Required field … is missing").
3. POST a valid request where the gated field is omitted while the gating condition is false — expect 200.
4. POST a valid request where the gated field is submitted while the gating condition is true — expect 200.
5. Submit nested chained conditions (B depends on A, A is gated off) — confirm B is treated as not applicable (fixed-point).
6. Confirm `LocationCustomPrivacyRequestField` entries are still validated by the existing required-location path and not double-checked here.

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [x] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [x] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [x] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [x] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-3516]: https://ethyca.atlassian.net/browse/ENG-3516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ