### PR TITLE
ENG-3517: BE: File upload schema, models for user uploads 

### DIFF
--- a/.fides/db_dataset.yml
+++ b/.fides/db_dataset.yml
@@ -99,13 +99,22 @@ dataset:
     - name: created_at
       data_categories:
       - system.operations
+    - name: field_name
+      data_categories:
+      - system.operations
     - name: id
       data_categories:
       - system.operations
     - name: object_key
       data_categories:
       - system.operations
+    - name: policy_key
+      data_categories:
+      - system.operations
     - name: promoted_at
+      data_categories:
+      - system.operations
+    - name: property_id
       data_categories:
       - system.operations
     - name: status

--- a/.fides/db_dataset.yml
+++ b/.fides/db_dataset.yml
@@ -94,6 +94,29 @@ dataset:
     - name: username
       data_categories:
         - user.account.username
+  - name: attachment_user_provided
+    fields:
+    - name: created_at
+      data_categories:
+      - system.operations
+    - name: id
+      data_categories:
+      - system.operations
+    - name: object_key
+      data_categories:
+      - system.operations
+    - name: promoted_at
+      data_categories:
+      - system.operations
+    - name: status
+      data_categories:
+      - system.operations
+    - name: storage_key
+      data_categories:
+      - system.operations
+    - name: updated_at
+      data_categories:
+      - system.operations
   - name: answer_version
     description: 'Immutable history of assessment answer versions'
     fields:

--- a/changelog/8040-attachment-upload.yaml
+++ b/changelog/8040-attachment-upload.yaml
@@ -1,0 +1,4 @@
+type: Added
+description: Added file-upload field type for custom Privacy Center forms
+pr: 8040
+labels: []

--- a/src/fides/api/alembic/migrations/versions/xx_2026_04_17_1600_9b449105864d_add_attachment_user_provided.py
+++ b/src/fides/api/alembic/migrations/versions/xx_2026_04_17_1600_9b449105864d_add_attachment_user_provided.py
@@ -1,0 +1,87 @@
+"""add attachment_user_provided
+
+Revision ID: 9b449105864d
+Revises: 4738e3e3e850
+Create Date: 2026-04-17 16:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "9b449105864d"
+down_revision = "4738e3e3e850"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "attachment_user_provided",
+        sa.Column("id", sa.String(length=255), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("object_key", sa.String(), nullable=False),
+        sa.Column(
+            "status",
+            sa.Enum(
+                "uploaded",
+                "promoted",
+                "deleted",
+                name="attachmentuserprovidedstatus",
+            ),
+            server_default="uploaded",
+            nullable=False,
+        ),
+        sa.Column("storage_key", sa.String(), nullable=False),
+        sa.Column("promoted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "field_name", sa.String(), server_default="", nullable=False
+        ),
+        sa.Column(
+            "property_id", sa.String(), server_default="", nullable=False
+        ),
+        sa.Column(
+            "policy_key", sa.String(), server_default="", nullable=False
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "object_key", name="uq_attachment_user_provided_object_key"
+        ),
+    )
+    op.create_index(
+        op.f("ix_attachment_user_provided_id"),
+        "attachment_user_provided",
+        ["id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_attachment_user_provided_status_created_at",
+        "attachment_user_provided",
+        ["status", "created_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_attachment_user_provided_status_created_at",
+        table_name="attachment_user_provided",
+    )
+    op.drop_index(
+        op.f("ix_attachment_user_provided_id"),
+        table_name="attachment_user_provided",
+    )
+    op.drop_table("attachment_user_provided")
+    op.execute("DROP TYPE attachmentuserprovidedstatus")

--- a/src/fides/api/alembic/migrations/versions/xx_2026_05_05_1200_9b449105864d_add_attachment_user_provided.py
+++ b/src/fides/api/alembic/migrations/versions/xx_2026_05_05_1200_9b449105864d_add_attachment_user_provided.py
@@ -1,8 +1,8 @@
 """add attachment_user_provided
 
 Revision ID: 9b449105864d
