### PR TITLE
ENG-3517: BE: File upload for custom privacy center fields

### DIFF
--- a/changelog/8035-attachment-upload.yaml
+++ b/changelog/8035-attachment-upload.yaml
@@ -1,0 +1,4 @@
+type: Added
+description: Added file-upload field type for custom Privacy Center forms
+pr: 8035
+labels: []

--- a/src/fides/api/alembic/migrations/versions/xx_2026_04_17_1200_9b449105864d_add_attachment_user_provided.py
+++ b/src/fides/api/alembic/migrations/versions/xx_2026_04_17_1200_9b449105864d_add_attachment_user_provided.py
@@ -1,0 +1,78 @@
+"""add attachment_user_provided
+
+Revision ID: 9b449105864d
+Revises: d71c7d274c04
+Create Date: 2026-04-17 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "9b449105864d"
+down_revision = "d71c7d274c04"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "attachment_user_provided",
+        sa.Column("id", sa.String(length=255), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("object_key", sa.String(), nullable=False),
+        sa.Column(
+            "status",
+            sa.Enum(
+                "uploaded",
+                "promoted",
+                "deleted",
+                name="attachmentuserprovidedstatus",
+            ),
+            server_default="uploaded",
+            nullable=False,
+        ),
+        sa.Column("storage_key", sa.String(), nullable=False),
+        sa.Column("promoted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "object_key", name="uq_attachment_user_provided_object_key"
+        ),
+    )
+    op.create_index(
+        op.f("ix_attachment_user_provided_id"),
+        "attachment_user_provided",
+        ["id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_attachment_user_provided_status_created_at",
+        "attachment_user_provided",
+        ["status", "created_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_attachment_user_provided_status_created_at",
+        table_name="attachment_user_provided",
+    )
+    op.drop_index(
+        op.f("ix_attachment_user_provided_id"),
+        table_name="attachment_user_provided",
+    )
+    op.drop_table("attachment_user_provided")
+    op.execute("DROP TYPE attachmentuserprovidedstatus")

--- a/src/fides/api/models/attachment.py
+++ b/src/fides/api/models/attachment.py
@@ -33,6 +33,7 @@ class AttachmentType(str, EnumType):
 
     internal_use_only = "internal_use_only"
     include_with_access_package = "include_with_access_package"
+    user_provided = "user_provided"
 
 
 class AttachmentReferenceType(str, EnumType):
@@ -46,6 +47,21 @@ class AttachmentReferenceType(str, EnumType):
     comment = "comment"
     manual_task_submission = "manual_task_submission"
     request_task = "request_task"
+
+
+class AttachmentUserProvidedStatus(str, EnumType):
+    """Lifecycle states for a data-subject-uploaded attachment.
+
+    - ``uploaded``: written to storage, awaiting privacy-request submission.
+    - ``promoted``: claimed by a submitted privacy request and converted to
+      an ``Attachment`` row; ``promoted_attachment_id`` is populated.
+    - ``deleted``: temp file removed by the orphan cleanup sweep (row kept
+      for audit).
+    """
+
+    uploaded = "uploaded"
+    promoted = "promoted"
+    deleted = "deleted"
 
 
 class AttachmentReference(Base):
@@ -175,3 +191,54 @@ class Attachment(Base):
     ) -> "Attachment":
         """Creates a new attachment record in the database."""
         return cls._create_record(db=db, data=data, check_name=check_name)
+
+
+class AttachmentUserProvided(Base):
+    """Tracks data-subject-uploaded file attachments through their lifecycle.
+
+    Each row owns the state of a single temp-storage object, from upload
+    (``uploaded``) → claim (``promoted``) → cleanup (``deleted``). Durable
+    across Redis restarts and queryable for audit.
+
+    Independent table — no foreign keys. ``storage_key`` /
+    ``promoted_attachment_id`` are plain string references looked up on
+    demand; removals in the referenced tables do not cascade here, so rows
+    are preserved for forensics regardless of storage-config or attachment
+    churn.
+    """
+
+    @declared_attr
+    def __tablename__(cls) -> str:
+        """Match the snake_case table name from the alembic migration."""
+        return "attachment_user_provided"
+
+    created_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    object_key = Column(String, nullable=False, unique=True)
+
+    status = Column(
+        EnumColumn(AttachmentUserProvidedStatus, name="attachmentuserprovidedstatus"),
+        nullable=False,
+        server_default=AttachmentUserProvidedStatus.uploaded.value,
+    )
+
+    storage_key = Column(String, nullable=False)
+    promoted_at = Column(DateTime(timezone=True), nullable=True)
+
+    __table_args__ = (
+        # Speeds up the orphan-cleanup sweep:
+        #   WHERE status = 'uploaded' AND created_at < :cutoff
+        Index(
+            "ix_attachment_user_provided_status_created_at",
+            "status",
+            "created_at",
+        ),
+    )

--- a/src/fides/api/schemas/attachment.py
+++ b/src/fides/api/schemas/attachment.py
@@ -1,0 +1,23 @@
+"""Pydantic schemas for data-subject-uploaded attachments."""
+
+from pydantic import ConfigDict, Field
+
+from fides.api.schemas.base_class import FidesSchema
+
+
+class PrivacyRequestAttachment(FidesSchema):
+    """Response payload for the privacy-request attachment upload endpoint.
+
+    The Privacy Center echoes ``id`` back in the custom field's ``value``
+    list when the request is submitted — that id is the sole identifier
+    the server uses to resolve the upload.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(
+        description=(
+            "AttachmentUserProvided row id. Echo this back in the custom "
+            "field's value list when the request is submitted."
+        ),
+    )

--- a/src/fides/api/schemas/privacy_center_config.py
+++ b/src/fides/api/schemas/privacy_center_config.py
@@ -106,6 +106,56 @@ class LocationCustomPrivacyRequestField(BaseCustomPrivacyRequestField):
         return values
 
 
