### PR TITLE
Update 2.84.0 changelog fragment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ loading, pipeline orchestration, and YAML config directory support. [#7944](http
 - Fixed browser navigation for Action Center ignored assets [#7961](https://github.com/ethyca/fides/pull/7961)
 - Fixed property-based DAG filtering for SaaS connector datasets. [#7868](https://github.com/ethyca/fides/pull/7868)
 - Fixed property creation 422 error caused by missing paths field in form submission payload [#7908](https://github.com/ethyca/fides/pull/7908)
+- Fix custom field updates on privacy declarations failing with duplicate key or null ID constraint violations. [#8024](https://github.com/ethyca/fides/pull/8024)
 
 ## [2.83.3](https://github.com/ethyca/fides/compare/2.83.2..2.83.3)
 

--- a/changelog/8024-fix-custom-field-upsert.yaml
+++ b/changelog/8024-fix-custom-field-upsert.yaml
@@ -1,4 +1,0 @@
-type: Fixed
-description: Fix custom field updates on privacy declarations failing with duplicate key or null ID constraint violations
-pr: 8024
-labels: []


### PR DESCRIPTION
# Description

Rolls the changelog fragment for PR #8024 into `CHANGELOG.md` under the 2.84.0 Fixed section, and removes the now-redundant `changelog/8024-fix-custom-field-upsert.yaml` file.

## Code Changes

- **CHANGELOG.md** — Added entry for #8024 (fix custom field updates on privacy declarations)
- **changelog/8024-fix-custom-field-upsert.yaml** — Deleted (rolled into CHANGELOG.md)

## Pre-Merge Checklist

- [x] Changelog entry included
- [ ] CI passes