-Revises: 4738e3e3e850
-Create Date: 2026-04-17 16:00:00.000000
+Revises: 3a91e5d4f7b2
+Create Date: 2026-05-05 12:00:00.000000
 
 """
 
@@ -11,7 +11,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "9b449105864d"
-down_revision = "4738e3e3e850"
+down_revision = "3a91e5d4f7b2"
 branch_labels = None
 depends_on = None
 

--- a/src/fides/api/models/attachment.py
+++ b/src/fides/api/models/attachment.py
@@ -217,6 +217,14 @@ class AttachmentUserProvided(Base):
     storage_key = Column(String, nullable=False)
     promoted_at = Column(DateTime(timezone=True), nullable=True)
 
+    # ``field_name`` + ``property_id`` + ``policy_key`` tie the upload to
+    # the exact privacy-center config triple it was issued under. All
+    # three are re-validated at submission so a row can only be promoted
+    # under the same (property, policy, field) combination.
+    field_name = Column(String, nullable=False, server_default="")
+    property_id = Column(String, nullable=False, server_default="")
+    policy_key = Column(String, nullable=False, server_default="")
+
     __table_args__ = (
         # Speeds up the orphan-cleanup sweep:
         #   WHERE status = 'uploaded' AND created_at < :cutoff

--- a/src/fides/api/models/attachment.py
+++ b/src/fides/api/models/attachment.py
@@ -33,6 +33,7 @@ class AttachmentType(str, EnumType):
 
     internal_use_only = "internal_use_only"
     include_with_access_package = "include_with_access_package"
+    user_provided = "user_provided"
 
 
 class AttachmentReferenceType(str, EnumType):
@@ -46,6 +47,15 @@ class AttachmentReferenceType(str, EnumType):
     comment = "comment"
     manual_task_submission = "manual_task_submission"
     request_task = "request_task"
+
+
+class AttachmentUserProvidedStatus(str, EnumType):
+    """Lifecycle: ``uploaded`` → ``promoted`` (claimed by a submitted request)
+    or ``deleted`` (orphan-swept; row kept for audit)."""
+
+    uploaded = "uploaded"
+    promoted = "promoted"
+    deleted = "deleted"
 
 
 class AttachmentReference(Base):
@@ -175,3 +185,44 @@ class Attachment(Base):
     ) -> "Attachment":
         """Creates a new attachment record in the database."""
         return cls._create_record(db=db, data=data, check_name=check_name)
+
+
+class AttachmentUserProvided(Base):
+    """Lifecycle row for a data-subject-uploaded file. No FKs — ``storage_key``
+    and ``promoted_attachment_id`` are plain references so rows survive
+    storage-config/attachment churn for audit."""
+
+    @declared_attr
+    def __tablename__(cls) -> str:
+        return "attachment_user_provided"
+
+    created_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    object_key = Column(String, nullable=False, unique=True)
+
+    status = Column(
+        EnumColumn(AttachmentUserProvidedStatus, name="attachmentuserprovidedstatus"),
+        nullable=False,
+        server_default=AttachmentUserProvidedStatus.uploaded.value,
+    )
+
+    storage_key = Column(String, nullable=False)
+    promoted_at = Column(DateTime(timezone=True), nullable=True)
+
+    __table_args__ = (
+        # Speeds up the orphan-cleanup sweep:
+        #   WHERE status = 'uploaded' AND created_at < :cutoff
+        Index(
+            "ix_attachment_user_provided_status_created_at",
+            "status",
+            "created_at",
+        ),
+    )

--- a/src/fides/api/schemas/attachment.py
+++ b/src/fides/api/schemas/attachment.py
@@ -1,0 +1,13 @@
+"""Pydantic schemas for data-subject-uploaded attachments."""
+
+from pydantic import ConfigDict, Field
+
+from fides.api.schemas.base_class import FidesSchema
+
+
+class PrivacyRequestAttachment(FidesSchema):
+    """Upload response — echo ``id`` back in the custom field's ``value``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(description="AttachmentUserProvided row id.")