+DEFAULT_FILE_MAX_SIZE_BYTES = 10 * 1024 * 1024  # 10 MB
+
+
+def _default_allowed_mime_types() -> List[str]:
+    # Import locally to avoid pulling storage/service modules at schema import time.
+    from fides.api.service.storage.util import PublicUploadAllowedFileTypes
+
+    return sorted(PublicUploadAllowedFileTypes.mime_types())
+
+
+class FileUploadCustomPrivacyRequestField(BaseCustomPrivacyRequestField):
+    """File upload field — supports a list of file attachments.
+
+    ``max_size_bytes`` and ``allowed_mime_types`` are config hints used by
+    the Privacy Center client to pre-filter uploads. The upload endpoint
+    currently enforces the global defaults (``DEFAULT_FILE_MAX_SIZE_BYTES``
+    and :meth:`PublicUploadAllowedFileTypes.mime_types`); per-field
+    tightening at upload time is a follow-up.
+    """
+
+    field_type: Literal["file"] = "file"
+    required: Optional[bool] = False
+    max_size_bytes: int = Field(default=DEFAULT_FILE_MAX_SIZE_BYTES, gt=0)
+    allowed_mime_types: List[str] = Field(default_factory=_default_allowed_mime_types)
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_file_field(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        if values.get("options"):
+            raise ValueError("file fields do not support options")
+        return values
+
+    @field_validator("allowed_mime_types")
+    @classmethod
+    def validate_allowed_mime_types(cls, v: List[str]) -> List[str]:
+        # Import locally to keep the schema module independent of services.
+        from fides.api.service.storage.util import PublicUploadAllowedFileTypes
+
+        supported = PublicUploadAllowedFileTypes.mime_types()
+        if not v:
+            raise ValueError("allowed_mime_types must not be empty")
+        unsupported = [mime for mime in v if mime not in supported]
+        if unsupported:
+            raise ValueError(
+                f"Unsupported MIME types: {sorted(unsupported)}. "
+                f"Supported: {sorted(supported)}"
+            )
+        return v
+
+
 # Create a discriminated union type using the field_type to properly distinguish between types
 def get_field_type_discriminator(v: Any) -> str:
     """Discriminator function for CustomPrivacyRequestFieldUnion"""
@@ -117,12 +167,15 @@ def get_field_type_discriminator(v: Any) -> str:
 
     if field_type == "location":
         return "location"
+    if field_type == "file":
+        return "file"
     return "custom"
 
 
 CustomPrivacyRequestFieldUnion = Annotated[
     Union[
         Annotated[LocationCustomPrivacyRequestField, Tag("location")],
+        Annotated[FileUploadCustomPrivacyRequestField, Tag("file")],
         Annotated[CustomPrivacyRequestField, Tag("custom")],
     ],
     Discriminator(get_field_type_discriminator),

--- a/src/fides/api/service/storage/util.py
+++ b/src/fides/api/service/storage/util.py
@@ -8,6 +8,81 @@ from loguru import logger
 
 from fides.api.util.storage_util import format_size
 
+
+class FilesMagicBytes(EnumType):
+    """Catalog of magic byte signatures for common upload-capable file types.
+
+    Used to verify actual file contents on upload — the declared
+    Content-Type header is not trusted on its own. Each member carries
+    ``(magic, mime)``; this is pure catalog data, independent of whether
+    a given type is currently accepted anywhere.
+
+    Some formats share magic bytes (docx/xlsx/zip are all ``PK\\x03\\x04``;
+    doc/xls are both OLE compound files); :meth:`from_bytes` resolves this
+    by returning the MIME of the first matching catalog entry (declaration
+    order). Plain-text formats (txt, csv) have no magic signature; their
+    ``magic`` is ``None`` and they never match via :meth:`from_bytes`.
+    """
+
+    pdf = (b"%PDF", "application/pdf")
+    doc = (b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1", "application/msword")
+    docx = (
+        b"PK\x03\x04",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    )
+    txt = (None, "text/plain")
+    jpg = (b"\xff\xd8\xff", "image/jpeg")
+    jpeg = (b"\xff\xd8\xff", "image/jpeg")
+    png = (b"\x89PNG\r\n\x1a\n", "image/png")
+    xls = (b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1", "application/vnd.ms-excel")
+    xlsx = (
+        b"PK\x03\x04",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    )
+    csv = (None, "text/csv")
+    zip = (b"PK\x03\x04", "application/zip")
+
+    def __init__(self, magic: Optional[bytes], mime: str) -> None:
+        self.magic = magic
+        self.mime = mime
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> Optional[str]:
+        """Return the single MIME type whose magic prefix matches ``data``.
+
+        Resolves shared-magic ambiguity (e.g. ``PK\\x03\\x04`` → docx/xlsx/zip;
+        OLE → doc/xls) by returning the MIME of the first catalog entry
+        that matches, in enum declaration order. Members with ``magic=None``
+        (plain-text formats) are never matched. Returns ``None`` if no
+        signature matches.
+
+        Callers gate the returned MIME against a policy set (e.g.
+        :meth:`PublicUploadAllowedFileTypes.mime_types`) — this method
+        answers "what is it?", not "is it allowed?".
+        """
+        for member in cls:
+            if member.magic is not None and data[: len(member.magic)] == member.magic:
+                return member.mime
+        return None
+
+
+class PublicUploadAllowedFileTypes(EnumType):
+    """MIME types accepted on public (unauthenticated) upload endpoints.
+
+    Narrower than :class:`FilesMagicBytes` by design — expanding the
+    allow-list is a one-line change here without touching the magic-byte
+    catalog.
+    """
+
+    pdf = "application/pdf"
+    jpg = "image/jpeg"
+    png = "image/png"
+
+    @classmethod
+    def mime_types(cls) -> set[str]:
+        return {member.value for member in cls}
+
+
 # This is the max file size for downloading the content of an attachment.
 # This is an industry standard used by companies like Google and Microsoft.
 LARGE_FILE_THRESHOLD = 2 * 1024 * 1024 * 1024  # 2 GB
@@ -29,6 +104,19 @@ class AllowedFileType(EnumType):
     xlsx = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
     csv = "text/csv"
     zip = "application/zip"
+
+
+MIME_TO_EXTENSION: dict[str, str] = {
+    member.value: member.name for member in AllowedFileType
+}
+
+
+def extension_for_mime(mime: str) -> str:
+    """Return the file extension matching an allowed MIME (without leading dot)."""
+    try:
+        return MIME_TO_EXTENSION[mime]
+    except KeyError as exc:
+        raise ValueError(f"No extension registered for MIME {mime!r}") from exc
 
 
 LOCAL_FIDES_UPLOAD_DIRECTORY = "fides_uploads"

--- a/src/fides/api/v1/api.py
+++ b/src/fides/api/v1/api.py
@@ -18,6 +18,7 @@ from fides.api.v1.endpoints import (
     policy_endpoints,
     policy_webhook_endpoints,
     pre_approval_webhook_endpoints,
+    privacy_request_attachment_endpoints,
     privacy_request_endpoints,
     privacy_request_redaction_patterns_endpoints,
     saas_config_endpoints,
@@ -45,6 +46,7 @@ api_router.include_router(oauth_endpoints.router)
 api_router.include_router(policy_endpoints.router)
 api_router.include_router(policy_webhook_endpoints.router)
 api_router.include_router(pre_approval_webhook_endpoints.router)
+api_router.include_router(privacy_request_attachment_endpoints.router)
 api_router.include_router(privacy_request_endpoints.router)
 api_router.include_router(privacy_request_redaction_patterns_endpoints.router)
 api_router.include_router(identity_verification_endpoints.router)

--- a/src/fides/api/v1/endpoints/privacy_request_attachment_endpoints.py
+++ b/src/fides/api/v1/endpoints/privacy_request_attachment_endpoints.py
@@ -1,0 +1,115 @@
+"""Unauthenticated upload endpoint for data-subject-uploaded privacy request files.
+
+Same trust level as privacy-request creation, protected by the public
+request rate limit and a streaming size cap.  See
+``fides.service.privacy_request.attachment_user_provided_service`` for the
+lifecycle model.
+"""
+
+from fastapi import Depends, File, Header, HTTPException, Request, Response, UploadFile
+from loguru import logger
+from sqlalchemy.orm import Session
+from starlette.status import (
+    HTTP_400_BAD_REQUEST,
+    HTTP_403_FORBIDDEN,
+    HTTP_413_CONTENT_TOO_LARGE,
+    HTTP_503_SERVICE_UNAVAILABLE,
+)
+
+from fides.api.deps import get_db
+from fides.api.schemas.attachment import PrivacyRequestAttachment
+from fides.api.util.api_router import APIRouter
+from fides.api.util.rate_limit import fides_limiter
+from fides.common.urn_registry import PRIVACY_REQUEST_ATTACHMENT, V1_URL_PREFIX
+from fides.config import CONFIG
+from fides.service.privacy_request.attachment_user_provided_service import (
+    DEFAULT_MAX_SIZE_BYTES,
+    UPLOAD_READ_CHUNK_BYTES,
+    upload_attachment,
+)
+
+router = APIRouter(tags=["Privacy Requests"], prefix=V1_URL_PREFIX)
+
+
+@router.post(
+    PRIVACY_REQUEST_ATTACHMENT,
+    response_model=PrivacyRequestAttachment,
+)
+@fides_limiter.limit(CONFIG.security.request_rate_limit)
+def upload_privacy_request_attachment(
+    *,
+    request: Request,  # required for rate limiting
+    response: Response,  # required for rate limiting
+    file: UploadFile = File(...),
+    content_length: int | None = Header(default=None),
+    db: Session = Depends(get_db),
+) -> PrivacyRequestAttachment:
+    """Upload a file attachment for use in a custom privacy request field.
+
+    Unauthenticated — same trust level as privacy-request creation. Protected
+    by the public request rate limit, a ``Content-Length`` pre-check, and a
+    streaming size cap so an attacker cannot buffer unbounded bodies into
+    memory.
+
+    Returns an attachment ``id`` to include in the custom field's ``value``
+    list when submitting the privacy request:
+
+        "value": ["<attachment id>"]
+
+    File type is verified via magic byte inspection.
+
+    Gated on ``CONFIG.execution.allow_custom_privacy_request_field_collection``
+    — uploads only make sense when custom fields (the mechanism that
+    references them) are themselves enabled.
+    """
+    if not CONFIG.execution.allow_custom_privacy_request_field_collection:
+        raise HTTPException(
+            status_code=HTTP_403_FORBIDDEN,
+            detail=(
+                "File attachments are disabled because custom privacy "
+                "request field collection is not enabled."
+            ),
+        )
+
+    # Content-Length pre-check — reject oversize requests before reading any
+    # body bytes. A hostile client can lie about Content-Length, so the
+    # streaming check below still runs as the authoritative guard; this just
+    # avoids buffering the body at all in the honest case.
+    if content_length is not None and content_length > DEFAULT_MAX_SIZE_BYTES:
+        raise HTTPException(
+            status_code=HTTP_413_CONTENT_TOO_LARGE,
+            detail=(
+                f"File exceeds maximum allowed size of {DEFAULT_MAX_SIZE_BYTES} bytes"
+            ),
+        )
+
+    chunks: list[bytes] = []
+    total = 0
+    while True:
+        chunk = file.file.read(UPLOAD_READ_CHUNK_BYTES)
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > DEFAULT_MAX_SIZE_BYTES:
+            raise HTTPException(
+                status_code=HTTP_413_CONTENT_TOO_LARGE,
+                detail=(
+                    f"File exceeds maximum allowed size of {DEFAULT_MAX_SIZE_BYTES} bytes"
+                ),
+            )
+        chunks.append(chunk)
+
+    file_data = b"".join(chunks)
+
+    try:
+        return upload_attachment(file_data=file_data, db=db)
+    except ValueError as exc:
+        raise HTTPException(status_code=HTTP_400_BAD_REQUEST, detail=str(exc))
+    except RuntimeError as exc:
+        # Log the internal reason but return a generic 503 to the public
+        # caller — storage-misconfig details shouldn't leak to unauth users.
+        logger.error("Attachment upload failed (misconfiguration): {}", exc)
+        raise HTTPException(
+            status_code=HTTP_503_SERVICE_UNAVAILABLE,
+            detail="File attachments are temporarily unavailable.",
+        )

--- a/src/fides/common/urn_registry.py
+++ b/src/fides/common/urn_registry.py
@@ -84,6 +84,7 @@ PRIVACY_REQUEST_APPROVE = "/privacy-request/administrate/approve"
 PRIVACY_REQUEST_BATCH_EMAIL_SEND = (
     "/privacy-request/administrate/process-awaiting-email-send"
 )
+PRIVACY_REQUEST_ATTACHMENT = "/privacy-request/attachment"
 PRIVACY_REQUEST_AUTHENTICATED = "/privacy-request/authenticated"
 PRIVACY_REQUEST_BULK_FINALIZE = "/privacy-request/bulk/finalize"
 PRIVACY_REQUEST_BULK_RETRY = "/privacy-request/bulk/retry"

--- a/src/fides/service/privacy_request/attachment_user_provided_repository.py
+++ b/src/fides/service/privacy_request/attachment_user_provided_repository.py
@@ -1,0 +1,87 @@
+"""Data-access layer for ``AttachmentUserProvided`` rows.
+
+Encapsulates every SQLAlchemy query and mutation the attachment
+user-provided service needs for upload + promotion. Cleanup-side
+methods (``mark_deleted`` / ``list_uploaded_older_than``) ship in the
+follow-up branch that adds the orphan-sweep task.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from fides.api.models.attachment import (
+    AttachmentUserProvided,
+    AttachmentUserProvidedStatus,
+)
+
+
+class AttachmentUserProvidedRepository:
+    """DB reads/writes for ``attachment_user_provided``."""
+
+    def __init__(self, db: Session) -> None:
+        self._db = db
+
+    def create_uploaded(
+        self, *, object_key: str, storage_key: str
+    ) -> AttachmentUserProvided:
+        """Insert a new ``uploaded`` row (in-session, no commit).
+
+        Flushes so the caller can read server-generated columns (``id``,
+        ``created_at``). The caller owns the transaction — the row is
+        visible to the same session and rolls back if the caller does.
+        """
+        row = AttachmentUserProvided(
+            object_key=object_key,
+            status=AttachmentUserProvidedStatus.uploaded,
+            storage_key=storage_key,
+        )
+        self._db.add(row)
+        self._db.flush()
+        self._db.refresh(row)
+        return row
+
+    def mark_promoted(
+        self,
+        rows: list[AttachmentUserProvided],
+        *,
+        promoted_at: Optional[datetime] = None,
+    ) -> None:
+        """Flip rows from ``uploaded`` to ``promoted`` (in-session, no commit).
+
+        Caller owns the transaction — mutations are visible to the same
+        session and roll back if the caller does.
+
+        Raises:
+            ValueError: A row is not in ``uploaded``.
+        """
+        now = promoted_at or datetime.now(timezone.utc)
+        for row in rows:
+            if row.status != AttachmentUserProvidedStatus.uploaded:
+                raise ValueError(
+                    f"Attachment '{row.object_key}' is in state {row.status}, "
+                    "expected 'uploaded'. Refusing to promote."
+                )
+            row.status = AttachmentUserProvidedStatus.promoted
+            row.promoted_at = now
+
+    def lock_uploaded_by_ids(self, ids: list[str]) -> list[AttachmentUserProvided]:
+        """Return ``uploaded`` rows matching ``ids`` under ``FOR UPDATE``.
+
+        The lock is released by any ``COMMIT`` (or ``ROLLBACK``) on the
+        caller's session — including commits issued by downstream
+        ``Base.create`` calls. The authoritative concurrency guard is
+        :meth:`mark_promoted`'s ``row.status != uploaded`` check.
+        """
+        return (
+            self._db.query(AttachmentUserProvided)
+            .filter(AttachmentUserProvided.id.in_(ids))
+            .filter(
+                AttachmentUserProvided.status == AttachmentUserProvidedStatus.uploaded
+            )
+            .with_for_update()
+            .all()
+        )

--- a/src/fides/service/privacy_request/attachment_user_provided_service.py
+++ b/src/fides/service/privacy_request/attachment_user_provided_service.py
@@ -1,0 +1,302 @@
+"""Service layer for data-subject-uploaded file attachments.
+
+Lifecycle (DB-backed state machine on ``attachment_user_provided``):
+
+    (no row) ──upload──▶ uploaded ──claim──▶ promoted
+
+Responsibilities:
+- Upload raw bytes to the active default storage backend and insert an
+  ``uploaded`` row.
+- Identify which custom-field values reference uploaded rows and return
+  the rows ready for promotion (``resolve_file_attachments``).
+- Atomically transition uploaded → promoted and create ``Attachment`` rows
+  linked to each promoted user-provided row (``promote_rows_to_attachments``).
+
+The orphan-sweep cleanup that takes ``uploaded`` rows to ``deleted`` ships
+in a follow-up branch.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from io import BytesIO
+from typing import Any, Dict, Optional
+from uuid import uuid4
+
+from loguru import logger
+from sqlalchemy.orm import Session
+
+from fides.api.models.attachment import (
+    AttachmentReferenceType,
+    AttachmentType,
+    AttachmentUserProvided,
+)
+from fides.api.models.privacy_request.privacy_request import PrivacyRequest
+from fides.api.models.storage import StorageConfig, get_active_default_storage_config
+from fides.api.schemas.attachment import PrivacyRequestAttachment
+from fides.api.schemas.privacy_center_config import DEFAULT_FILE_MAX_SIZE_BYTES
+from fides.api.schemas.redis_cache import CustomPrivacyRequestField
+from fides.api.service.storage.providers import StorageProviderFactory
+from fides.api.service.storage.providers.base import StorageProvider
+from fides.api.service.storage.util import (
+    FilesMagicBytes,
+    PublicUploadAllowedFileTypes,
+    extension_for_mime,
+)
+from fides.config import CONFIG
+from fides.service.attachment_service import AttachmentService
+from fides.service.privacy_request.attachment_user_provided_repository import (
+    AttachmentUserProvidedRepository,
+)
+
+# Re-export under a shorter local alias for the endpoint + internal use.
+DEFAULT_MAX_SIZE_BYTES = DEFAULT_FILE_MAX_SIZE_BYTES
+
+# Chunk size for streaming uploads — abort as soon as cumulative size exceeds
+# DEFAULT_MAX_SIZE_BYTES so an attacker cannot buffer an unbounded body.
+UPLOAD_READ_CHUNK_BYTES = 64 * 1024
+
+OBJECT_KEY_PREFIX = "privacy_request_attachments/"
+
+
+def _bucket(storage_config: StorageConfig) -> str:
+    return (storage_config.details or {}).get("bucket", "")
+
+
+def _get_provider_and_bucket(
+    db: Session,
+) -> tuple[StorageProvider, str, StorageConfig]:
+    """Return (provider, bucket, storage_config) or raise RuntimeError.
+
+    Centralises the three-way lookup used by upload, promotion, and orphan
+    cleanup so callers share the same error path.
+    """
+    storage_config = get_active_default_storage_config(db)
+    if not storage_config:
+        raise RuntimeError(
+            "No active default storage configuration found. "
+            "Configure a storage backend before accepting file attachments."
+        )
+    provider = StorageProviderFactory.create(storage_config)
+    return provider, _bucket(storage_config), storage_config
+
+
+def upload_attachment(
+    *,
+    file_data: bytes,
+    db: Session,
+) -> PrivacyRequestAttachment:
+    """Validate, store, and register a file attachment.
+
+    Writes the file under ``privacy_request_attachments/{uuid}.{ext}``
+    using the active default storage backend and inserts an
+    ``AttachmentUserProvided`` row with status ``pending``. The original
+    client-supplied filename is discarded — the stored name is entirely
+    server-generated, eliminating a class of path/metadata-injection
+    risks at the storage boundary.
+
+    File type is determined purely from magic-byte inspection; the
+    client-declared Content-Type is ignored. Size is enforced via
+    ``DEFAULT_MAX_SIZE_BYTES``.
+
+    Raises:
+        ValueError: File fails size or type validation.
+        RuntimeError: No active storage config found.
+    """
+    if len(file_data) > DEFAULT_MAX_SIZE_BYTES:
+        raise ValueError(
+            f"File exceeds maximum allowed size of {DEFAULT_MAX_SIZE_BYTES} bytes "
+            f"(received {len(file_data)} bytes)"
+        )
+
+    allowed = PublicUploadAllowedFileTypes.mime_types()
+    content_type = FilesMagicBytes.from_bytes(file_data)
+    if content_type is None or content_type not in allowed:
+        raise ValueError(f"File type is not allowed. Allowed types: {sorted(allowed)}")
+
+    provider, bucket, storage_config = _get_provider_and_bucket(db)
+    object_key = f"{OBJECT_KEY_PREFIX}{uuid4()}.{extension_for_mime(content_type)}"
+    result = provider.upload(
+        bucket=bucket,
+        key=object_key,
+        data=BytesIO(file_data),
+        content_type=content_type,
+    )
+
+    row = AttachmentUserProvidedRepository(db).create_uploaded(
+        object_key=object_key,
+        storage_key=storage_config.key,
+    )
+    db.commit()
+
+    logger.info(
+        "Uploaded attachment id={} size={} type={}",
+        row.id,
+        result.file_size,
+        content_type,
+    )
+
+    return PrivacyRequestAttachment(id=row.id)
+
+
+def resolve_file_attachments(
+    custom_privacy_request_fields: Optional[Dict[str, CustomPrivacyRequestField]],
+    file_field_names: set[str],
+    db: Session,
+) -> list[AttachmentUserProvided]:
+    """Resolve file-field values to ``AttachmentUserProvided`` rows.
+
+    ``file_field_names`` is authoritative — derived from the Privacy Center
+    config's ``field_type == "file"`` entries. For each listed field, each
+    id in its ``value`` list is looked up against the pending rows. The
+    caller is responsible for stripping the file-field keys from the
+    payload before persisting the remaining custom fields.
+
+    Lock semantics: ``lock_uploaded_by_ids`` issues ``FOR UPDATE``, but any
+    subsequent ``db.commit()`` on the caller's session releases that lock.
+    The authoritative concurrency guard is the ``row.status != pending``
+    check inside :func:`AttachmentUserProvidedRepository.mark_promoted`;
+    a racing promotion on the same row causes that check to raise and the
+    caller to roll back. The lock is a best-effort optimisation to reduce
+    the race window, not a hard guarantee.
+
+    Status transitions do NOT happen here; they are deferred to
+    :func:`promote_rows_to_attachments` so that if privacy-request
+    creation rolls back, pending rows stay pending.
+
+    Raises:
+        ValueError: A file field's value is malformed (not a list of
+            strings) or any id fails to resolve to a pending row.
+    """
+    if not custom_privacy_request_fields or not file_field_names:
+        return []
+
+    if not CONFIG.execution.allow_custom_privacy_request_field_collection:
+        return []
+
+    rows: list[AttachmentUserProvided] = []
+    repo = AttachmentUserProvidedRepository(db)
+
+    for name in file_field_names:
+        field = custom_privacy_request_fields.get(name)
+        if field is None:
+            continue
+
+        value = field.value
+        if not isinstance(value, list) or not all(isinstance(v, str) for v in value):
+            raise ValueError(
+                f"File attachment for field '{name}' must be a list of attachment ids."
+            )
+        ids: list[str] = [v for v in value if isinstance(v, str)]
+        if not ids:
+            continue
+
+        pending = {r.id: r for r in repo.lock_uploaded_by_ids(ids)}
+        for item in ids:
+            row = pending.get(item)
+            if row is None:
+                raise ValueError(
+                    f"File attachment for field '{name}' "
+                    "has expired or is invalid. Please re-upload and resubmit."
+                )
+            rows.append(row)
+
+    return rows
+
+
+def promote_rows_to_attachments(
+    privacy_request: PrivacyRequest,
+    db: Session,
+    rows: list[AttachmentUserProvided],
+) -> None:
+    """Transition pending rows → promoted and create ``Attachment`` records.
+
+    Three phases:
+    1. Flip every row's status to ``promoted`` (they were locked ``FOR
+       UPDATE`` by :func:`resolve_file_attachments`).
+    2. Download each row's bytes and create an ``Attachment`` record
+       linked to the privacy request. ``AttachmentService.create_and_upload``
+       commits per row — this function tracks those so a mid-loop failure
+       can explicitly delete the partial work.
+    3. Delete the temp objects from storage (best-effort — orphan sweep
+       reaps leftovers under ``privacy_request_attachments/``).
+
+    Raises:
+        Exception: Re-raises any storage or AttachmentService error after
+            deleting any ``Attachment`` rows already created on this call.
+            Caller should still delete the privacy request itself.
+    """
+    if not rows:
+        return
+
+    provider, bucket, storage_config = _get_provider_and_bucket(db)
+    attachment_service = AttachmentService(db=db)
+    repo = AttachmentUserProvidedRepository(db)
+
+    # Phase 1: flip status under the already-held FOR UPDATE lock.
+    repo.mark_promoted(rows)
+
+    # Phase 2: download + create Attachment rows.  Each iteration commits
+    # (Attachment._create_record + AttachmentReference.create). Track what
+    # we've created so partial failure can be compensated explicitly —
+    # AttachmentReference has no FK cascade on reference_id, so deleting
+    # the privacy_request alone would orphan any rows created before the
+    # failure. filename is the last path segment of the object_key, which
+    # is server-generated (uuid + extension) — no user-supplied name is
+    # preserved.
+    created: list[Any] = []
+    try:
+        for row in rows:
+            file_content = provider.download(bucket, row.object_key)
+            file_name = os.path.basename(row.object_key)
+            attachment = attachment_service.create_and_upload(
+                data={
+                    "file_name": file_name,
+                    "user_id": None,
+                    "username": "data_subject",
+                    "attachment_type": AttachmentType.user_provided,
+                    "storage_key": storage_config.key,
+                },
+                file_data=file_content,
+                references=[
+                    {
+                        "reference_id": privacy_request.id,
+                        "reference_type": AttachmentReferenceType.privacy_request,
+                    }
+                ],
+            )
+            created.append(attachment)
+            logger.info(
+                "Promoted attachment {} on request {} → Attachment {}",
+                row.id,
+                privacy_request.id,
+                attachment.id,
+            )
+    except Exception:
+        for attachment in created:
+            try:
+                attachment_service.delete(attachment)
+            except Exception:
+                logger.warning(
+                    "Failed to clean up partially-created Attachment {} after "
+                    "promotion failure",
+                    attachment.id,
+                    exc_info=True,
+                )
+        raise
+
+    # Phase 3: delete temp objects.  Failures here are logged only — the row
+    # is now ``promoted`` so the orphan sweep (which targets ``pending``
+    # only) won't pick it up. Leftover storage objects under this prefix
+    # become dead weight; see the ticket for follow-up on a promoted-row
+    # storage-reconciliation sweep.
+    for row in rows:
+        try:
+            provider.delete(bucket, row.object_key)
+        except Exception:
+            logger.warning(
+                "Could not delete temporary file {} after promotion",
+                row.object_key,
+                exc_info=True,
+            )

--- a/tests/ops/api/v1/endpoints/test_privacy_request_attachment_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_request_attachment_endpoints.py
@@ -1,0 +1,112 @@
+"""Tests for the unauthenticated POST /privacy-request/attachment endpoint."""
+
+import io
+from unittest.mock import MagicMock, patch
+
+import pytest
+from starlette.testclient import TestClient
+
+from fides.common.urn_registry import PRIVACY_REQUEST_ATTACHMENT, V1_URL_PREFIX
+from fides.service.privacy_request.attachment_user_provided_service import (
+    DEFAULT_MAX_SIZE_BYTES,
+)
+
+URL = V1_URL_PREFIX + PRIVACY_REQUEST_ATTACHMENT
+
+PDF_BYTES = b"%PDF-1.4 minimal pdf body"
+
+
+@pytest.fixture
+def mock_provider():
+    result = MagicMock(file_size=len(PDF_BYTES))
+    provider = MagicMock()
+    provider.upload.return_value = result
+    return provider
+
+
+@pytest.fixture
+def patch_storage_factory(mock_provider, storage_config_default):
+    """Short-circuit provider + bucket lookup so tests don't depend on
+    which storage config happens to be the active default at runtime."""
+    with (
+        patch(
+            "fides.service.privacy_request.attachment_user_provided_service.StorageProviderFactory"
+        ) as factory,
+        patch(
+            "fides.service.privacy_request.attachment_user_provided_service._get_provider_and_bucket",
+            return_value=(mock_provider, "test_bucket", storage_config_default),
+        ),
+    ):
+        factory.create.return_value = mock_provider
+        yield factory
+
+
+class TestPostPrivacyRequestAttachment:
+    def test_upload_forbidden_when_custom_fields_disabled(
+        self,
+        api_client: TestClient,
+        allow_custom_privacy_request_field_collection_disabled,
+    ):
+        resp = api_client.post(URL, files={"file": ("x.pdf", io.BytesIO(PDF_BYTES))})
+        assert resp.status_code == 403
+        assert "disabled" in resp.json()["detail"].lower()
+
+    def test_upload_rejects_oversize(
+        self,
+        api_client: TestClient,
+        allow_custom_privacy_request_field_collection_enabled,
+    ):
+        oversize = b"%PDF" + b"x" * (DEFAULT_MAX_SIZE_BYTES + 1)
+        resp = api_client.post(URL, files={"file": ("x.pdf", io.BytesIO(oversize))})
+        assert resp.status_code == 413
+        assert "maximum allowed size" in resp.json()["detail"]
+
+    def test_upload_rejects_bad_magic(
+        self,
+        api_client: TestClient,
+        allow_custom_privacy_request_field_collection_enabled,
+        storage_config_default,
+        patch_storage_factory,
+    ):
+        resp = api_client.post(
+            URL, files={"file": ("x.pdf", io.BytesIO(b"not a real pdf"))}
+        )
+        assert resp.status_code == 400
+        assert "not allowed" in resp.json()["detail"]
+
+    def test_upload_returns_503_without_storage_config(
+        self,
+        api_client: TestClient,
+        allow_custom_privacy_request_field_collection_enabled,
+    ):
+        with patch(
+            "fides.service.privacy_request.attachment_user_provided_service.get_active_default_storage_config",
+            return_value=None,
+        ):
+            resp = api_client.post(
+                URL, files={"file": ("x.pdf", io.BytesIO(PDF_BYTES))}
+            )
+        assert resp.status_code == 503
+        assert resp.json()["detail"] == "File attachments are temporarily unavailable."
+
+    def test_upload_happy_path(
+        self,
+        api_client: TestClient,
+        allow_custom_privacy_request_field_collection_enabled,
+        storage_config_default,
+        patch_storage_factory,
+        mock_provider,
+    ):
+        resp = api_client.post(
+            URL, files={"file": ("original.pdf", io.BytesIO(PDF_BYTES))}
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["id"].startswith("att_")
+
+        # Storage upload was invoked with server-generated key under the prefix.
+        mock_provider.upload.assert_called_once()
+        kwargs = mock_provider.upload.call_args.kwargs
+        assert kwargs["key"].startswith("privacy_request_attachments/")
+        assert kwargs["key"].endswith(".pdf")
+        assert kwargs["content_type"] == "application/pdf"

--- a/tests/ops/service/privacy_request/test_attachment_user_provided_service.py
+++ b/tests/ops/service/privacy_request/test_attachment_user_provided_service.py
@@ -1,0 +1,318 @@
+"""Tests for the data-subject-uploaded attachment lifecycle.
+
+Covers upload_attachment, resolve_file_attachments, promote_rows_to_attachments,
+cleanup_orphaned_attachments, and the repository helpers.
+"""
+
+import io
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fides.api.models.attachment import (
+    Attachment,
+    AttachmentReference,
+    AttachmentReferenceType,
+    AttachmentUserProvided,
+    AttachmentUserProvidedStatus,
+)
+from fides.api.schemas.redis_cache import CustomPrivacyRequestField
+from fides.service.privacy_request.attachment_user_provided_repository import (
+    AttachmentUserProvidedRepository,
+)
+from fides.service.privacy_request.attachment_user_provided_service import (
+    DEFAULT_MAX_SIZE_BYTES,
+    promote_rows_to_attachments,
+    resolve_file_attachments,
+    upload_attachment,
+)
+
+PDF_BYTES = b"%PDF-1.4 minimal pdf body"
+JPEG_BYTES = b"\xff\xd8\xff\xe0 jpeg body"
+
+
+@pytest.fixture
+def mock_provider_result():
+    """Stub for storage provider .upload() return value."""
+    result = MagicMock()
+    result.file_size = 123
+    return result
+
+
+@pytest.fixture
+def mock_provider(mock_provider_result):
+    """Mock storage provider with upload/download/delete methods."""
+    provider = MagicMock()
+    provider.upload.return_value = mock_provider_result
+    provider.download.side_effect = lambda *_a, **_kw: io.BytesIO(PDF_BYTES)
+    return provider
+
+
+@pytest.fixture
+def patch_provider_factory(mock_provider, storage_config_default):
+    """Short-circuit storage lookup + provider construction.
+
+    Other tests in the suite leak ``storage_config_default`` rows without
+    teardown and the *active* default is governed by an app property — so
+    relying on DB state for provider/bucket/key resolution is brittle.
+    We pin all three here for deterministic assertions on bucket + key.
+    """
+    with (
+        patch(
+            "fides.service.privacy_request.attachment_user_provided_service.StorageProviderFactory"
+        ) as factory,
+        patch(
+            "fides.service.privacy_request.attachment_user_provided_service._get_provider_and_bucket",
+            return_value=(mock_provider, "test_bucket", storage_config_default),
+        ),
+    ):
+        factory.create.return_value = mock_provider
+        yield factory
+
+
+class TestUploadAttachment:
+    def test_upload_happy_path_creates_uploaded_row(
+        self,
+        db,
+        storage_config_default,
+        patch_provider_factory,
+        mock_provider,
+    ):
+        result = upload_attachment(file_data=PDF_BYTES, db=db)
+
+        assert result.id.startswith("att_")
+        row = (
+            db.query(AttachmentUserProvided)
+            .filter(AttachmentUserProvided.id == result.id)
+            .one()
+        )
+        assert row.status == AttachmentUserProvidedStatus.uploaded
+        assert row.storage_key == storage_config_default.key
+        assert row.object_key.startswith("privacy_request_attachments/")
+        assert row.object_key.endswith(".pdf")
+
+        mock_provider.upload.assert_called_once()
+        kwargs = mock_provider.upload.call_args.kwargs
+        assert kwargs["content_type"] == "application/pdf"
+
+        row.delete(db)
+
+    def test_upload_rejects_oversize(self, db, storage_config_default):
+        oversize = b"%PDF" + b"x" * (DEFAULT_MAX_SIZE_BYTES + 1)
+        with pytest.raises(ValueError, match="maximum allowed size"):
+            upload_attachment(file_data=oversize, db=db)
+
+    def test_upload_rejects_unknown_magic(
+        self, db, storage_config_default, patch_provider_factory
+    ):
+        with pytest.raises(ValueError, match="File type is not allowed"):
+            upload_attachment(file_data=b"not a real file format", db=db)
+
+    def test_upload_rejects_disallowed_known_magic(
+        self, db, storage_config_default, patch_provider_factory
+    ):
+        """docx bytes are catalogued but not on the public allowlist."""
+        docx_bytes = b"PK\x03\x04 docx body"
+        with pytest.raises(ValueError, match="File type is not allowed"):
+            upload_attachment(file_data=docx_bytes, db=db)
+
+    def test_upload_without_storage_config_raises(self, db):
+        """No active default storage config → RuntimeError.
+
+        Deliberately does NOT use ``patch_provider_factory`` (which pins
+        ``_get_provider_and_bucket``); we want the real RuntimeError path.
+        """
+        with patch(
+            "fides.service.privacy_request.attachment_user_provided_service.get_active_default_storage_config",
+            return_value=None,
+        ):
+            with pytest.raises(RuntimeError, match="No active default storage"):
+                upload_attachment(file_data=PDF_BYTES, db=db)
+
+
+class TestResolveFileAttachments:
+    def test_returns_empty_when_no_fields(self, db):
+        assert resolve_file_attachments(None, {"file"}, db) == []
+
+    def test_returns_empty_when_no_declared_file_names(self, db):
+        fields = {"other": CustomPrivacyRequestField(label="other", value="something")}
+        assert resolve_file_attachments(fields, set(), db) == []
+
+    def test_returns_empty_when_collection_disabled(
+        self, db, allow_custom_privacy_request_field_collection_disabled
+    ):
+        fields = {"file": CustomPrivacyRequestField(label="file", value=["missing_id"])}
+        assert resolve_file_attachments(fields, {"file"}, db) == []
+
+    def test_happy_path_resolves_uploaded_rows(
+        self,
+        db,
+        storage_config_default,
+        allow_custom_privacy_request_field_collection_enabled,
+    ):
+        repo = AttachmentUserProvidedRepository(db)
+        row = repo.create_uploaded(
+            object_key="privacy_request_attachments/one.pdf",
+            storage_key=storage_config_default.key,
+        )
+        db.commit()
+
+        fields = {"file": CustomPrivacyRequestField(label="file", value=[row.id])}
+        rows = resolve_file_attachments(fields, {"file"}, db)
+        assert [r.id for r in rows] == [row.id]
+
+        row.delete(db)
+
+    def test_missing_id_raises(
+        self,
+        db,
+        storage_config_default,
+        allow_custom_privacy_request_field_collection_enabled,
+    ):
+        fields = {
+            "file": CustomPrivacyRequestField(label="file", value=["att_missing"])
+        }
+        with pytest.raises(ValueError, match="expired or is invalid"):
+            resolve_file_attachments(fields, {"file"}, db)
+
+    def test_non_list_value_raises(
+        self,
+        db,
+        storage_config_default,
+        allow_custom_privacy_request_field_collection_enabled,
+    ):
+        fields = {"file": CustomPrivacyRequestField(label="file", value="not a list")}
+        with pytest.raises(ValueError, match="must be a list"):
+            resolve_file_attachments(fields, {"file"}, db)
+
+    def test_field_not_submitted_is_skipped(
+        self,
+        db,
+        storage_config_default,
+        allow_custom_privacy_request_field_collection_enabled,
+    ):
+        """Declared file field not in submission → no error, just skipped."""
+        fields = {"other": CustomPrivacyRequestField(label="other", value="hello")}
+        assert resolve_file_attachments(fields, {"file"}, db) == []
+
+
+class TestPromoteRowsToAttachments:
+    def test_no_rows_is_noop(self, db, storage_config_default):
+        promote_rows_to_attachments(MagicMock(), db, [])
+
+    def test_promote_flips_status_and_creates_attachment(
+        self,
+        db,
+        storage_config_default,
+        privacy_request,
+        patch_provider_factory,
+        mock_provider,
+    ):
+        repo = AttachmentUserProvidedRepository(db)
+        row = repo.create_uploaded(
+            object_key="privacy_request_attachments/promote.pdf",
+            storage_key=storage_config_default.key,
+        )
+        db.commit()
+
+        promote_rows_to_attachments(privacy_request, db, [row])
+
+        db.refresh(row)
+        assert row.status == AttachmentUserProvidedStatus.promoted
+        assert row.promoted_at is not None
+
+        attachment_ref = (
+            db.query(AttachmentReference)
+            .filter(
+                AttachmentReference.reference_id == privacy_request.id,
+                AttachmentReference.reference_type
+                == AttachmentReferenceType.privacy_request,
+            )
+            .first()
+        )
+        assert attachment_ref is not None
+
+        attachment = (
+            db.query(Attachment)
+            .filter(Attachment.id == attachment_ref.attachment_id)
+            .one()
+        )
+        assert attachment.file_name == "promote.pdf"
+
+        mock_provider.delete.assert_called_with(
+            "test_bucket", "privacy_request_attachments/promote.pdf"
+        )
+
+        # Clean up
+        db.delete(attachment_ref)
+        db.delete(attachment)
+        row.delete(db)
+
+    def test_promote_rejects_non_uploaded_row(
+        self,
+        db,
+        storage_config_default,
+        privacy_request,
+        patch_provider_factory,
+    ):
+        repo = AttachmentUserProvidedRepository(db)
+        row = repo.create_uploaded(
+            object_key="privacy_request_attachments/bad.pdf",
+            storage_key=storage_config_default.key,
+        )
+        row.status = AttachmentUserProvidedStatus.deleted
+        db.commit()
+
+        with pytest.raises(ValueError, match="Refusing to promote"):
+            promote_rows_to_attachments(privacy_request, db, [row])
+
+        row.delete(db)
+
+
+class TestAttachmentUserProvidedRepository:
+    def test_create_uploaded_flushes_without_commit(self, db, storage_config_default):
+        repo = AttachmentUserProvidedRepository(db)
+        row = repo.create_uploaded(
+            object_key="privacy_request_attachments/flush.pdf",
+            storage_key=storage_config_default.key,
+        )
+        assert row.id is not None
+        assert row.status == AttachmentUserProvidedStatus.uploaded
+        # Roll back — no commit was issued inside create_uploaded.
+        db.rollback()
+        assert (
+            db.query(AttachmentUserProvided)
+            .filter(AttachmentUserProvided.id == row.id)
+            .first()
+            is None
+        )
+
+    def test_mark_promoted_rejects_non_uploaded(self, db, storage_config_default):
+        repo = AttachmentUserProvidedRepository(db)
+        row = repo.create_uploaded(
+            object_key="privacy_request_attachments/guard.pdf",
+            storage_key=storage_config_default.key,
+        )
+        row.status = AttachmentUserProvidedStatus.deleted
+        with pytest.raises(ValueError, match="Refusing to promote"):
+            repo.mark_promoted([row])
+
+    def test_lock_uploaded_by_ids_filters_to_uploaded(self, db, storage_config_default):
+        repo = AttachmentUserProvidedRepository(db)
+        uploaded = repo.create_uploaded(
+            object_key="privacy_request_attachments/lock1.pdf",
+            storage_key=storage_config_default.key,
+        )
+        deleted = repo.create_uploaded(
+            object_key="privacy_request_attachments/lock2.pdf",
+            storage_key=storage_config_default.key,
+        )
+        deleted.status = AttachmentUserProvidedStatus.deleted
+        db.commit()
+
+        rows = repo.lock_uploaded_by_ids([uploaded.id, deleted.id, "att_missing"])
+        assert [r.id for r in rows] == [uploaded.id]
+
+        uploaded.delete(db)
+        deleted.delete(db)


### PR DESCRIPTION
Adds the upload half of data-subject file attachments:

* FileUploadCustomPrivacyRequestField variant in the discriminated union with max_size_bytes + allowed_mime_types validation against PublicUploadAllowedFileTypes.
* AttachmentUserProvided model + AttachmentUserProvidedStatus enum (uploaded → deleted lifecycle; promoted state ships with the follow-up promotion branch).
* POST /api/v1/privacy-request/attachment — unauthenticated, rate-limited, streaming size cap, magic-byte MIME sniff, server-generated object key.
* FilesMagicBytes catalog + PublicUploadAllowedFileTypes allow-list in storage/util.py; MIME→extension helpers.
* AttachmentUserProvidedRepository (upload + cleanup methods).
* Orphan sweep Celery task + APScheduler registration.
* Alembic migration for attachment_user_provided table.

Promotion of uploaded rows to Attachment records (resolve_file_attachments, promote_rows_to_attachments) ships in ENG-3517-1.

Ticket [<issue>] <!-- simply paste the ticket number between the brackets and it will auto-convert to a link -->

### Description Of Changes

<!-- Write some things about the changes and any potential caveats -->

### Code Changes

* <!-- list your code changes -->

### Steps to Confirm

1. <!-- list any manual steps for reviewers to confirm the changes -->

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [x] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
