### PR TITLE
ENG-3627: Update FidesJS JSDoc links for new fidesdocs structure

### DIFF
--- a/changelog/8038-fidesjs-jsdoc-link-paths.yaml
+++ b/changelog/8038-fidesjs-jsdoc-link-paths.yaml
@@ -1,0 +1,4 @@
+type: Docs
+description: Updated FidesJS JSDoc links to match the new fidesdocs domain-based structure
+pr: 8038
+labels: []

--- a/clients/fides-js/docs/README.md
+++ b/clients/fides-js/docs/README.md
@@ -1,7 +1,7 @@
 # FidesJS: JavaScript SDK for Fides
 
 FidesJS is a JavaScript SDK to integrate Fides consent into any website or
-app! Commonly referred to as a Consent Management Platform (CMP), FidesJS
+app! Commonly referred to as a [Consent Management Platform (CMP)](/consent/concepts/fundamentals#consent-management-platform-cmp), FidesJS
 includes all the UI components (banners, modals, etc.), state management, and
 utility functions you need to collect consent & enforce data privacy in your
 application.

--- a/clients/fides-js/docs/enumerations/PrivacyNoticeRegion.md
+++ b/clients/fides-js/docs/enumerations/PrivacyNoticeRegion.md
@@ -1,6 +1,6 @@
 # Enumeration: PrivacyNoticeRegion
 
-A string that represents a specific region of the world. It is used to specify regions that apply to a [Privacy Experience](/tutorials/consent-management/consent-management-configuration/privacy-experiences#what-are-privacy-experiences).
+A string that represents a specific region of the world. It is used to specify regions that apply to a [Privacy Experience](/consent/guides/privacy-experiences#what-are-privacy-experiences).
 The string is formatted with [ISO 3166](https://en.wikipedia.org/wiki/ISO_3166) two-letter codes for a country and subdivisions. They're written in lowercase and separated with an underscore. Subdivisions are currently supported for the United States and Canada.
 The PrivacyNoticeRegion can also be one of the following non-iso standard codes:
 - `eea` : European Economic Area

--- a/clients/fides-js/docs/interfaces/Fides.md
+++ b/clients/fides-js/docs/interfaces/Fides.md
@@ -307,7 +307,7 @@ automatically push all [FidesEvent](FidesEvent.md) events to the GTM data layer 
 they occur, which can then be used to trigger/block tags in GTM based on
 `Fides.consent` preferences or other business logic.
 
-See the [Google Tag Manager tutorial](/tutorials/consent-management/consent-management-configuration/google-tag-manager-consent-mode) for more.
+See the [Google Tag Manager tutorial](/consent/guides/google-tag-manager-consent-mode) for more.
 
 #### Parameters
 
@@ -571,7 +571,7 @@ FidesJS is included. Once enabled, FidesJS will automatically push all
 consent updates to Shopify's Customer Privacy API, which can then be used
 to ensure consent is enforced on Shopify-managed apps & pixels.
 
-See the [Shopify installation tutorial](/tutorials/consent-management/consent-management-configuration/install-fides-shopify) for more.
+See the [Shopify installation tutorial](/consent/guides/install-fides-shopify) for more.
 
 #### Parameters
 
@@ -629,7 +629,7 @@ However, initialization can be called manually if needed - for example to delay
 initialization until after your own custom JavaScript has run to set up some
 config options. In this case, you can disable the automatic initialization
 by including the query param `initialize=false` in the Fides script URL
-(see [Privacy Center FidesJS Hosting](/dev-docs/js/privacy-center-fidesjs-hosting) for details).
+(see [Privacy Center FidesJS Hosting](/privacy-center-fidesjs/fidesjs/privacy-center-fidesjs-hosting) for details).
 You will then need to call `Fides.init()` manually at the appropriate time.
 
 This function can also be used to reinitialize FidesJS. This is useful when

--- a/clients/fides-js/docs/interfaces/FidesOptions.md
+++ b/clients/fides-js/docs/interfaces/FidesOptions.md
@@ -255,7 +255,7 @@ function encodeNoticeConsentString(consent: Record<string, boolean | 0 | 1>) {
 For debugging purposes, you can decode the Notice Consent string using the
 `window.Fides.decodeNoticeConsentString` function (see [Fides.decodeNoticeConsentString](Fides.md#decodenoticeconsentstring)).
 
-Note: The Notice Consent string will take precedence over [GPC](/docs/regulations/gpc) and override any prior user consent.
+Note: The Notice Consent string will take precedence over [GPC](/regulations/gpc) and override any prior user consent.
 
 Defaults to `undefined`.
 
@@ -449,7 +449,7 @@ the behavior.
   this is not a supported configuration
 - "disabled" = prevents repeated script loading entirely
 
-See [Troubleshooting](/docs/dev-docs/js/troubleshooting) for more information.
+See [Troubleshooting](/privacy-center-fidesjs/fidesjs/troubleshooting) for more information.
 
 Defaults to `"disabled"`.
 

--- a/clients/fides-js/src/docs/fides-options.ts
+++ b/clients/fides-js/src/docs/fides-options.ts
@@ -236,7 +236,7 @@ export interface FidesOptions {
    * For debugging purposes, you can decode the Notice Consent string using the
    * `window.Fides.decodeNoticeConsentString` function (see {@link Fides.decodeNoticeConsentString}).
    *
-   * Note: The Notice Consent string will take precedence over [GPC](/docs/regulations/gpc) and override any prior user consent.
+   * Note: The Notice Consent string will take precedence over [GPC](/regulations/gpc) and override any prior user consent.
    *
    * Defaults to `undefined`.
    */
@@ -396,7 +396,7 @@ export interface FidesOptions {
    *   this is not a supported configuration
    * - "disabled" = prevents repeated script loading entirely
    *
-   * See [Troubleshooting](/docs/dev-docs/js/troubleshooting) for more information.
+   * See [Troubleshooting](/privacy-center-fidesjs/fidesjs/troubleshooting) for more information.
    *
    * Defaults to `"disabled"`.
    */

--- a/clients/fides-js/src/docs/fides.ts
+++ b/clients/fides-js/src/docs/fides.ts
@@ -255,7 +255,7 @@ export interface Fides {
    * they occur, which can then be used to trigger/block tags in GTM based on
    * `Fides.consent` preferences or other business logic.
    *
-   * See the [Google Tag Manager tutorial](/tutorials/consent-management/consent-management-configuration/google-tag-manager-consent-mode) for more.
+   * See the [Google Tag Manager tutorial](/consent/guides/google-tag-manager-consent-mode) for more.
    *
    * @param options - Optional configuration for the GTM integration
    * @param options.non_applicable_flag_mode - Controls how non-applicable privacy notices are handled in the data layer. Can be "omit" (default) to exclude non-applicable notices, or "include" to include them with a default value.
@@ -481,7 +481,7 @@ export interface Fides {
    * consent updates to Shopify's Customer Privacy API, which can then be used
    * to ensure consent is enforced on Shopify-managed apps & pixels.
    *
-   * See the [Shopify installation tutorial](/tutorials/consent-management/consent-management-configuration/install-fides-shopify) for more.
+   * See the [Shopify installation tutorial](/consent/guides/install-fides-shopify) for more.
    *
    * @param options - Optional configuration for the Shopify integration
    * @param options.sale_of_data_default - Controls the default value for Shopify's "sale of data" consent. If `true`, the user will be opted-in by default. If `false` or omitted, the user will be opted-out by default.
@@ -530,7 +530,7 @@ export interface Fides {
    * initialization until after your own custom JavaScript has run to set up some
    * config options. In this case, you can disable the automatic initialization
    * by including the query param `initialize=false` in the Fides script URL
-   * (see [Privacy Center FidesJS Hosting](/dev-docs/js/privacy-center-fidesjs-hosting) for details).
+   * (see [Privacy Center FidesJS Hosting](/privacy-center-fidesjs/fidesjs/privacy-center-fidesjs-hosting) for details).
    * You will then need to call `Fides.init()` manually at the appropriate time.
    *
    * This function can also be used to reinitialize FidesJS. This is useful when

--- a/clients/fides-js/src/docs/index.ts
+++ b/clients/fides-js/src/docs/index.ts
@@ -1,6 +1,6 @@
 /**
  * FidesJS is a JavaScript SDK to integrate Fides consent into any website or
- * app! Commonly referred to as a Consent Management Platform (CMP), FidesJS
+ * app! Commonly referred to as a [Consent Management Platform (CMP)](/consent/concepts/fundamentals#consent-management-platform-cmp), FidesJS
  * includes all the UI components (banners, modals, etc.), state management, and
  * utility functions you need to collect consent & enforce data privacy in your
  * application.
@@ -36,7 +36,7 @@
  * engineers integrating FidesJS into their own applications rely on. The TSDoc
  * comments are then used to generate (via `npm run docs:generate`) living
  * developer documentation that is then imported and hosted on Ethyca's
- * docs site here: [FidesJS SDK Documentation](https://ethyca.com/docs/dev-docs/js)
+ * docs site here: [FidesJS SDK Documentation](https://ethyca.com/docs/privacy-center-fidesjs/fidesjs)
  *
  * Therefore, all the types in src/docs should be considered part of FidesJS'
  * *official* developer API, so treat them with care!

--- a/clients/fides-js/src/docs/privacy-notice-region.ts
+++ b/clients/fides-js/src/docs/privacy-notice-region.ts
@@ -1,5 +1,5 @@
 /**
- * A string that represents a specific region of the world. It is used to specify regions that apply to a [Privacy Experience](/tutorials/consent-management/consent-management-configuration/privacy-experiences#what-are-privacy-experiences).
+ * A string that represents a specific region of the world. It is used to specify regions that apply to a [Privacy Experience](/consent/guides/privacy-experiences#what-are-privacy-experiences).
  * The string is formatted with [ISO 3166](https://en.wikipedia.org/wiki/ISO_3166) two-letter codes for a country and subdivisions. They're written in lowercase and separated with an underscore. Subdivisions are currently supported for the United States and Canada.
  * The PrivacyNoticeRegion can also be one of the following non-iso standard codes:
  * - `eea` : European Economic Area


### PR DESCRIPTION
Ticket [ENG-3627]

### Description Of Changes

[fidesdocs PR #725](https://github.com/ethyca/fidesdocs/pull/725) restructured the docs site from audience-based (`/dev-docs/`, `/tutorials/`) to domain-based (`/consent/`, `/privacy-center-fidesjs/`) URLs. As part of that PR the imported `clients/fides-js/docs/*.md` reference files were hand-edited in fidesdocs, but the JSDoc source comments here still pointed at the old paths.

This was dormant because the fidesdocs auto-importer has been broken since #725 (see [ethyca/fidesdocs#759](https://github.com/ethyca/fidesdocs/pull/759), the companion ENG-3627 fix). Once that ships, the next auto-import would have regenerated these files from stale JSDocs and regressed the link cleanup. This PR updates the source so the next import produces clean output.

> **Companion PR:** [ethyca/fidesdocs#759](https://github.com/ethyca/fidesdocs/pull/759) restores the importer scripts. This PR should land before that one's first re-run of the `Import FidesJS Docs` workflow on fidesdocs.

### Code Changes

* `clients/fides-js/src/docs/fides.ts`: GTM tutorial, Shopify tutorial, Privacy Center FidesJS Hosting links updated to `/consent/guides/*` and `/privacy-center-fidesjs/fidesjs/*`
* `clients/fides-js/src/docs/fides-options.ts`: `[GPC](/regulations/gpc)` and `[Troubleshooting](/privacy-center-fidesjs/fidesjs/troubleshooting)`
* `clients/fides-js/src/docs/privacy-notice-region.ts`: Privacy Experience link → `/consent/guides/privacy-experiences#what-are-privacy-experiences`
* `clients/fides-js/src/docs/index.ts`: external SDK docs link → `https://ethyca.com/docs/privacy-center-fidesjs/fidesjs`; linkified the "Consent Management Platform (CMP)" mention to `/consent/concepts/fundamentals#consent-management-platform-cmp`
* `clients/fides-js/docs/*`: regenerated typedoc output (`npm run docs:generate`)

### Steps to Confirm

1. Check out this branch in `fides`.
2. Run `cd clients/fides-js && npm run docs:generate`.
3. Diff the regenerated `clients/fides-js/docs/` against `pages/privacy-center-fidesjs/fidesjs/reference/` in [fidesdocs#759](https://github.com/ethyca/fidesdocs/pull/759) — the only remaining differences should be:
   * Hand-authored `_meta.json` files and `gpp-api.mdx` (these don't come from JSDoc)
   * New content the JSDoc has gained since #725 was opened: `Fides.matomo()` method and `FidesExperienceConfig.resurface_behavior`
4. After merge: trigger the `Import FidesJS Docs` workflow on fidesdocs (`workflow_dispatch`) and confirm the auto-PR contains only the genuinely new content above, with no link regressions.

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated (via `changelog/8038-fidesjs-jsdoc-link-paths.yaml`)
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [x] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pull/759)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required

[ENG-3627]: https://ethyca.atlassian.net/browse/ENG-3627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