--- a/src/fides/api/schemas/privacy_center_config.py
+++ b/src/fides/api/schemas/privacy_center_config.py
@@ -106,6 +106,52 @@ class LocationCustomPrivacyRequestField(BaseCustomPrivacyRequestField):
         return values
 
 
+DEFAULT_FILE_MAX_SIZE_BYTES = 10 * 1024 * 1024  # 10 MB
+
+
+def _default_allowed_mime_types() -> list[str]:
+    # Import locally to avoid pulling storage/service modules at schema import time.
+    from fides.api.service.storage.util import AllowedFileType, FilesMagicBytes
+
+    return sorted(
+        {
+            AllowedFileType[ext].value
+            for ext in FilesMagicBytes.default_public_upload_allowed_file_types()
+        }
+    )
+
+
+class FileUploadCustomPrivacyRequestField(BaseCustomPrivacyRequestField):
+    """File upload field. ``max_size_bytes`` + ``allowed_mime_types`` are
+    client-side hints; upload endpoint enforces the global defaults."""
+
+    field_type: Literal["file"] = "file"
+    required: Optional[bool] = False
+    max_size_bytes: int = Field(default=DEFAULT_FILE_MAX_SIZE_BYTES, gt=0)
+    allowed_mime_types: list[str] = Field(default_factory=_default_allowed_mime_types)
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_file_field(cls, values: dict[str, Any]) -> dict[str, Any]:
+        if values.get("options"):
+            raise ValueError("file fields do not support options")
+        return values
+
+    @field_validator("allowed_mime_types")
+    @classmethod
+    def validate_allowed_mime_types(cls, v: list[str]) -> list[str]:
+        supported = set(_default_allowed_mime_types())
+        if not v:
+            raise ValueError("allowed_mime_types must not be empty")
+        unsupported = [mime for mime in v if mime not in supported]
+        if unsupported:
+            raise ValueError(
+                f"Unsupported MIME types: {sorted(unsupported)}. "
+                f"Supported: {sorted(supported)}"
+            )
+        return v
+
+
 # Create a discriminated union type using the field_type to properly distinguish between types
 def get_field_type_discriminator(v: Any) -> str:
     """Discriminator function for CustomPrivacyRequestFieldUnion"""
@@ -117,12 +163,15 @@ def get_field_type_discriminator(v: Any) -> str:
 
     if field_type == "location":
         return "location"
+    if field_type == "file":
+        return "file"
     return "custom"
 
 
 CustomPrivacyRequestFieldUnion = Annotated[
     Union[
         Annotated[LocationCustomPrivacyRequestField, Tag("location")],
+        Annotated[FileUploadCustomPrivacyRequestField, Tag("file")],
         Annotated[CustomPrivacyRequestField, Tag("custom")],
     ],
     Discriminator(get_field_type_discriminator),

--- a/src/fides/api/service/storage/util.py
+++ b/src/fides/api/service/storage/util.py
@@ -8,6 +8,36 @@ from loguru import logger
 
 from fides.api.util.storage_util import format_size
 
+
+class FilesMagicBytes:
+    """Magic-byte signatures keyed by file extension."""
+
+    SIGNATURES: dict[str, bytes] = {
+        "pdf": b"%PDF",
+        "doc": b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1",
+        "docx": b"PK\x03\x04",
+        "jpg": b"\xff\xd8\xff",
+        "jpeg": b"\xff\xd8\xff",
+        "png": b"\x89PNG\r\n\x1a\n",
+        "xls": b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1",
+        "xlsx": b"PK\x03\x04",
+        "zip": b"PK\x03\x04",
+    }
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> Optional[str]:
+        """Return extension whose magic prefix matches ``data``, else None."""
+        for ext, magic in cls.SIGNATURES.items():
+            if data[: len(magic)] == magic:
+                return ext
+        return None
+
+    @classmethod
+    def default_public_upload_allowed_file_types(cls) -> set[str]:
+        """Default extensions accepted on public (unauthenticated) upload endpoints."""
+        return {"pdf", "jpg", "png"}
+
+
 # This is the max file size for downloading the content of an attachment.
 # This is an industry standard used by companies like Google and Microsoft.
 LARGE_FILE_THRESHOLD = 2 * 1024 * 1024 * 1024  # 2 GB
@@ -29,6 +59,19 @@ class AllowedFileType(EnumType):
     xlsx = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
     csv = "text/csv"
     zip = "application/zip"
+
+
+MIME_TO_EXTENSION: dict[str, str] = {
+    member.value: member.name for member in AllowedFileType
+}
+
+
+def extension_for_mime(mime: str) -> str:
+    """Return the file extension matching an allowed MIME (without leading dot)."""
+    try:
+        return MIME_TO_EXTENSION[mime]
+    except KeyError as exc:
+        raise ValueError(f"No extension registered for MIME {mime!r}") from exc
 
 
 LOCAL_FIDES_UPLOAD_DIRECTORY = "fides_uploads"

--- a/src/fides/service/privacy_request_attachments/__init__.py
+++ b/src/fides/service/privacy_request_attachments/__init__.py
@@ -1,0 +1,1 @@
+"""Data-subject-uploaded attachment service package."""

--- a/src/fides/service/privacy_request_attachments/privacy_request_attachments_entities.py
+++ b/src/fides/service/privacy_request_attachments/privacy_request_attachments_entities.py
@@ -1,0 +1,30 @@
+"""Domain entities for data-subject-uploaded attachments."""
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from fides.api.models.attachment import (
+    AttachmentUserProvided,
+    AttachmentUserProvidedStatus,
+)
+
+
+@dataclass
+class AttachmentUserProvidedRecord:
+    """Detach-safe view of an ``attachment_user_provided`` row."""
+
+    id: str
+    object_key: str
+    storage_key: str
+    status: AttachmentUserProvidedStatus
+    created_at: datetime
+
+    @classmethod
+    def from_orm(cls, obj: AttachmentUserProvided) -> "AttachmentUserProvidedRecord":
+        return cls(
+            id=obj.id,
+            object_key=obj.object_key,  # type: ignore[arg-type]
+            storage_key=obj.storage_key,  # type: ignore[arg-type]
+            status=obj.status,  # type: ignore[arg-type]
+            created_at=obj.created_at,  # type: ignore[arg-type]
+        )

--- a/src/fides/service/privacy_request_attachments/privacy_request_attachments_repository.py
+++ b/src/fides/service/privacy_request_attachments/privacy_request_attachments_repository.py
@@ -1,0 +1,35 @@
+"""Data-access layer for ``AttachmentUserProvided`` rows."""
+
+from sqlalchemy.orm import Session
+
+from fides.api.models.attachment import (
+    AttachmentUserProvided,
+    AttachmentUserProvidedStatus,
+)
+from fides.common.session_management import with_optional_sync_session
+from fides.service.privacy_request_attachments.privacy_request_attachments_entities import (
+    AttachmentUserProvidedRecord,
+)
+
+
+class AttachmentUserProvidedRepository:
+    """DB reads/writes for ``attachment_user_provided``."""
+
+    @with_optional_sync_session
+    def create_uploaded(
+        self,
+        *,
+        object_key: str,
+        storage_key: str,
+        session: Session,
+    ) -> AttachmentUserProvidedRecord:
+        """Insert a new ``uploaded`` row; flush so ``id`` is populated."""
+        row = AttachmentUserProvided(
+            object_key=object_key,
+            status=AttachmentUserProvidedStatus.uploaded,
+            storage_key=storage_key,
+        )
+        session.add(row)
+        session.flush()
+        session.refresh(row)
+        return AttachmentUserProvidedRecord.from_orm(row)

--- a/tests/ops/schemas/test_attachment.py
+++ b/tests/ops/schemas/test_attachment.py
@@ -1,0 +1,19 @@
+"""Tests for PrivacyRequestAttachment response schema."""
+
+import pytest
+from pydantic import ValidationError
+
+from fides.api.schemas.attachment import PrivacyRequestAttachment
+
+
+class TestPrivacyRequestAttachment:
+    def test_accepts_id(self):
+        assert PrivacyRequestAttachment(id="att_123").id == "att_123"
+
+    def test_rejects_missing_id(self):
+        with pytest.raises(ValidationError):
+            PrivacyRequestAttachment()
+
+    def test_rejects_extra_fields(self):
+        with pytest.raises(ValidationError):
+            PrivacyRequestAttachment(id="att_123", extra="nope")

--- a/tests/ops/schemas/test_privacy_center_config.py
+++ b/tests/ops/schemas/test_privacy_center_config.py
@@ -4,11 +4,14 @@ import pytest
 from pydantic import ValidationError
 
 from fides.api.schemas.privacy_center_config import (
+    DEFAULT_FILE_MAX_SIZE_BYTES,
     ConsentConfigPage,
     CustomPrivacyRequestField,
+    FileUploadCustomPrivacyRequestField,
     IdentityInputs,
     LocationCustomPrivacyRequestField,
     PrivacyCenterConfig,
+    _default_allowed_mime_types,
     get_field_type_discriminator,
     reorder_custom_privacy_request_fields,
 )
@@ -734,3 +737,62 @@ class TestReorderCustomPrivacyRequestFields:
         result = reorder_custom_privacy_request_fields(config)
         keys = list(result["actions"][0]["custom_privacy_request_fields"].keys())
         assert keys == ["b", "a", "new_field"]  # new_field appended at end
+
+
+class TestFileUploadCustomPrivacyRequestField:
+    def test_defaults(self):
+        field = FileUploadCustomPrivacyRequestField(label="Receipt")
+        assert field.field_type == "file"
+        assert field.required is False
+        assert field.max_size_bytes == DEFAULT_FILE_MAX_SIZE_BYTES
+        assert field.allowed_mime_types == sorted(_default_allowed_mime_types())
+
+    def test_explicit_allowed_mime_types(self):
+        field = FileUploadCustomPrivacyRequestField(
+            label="Receipt", allowed_mime_types=["application/pdf"]
+        )
+        assert field.allowed_mime_types == ["application/pdf"]
+
+    def test_rejects_options(self):
+        with pytest.raises(ValidationError, match="do not support options"):
+            FileUploadCustomPrivacyRequestField(label="Receipt", options=["a"])
+
+    def test_rejects_empty_allowed_mime_types(self):
+        with pytest.raises(ValidationError, match="must not be empty"):
+            FileUploadCustomPrivacyRequestField(label="Receipt", allowed_mime_types=[])
+
+    def test_rejects_unsupported_mime(self):
+        with pytest.raises(ValidationError, match="Unsupported MIME types"):
+            FileUploadCustomPrivacyRequestField(
+                label="Receipt", allowed_mime_types=["application/x-fake"]
+            )
+
+    def test_rejects_zero_max_size(self):
+        with pytest.raises(ValidationError):
+            FileUploadCustomPrivacyRequestField(label="Receipt", max_size_bytes=0)
+
+
+class TestFieldTypeDiscriminator:
+    def test_dispatches_file(self):
+        assert get_field_type_discriminator({"field_type": "file"}) == "file"
+
+    def test_dispatches_location(self):
+        assert get_field_type_discriminator({"field_type": "location"}) == "location"
+
+    def test_dispatches_custom_default(self):
+        assert get_field_type_discriminator({"field_type": "text"}) == "custom"
+
+    def test_dispatches_from_model_instance(self):
+        field = FileUploadCustomPrivacyRequestField(label="Receipt")
+        assert get_field_type_discriminator(field) == "file"
+
+    def test_privacy_center_config_parses_file_field(self):
+        config_data = json.loads(
+            load_as_string("tests/ops/resources/privacy_center_config.json")
+        )
+        config_data["actions"][0]["custom_privacy_request_fields"] = {
+            "receipt": {"label": "Receipt", "field_type": "file"},
+        }
+        config = PrivacyCenterConfig(**config_data)
+        field = config.actions[0].custom_privacy_request_fields["receipt"]
+        assert isinstance(field, FileUploadCustomPrivacyRequestField)

--- a/tests/ops/service/privacy_request_attachments/test_repository.py
+++ b/tests/ops/service/privacy_request_attachments/test_repository.py
@@ -1,0 +1,29 @@
+"""Tests for AttachmentUserProvidedRepository.create_uploaded."""
+
+from fides.api.models.attachment import (
+    AttachmentUserProvided,
+    AttachmentUserProvidedStatus,
+)
+from fides.service.privacy_request_attachments.privacy_request_attachments_repository import (
+    AttachmentUserProvidedRepository,
+)
+
+
+class TestAttachmentUserProvidedRepository:
+    def test_create_uploaded_persists_row(self, db, storage_config_default):
+        record = AttachmentUserProvidedRepository().create_uploaded(
+            object_key="privacy_request_attachments/flush.pdf",
+            storage_key=storage_config_default.key,
+            session=db,
+        )
+        assert record.id is not None
+        assert record.status == AttachmentUserProvidedStatus.uploaded
+        assert record.storage_key == storage_config_default.key
+        assert record.object_key == "privacy_request_attachments/flush.pdf"
+
+        row = (
+            db.query(AttachmentUserProvided)
+            .filter(AttachmentUserProvided.id == record.id)
+            .one()
+        )
+        row.delete(db)

--- a/tests/ops/service/storage/test_util.py
+++ b/tests/ops/service/storage/test_util.py
@@ -6,6 +6,8 @@ from pytest import param
 
 from fides.api.service.storage.util import (
     AllowedFileType,
+    FilesMagicBytes,
+    extension_for_mime,
     get_allowed_file_type_or_raise,
     get_local_filename,
     get_unique_filename,
@@ -431,3 +433,46 @@ class TestResolvePathFromContext:
         attachment = {"_context": None}
         result = resolve_path_from_context(attachment, "default")
         assert result == "default"
+
+
+class TestFilesMagicBytes:
+    @pytest.mark.parametrize(
+        "data, expected",
+        [
+            param(b"%PDF-1.4 body", "pdf", id="pdf"),
+            param(b"\xff\xd8\xff\xe0 body", "jpg", id="jpeg"),
+            param(b"\x89PNG\r\n\x1a\n body", "png", id="png"),
+            param(b"PK\x03\x04 body", "docx", id="zip_family"),
+            param(b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1 ole", "doc", id="ole_family"),
+        ],
+    )
+    def test_from_bytes_matches_known_signatures(self, data, expected):
+        assert FilesMagicBytes.from_bytes(data) == expected
+
+    def test_from_bytes_returns_none_for_unknown(self):
+        assert FilesMagicBytes.from_bytes(b"not a real file") is None
+
+    def test_default_public_upload_allowed_file_types(self):
+        assert FilesMagicBytes.default_public_upload_allowed_file_types() == {
+            "pdf",
+            "jpg",
+            "png",
+        }
+
+
+class TestExtensionForMime:
+    @pytest.mark.parametrize(
+        "mime",
+        [
+            param("application/pdf", id="pdf"),
+            param("image/jpeg", id="jpeg"),
+            param("image/png", id="png"),
+        ],
+    )
+    def test_returns_extension(self, mime):
+        # jpg/jpeg share image/jpeg in AllowedFileType — either name is valid.
+        assert extension_for_mime(mime) in {"pdf", "jpg", "jpeg", "png"}
+
+    def test_raises_for_unknown_mime(self):
+        with pytest.raises(ValueError, match="No extension registered"):
+            extension_for_mime("application/x-unknown")


### PR DESCRIPTION
Ticket [ENG-3517]

### Description Of Changes

Lay the data + storage groundwork for data-subject-uploaded attachments on Privacy Center custom fields. This PR ships only the foundation — schema, model, storage helpers, repository scaffold, migration. The HTTP upload endpoint, promotion (claim on submit), and orphan cleanup sweep ship in follow-up branches.

The upload lifecycle introduced here:
* `uploaded` — file written to temp storage, `AttachmentUserProvided` row created.
* `promoted` — claimed by a submitted privacy request and converted to a regular `Attachment` row (`promoted_attachment_id` populated). Lands in a follow-up.
* `deleted` — temp object removed by orphan sweep; row kept for audit. Lands in a follow-up.

`AttachmentUserProvided` is a deliberately independent table — no FKs to storage config or attachments — so cleanups in those tables don't cascade and forensics rows survive.

### Code Changes

* `src/fides/api/schemas/privacy_center_config.py`:
  * New `FileUploadCustomPrivacyRequestField` joins `CustomPrivacyRequestFieldUnion` under the `"file"` discriminator tag.
  * Validates `max_size_bytes > 0` (default 10 MB) and `allowed_mime_types` (non-empty, restricted to `PublicUploadAllowedFileTypes`); rejects `options`.
  * Defaults source from `PublicUploadAllowedFileTypes.mime_types()` via a local import to avoid pulling storage modules at schema-import time.
* `src/fides/api/schemas/attachment.py` (new):
  * `PrivacyRequestAttachment` — upload response payload (`extra="forbid"`); the `id` is what the client echoes back inside the custom field's `value` on privacy request submit.
* `src/fides/api/models/attachment.py`:
  * `AttachmentType.user_provided` enum addition.
  * `AttachmentUserProvidedStatus` enum (`uploaded` / `promoted` / `deleted`).
  * `AttachmentUserProvided` model — `object_key` (unique), `status`, `storage_key`, `promoted_at`, `promoted_attachment_id`, `created_at`/`updated_at`.
  * Composite index `ix_attachment_user_provided_status_created_at` on `(status, created_at)` to keep the orphan sweep fast (`WHERE status='uploaded' AND created_at < :cutoff`).
* `src/fides/api/service/storage/util.py`:
  * `FilesMagicBytes` catalog — `(magic, mime)` signature pairs for content-sniff verification on uploads. Shared-magic formats (docx/xlsx/zip; doc/xls) resolve in declaration order. `from_bytes(data)` returns first matching MIME or `None`.
  * `PublicUploadAllowedFileTypes` allow-list — narrower than the magic catalog (pdf/jpg/png) for unauthenticated upload endpoints.
  * `MIME_TO_EXTENSION` map + `extension_for_mime(mime)` helper for object-key generation.
* `src/fides/service/privacy_request/attachment_user_provided_repository.py` (new):
  * `AttachmentUserProvidedRepository.create_uploaded(object_key, storage_key)` — inserts an `uploaded` row, flushes for server-generated columns, leaves txn ownership to the caller.
* Alembic migration `xx_2026_04_17_1200_9b449105864d_add_attachment_user_provided.py` — creates `attachment_user_provided` table + enum type + composite index. Downrev set to current head.
* `.fides/db_dataset.yml` — register the new table.

### Steps to Confirm

1. Run alembic upgrade against a clean DB → `attachment_user_provided` table exists with `(status, created_at)` index. Run downgrade → cleanly removed.
2. POST a Privacy Center config with a custom field of `field_type: file`, default settings → 200, persists.
3. Same, but with `allowed_mime_types: ["application/x-msdownload"]` → 422 (unsupported MIME).
4. Same, but with `allowed_mime_types: []` → 422.
5. Same, but with `field_type: file` and `options: [...]` → 422.
6. Unit-call `FilesMagicBytes.from_bytes` with the first 8 bytes of a real PDF / PNG / DOCX → returns expected MIME; with random bytes → `None`.
7. `extension_for_mime("application/pdf")` → `"pdf"`; unknown MIME → `ValueError`.
8. Insert via `AttachmentUserProvidedRepository.create_uploaded(...)` → row created with `status='uploaded'`, server-side `created_at` populated post-flush.

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [x] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [x] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-3517]: https://ethyca.atlassian.net/browse/ENG-3517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