### PR TITLE
ENG-3517: Upload service + endpoint

### DIFF
--- a/changelog/8042-attachment-upload-endpoint.yaml
+++ b/changelog/8042-attachment-upload-endpoint.yaml
@@ -1,0 +1,4 @@
+type: Added
+description: Upload service + attachment endpoint for data-subject file attachments on custom Privacy Center fields
+pr: 8042
+labels: []

--- a/src/fides/api/v1/api.py
+++ b/src/fides/api/v1/api.py
@@ -18,6 +18,7 @@ from fides.api.v1.endpoints import (
     policy_endpoints,
     policy_webhook_endpoints,
     pre_approval_webhook_endpoints,
+    privacy_request_attachment_endpoints,
     privacy_request_endpoints,
     privacy_request_redaction_patterns_endpoints,
     saas_config_endpoints,
@@ -45,6 +46,7 @@ api_router.include_router(oauth_endpoints.router)
 api_router.include_router(policy_endpoints.router)
 api_router.include_router(policy_webhook_endpoints.router)
 api_router.include_router(pre_approval_webhook_endpoints.router)
+api_router.include_router(privacy_request_attachment_endpoints.router)
 api_router.include_router(privacy_request_endpoints.router)
 api_router.include_router(privacy_request_redaction_patterns_endpoints.router)
 api_router.include_router(identity_verification_endpoints.router)

--- a/src/fides/api/v1/endpoints/privacy_request_attachment_endpoints.py
+++ b/src/fides/api/v1/endpoints/privacy_request_attachment_endpoints.py
@@ -92,7 +92,9 @@ def upload_privacy_request_attachment(
     file_data = b"".join(chunks)
 
     try:
-        return service.upload_attachment(file_data=file_data, session=db)
+        result = service.upload_attachment(file_data=file_data, session=db)
+        db.commit()
+        return result
     except FileTooLargeError as exc:
         raise HTTPException(status_code=HTTP_413_CONTENT_TOO_LARGE, detail=str(exc))
     except DisallowedFileTypeError as exc:

--- a/src/fides/api/v1/endpoints/privacy_request_attachment_endpoints.py
+++ b/src/fides/api/v1/endpoints/privacy_request_attachment_endpoints.py
@@ -1,0 +1,106 @@
+"""Unauthenticated upload endpoint for privacy-request file attachments."""
+
+from fastapi import Depends, File, Header, HTTPException, Request, Response, UploadFile
+from loguru import logger
+from sqlalchemy.orm import Session
+from starlette.status import (
+    HTTP_400_BAD_REQUEST,
+    HTTP_403_FORBIDDEN,
+    HTTP_413_CONTENT_TOO_LARGE,
+    HTTP_503_SERVICE_UNAVAILABLE,
+)
+
+from fides.api.deps import get_db
+from fides.api.schemas.attachment import PrivacyRequestAttachment
+from fides.api.util.api_router import APIRouter
+from fides.api.util.rate_limit import fides_limiter
+from fides.common.urn_registry import PRIVACY_REQUEST_ATTACHMENT, V1_URL_PREFIX
+from fides.config import CONFIG
+from fides.service.privacy_request_attachments.privacy_request_attachments_deps import (
+    get_attachment_user_provided_service,
+)
+from fides.service.privacy_request_attachments.privacy_request_attachments_exceptions import (
+    DisallowedFileTypeError,
+    FileTooLargeError,
+    StorageBucketNotConfiguredError,
+    StorageNotConfiguredError,
+)
+from fides.service.privacy_request_attachments.privacy_request_attachments_service import (
+    DEFAULT_MAX_SIZE_BYTES,
+    UPLOAD_READ_CHUNK_BYTES,
+    AttachmentUserProvidedService,
+)
+
+router = APIRouter(tags=["Privacy Requests"], prefix=V1_URL_PREFIX)
+
+
+@router.post(
+    PRIVACY_REQUEST_ATTACHMENT,
+    response_model=PrivacyRequestAttachment,
+)
+@fides_limiter.limit(CONFIG.security.privacy_request_attachment_rate_limit)
+def upload_privacy_request_attachment(
+    *,
+    request: Request,  # required for rate limiting
+    response: Response,  # required for rate limiting
+    file: UploadFile = File(...),
+    content_length: int | None = Header(default=None),
+    db: Session = Depends(get_db),
+    service: AttachmentUserProvidedService = Depends(
+        get_attachment_user_provided_service
+    ),
+) -> PrivacyRequestAttachment:
+    """Upload a file attachment for a custom privacy request field. Returns
+    an ``id`` to echo back in the field's ``value`` list. Gated on
+    ``allow_custom_privacy_request_field_collection`` and
+    ``allow_custom_privacy_request_file_upload``."""
+    if not (
+        CONFIG.execution.allow_custom_privacy_request_field_collection
+        and CONFIG.execution.allow_custom_privacy_request_file_upload
+    ):
+        raise HTTPException(
+            status_code=HTTP_403_FORBIDDEN,
+            detail="File attachments are disabled.",
+        )
+
+    # Content-Length pre-check — clients can lie, so the streaming check
+    # below is the authoritative guard.
+    if content_length is not None and content_length > DEFAULT_MAX_SIZE_BYTES:
+        raise HTTPException(
+            status_code=HTTP_413_CONTENT_TOO_LARGE,
+            detail=(
+                f"File exceeds maximum allowed size of {DEFAULT_MAX_SIZE_BYTES} bytes"
+            ),
+        )
+
+    chunks: list[bytes] = []
+    total = 0
+    while True:
+        chunk = file.file.read(UPLOAD_READ_CHUNK_BYTES)
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > DEFAULT_MAX_SIZE_BYTES:
+            raise HTTPException(
+                status_code=HTTP_413_CONTENT_TOO_LARGE,
+                detail=(
+                    f"File exceeds maximum allowed size of {DEFAULT_MAX_SIZE_BYTES} bytes"
+                ),
+            )
+        chunks.append(chunk)
+
+    file_data = b"".join(chunks)
+
+    try:
+        return service.upload_attachment(file_data=file_data, session=db)
+    except FileTooLargeError as exc:
+        raise HTTPException(status_code=HTTP_413_CONTENT_TOO_LARGE, detail=str(exc))
+    except DisallowedFileTypeError as exc:
+        raise HTTPException(status_code=HTTP_400_BAD_REQUEST, detail=str(exc))
+    except (StorageNotConfiguredError, StorageBucketNotConfiguredError) as exc:
+        # Log internal reason; return generic 503 to unauth callers.
+        logger.error("Attachment upload failed (misconfiguration): {}", exc)
+        raise HTTPException(
+            status_code=HTTP_503_SERVICE_UNAVAILABLE,
+            detail="File attachments are temporarily unavailable.",
+        )

--- a/src/fides/common/urn_registry.py
+++ b/src/fides/common/urn_registry.py
@@ -84,6 +84,7 @@ PRIVACY_REQUEST_APPROVE = "/privacy-request/administrate/approve"
 PRIVACY_REQUEST_BATCH_EMAIL_SEND = (
     "/privacy-request/administrate/process-awaiting-email-send"
 )
+PRIVACY_REQUEST_ATTACHMENT = "/privacy-request/attachment"
 PRIVACY_REQUEST_AUTHENTICATED = "/privacy-request/authenticated"
 PRIVACY_REQUEST_BULK_FINALIZE = "/privacy-request/bulk/finalize"
 PRIVACY_REQUEST_BULK_RETRY = "/privacy-request/bulk/retry"

--- a/src/fides/config/execution_settings.py
+++ b/src/fides/config/execution_settings.py
@@ -45,6 +45,10 @@ class ExecutionSettings(FidesSettings):
         default=False,
         description="Allows custom privacy request fields to be used in request execution.",
     )
+    allow_custom_privacy_request_file_upload: bool = Field(
+        default=False,
+        description="Allows file uploads to be attached to incoming privacy requests.",
+    )
     request_task_ttl: int = Field(
         default=604800,
         description="The number of seconds a request task should live.",

--- a/src/fides/config/security_settings.py
+++ b/src/fides/config/security_settings.py
@@ -131,6 +131,10 @@ class SecuritySettings(FidesSettings):
         default="10/minute",
         description="The number of authentication requests from a single IP address allowed to hit authentication endpoints (login, OAuth token) within the specified time period.",
     )
+    privacy_request_attachment_rate_limit: str = Field(
+        default="30/minute",
+        description="Per-IP rate limit for the unauthenticated privacy-request attachment upload endpoint. Tighter than the global limit because the endpoint accepts large multipart bodies.",
+    )
     root_user_scopes: List[str] = Field(
         default=SCOPE_REGISTRY,
         description="The list of scopes that are given to the root user.",
@@ -302,7 +306,11 @@ class SecuritySettings(FidesSettings):
             )
         return v
 
-    @field_validator("request_rate_limit", "auth_rate_limit")
+    @field_validator(
+        "request_rate_limit",
+        "auth_rate_limit",
+        "privacy_request_attachment_rate_limit",
+    )
     @classmethod
     def validate_rate_limits(
         cls,

--- a/src/fides/service/privacy_request_attachments/privacy_request_attachments_deps.py
+++ b/src/fides/service/privacy_request_attachments/privacy_request_attachments_deps.py
@@ -1,0 +1,9 @@
+"""Dependency-injection factory for the attachments service."""
+
+from fides.service.privacy_request_attachments.privacy_request_attachments_service import (
+    AttachmentUserProvidedService,
+)
+
+
+def get_attachment_user_provided_service() -> AttachmentUserProvidedService:
+    return AttachmentUserProvidedService()

--- a/src/fides/service/privacy_request_attachments/privacy_request_attachments_exceptions.py
+++ b/src/fides/service/privacy_request_attachments/privacy_request_attachments_exceptions.py
@@ -1,0 +1,43 @@
+"""Domain exceptions for the attachments service.
+
+Routes catch these and translate to HTTP. Services and repositories must
+never raise ``HTTPException`` directly.
+"""
+
+
+class AttachmentsServiceError(Exception):
+    """Base class for attachments service domain errors."""
+
+
+class StorageNotConfiguredError(AttachmentsServiceError):
+    """Raised when no active default storage config is available."""
+
+    def __init__(self, detail: str = "No active default storage configuration found."):
+        self.detail = detail
+        super().__init__(detail)
+
+
+class StorageBucketNotConfiguredError(AttachmentsServiceError):
+    """Raised when the active storage config has no bucket set."""
+
+    def __init__(self, detail: str = "Active storage configuration has no bucket."):
+        self.detail = detail
+        super().__init__(detail)
+
+
+class FileTooLargeError(AttachmentsServiceError):
+    """Raised when an upload exceeds the configured max size."""
+
+    def __init__(self, max_size_bytes: int):
+        self.max_size_bytes = max_size_bytes
+        super().__init__(f"File exceeds maximum allowed size of {max_size_bytes} bytes")
+
+
+class DisallowedFileTypeError(AttachmentsServiceError):
+    """Raised when an upload's detected file type is not in the allow-list."""
+
+    def __init__(self, allowed_extensions: list[str]):
+        self.allowed_extensions = allowed_extensions
+        super().__init__(
+            f"File type is not allowed. Allowed extensions: {sorted(allowed_extensions)}"
+        )

--- a/src/fides/service/privacy_request_attachments/privacy_request_attachments_service.py
+++ b/src/fides/service/privacy_request_attachments/privacy_request_attachments_service.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 from fides.api.models.storage import StorageConfig, get_active_default_storage_config
 from fides.api.schemas.attachment import PrivacyRequestAttachment
 from fides.api.schemas.privacy_center_config import DEFAULT_FILE_MAX_SIZE_BYTES
+from fides.api.schemas.storage.storage import StorageType
 from fides.api.service.storage.providers import StorageProviderFactory
 from fides.api.service.storage.providers.base import StorageProvider
 from fides.api.service.storage.util import AllowedFileType, FilesMagicBytes
@@ -43,7 +44,7 @@ def _get_provider_and_bucket(
     if not storage_config:
         raise StorageNotConfiguredError()
     bucket = _bucket(storage_config)
-    if not bucket:
+    if not bucket and storage_config.type != StorageType.local:
         raise StorageBucketNotConfiguredError()
     provider = StorageProviderFactory.create(storage_config)
     return provider, bucket, storage_config

--- a/src/fides/service/privacy_request_attachments/privacy_request_attachments_service.py
+++ b/src/fides/service/privacy_request_attachments/privacy_request_attachments_service.py
@@ -1,0 +1,107 @@
+"""Upload service for data-subject-uploaded file attachments."""
+
+import posixpath
+from io import BytesIO
+from typing import Optional
+from uuid import uuid4
+
+from loguru import logger
+from sqlalchemy.orm import Session
+
+from fides.api.models.storage import StorageConfig, get_active_default_storage_config
+from fides.api.schemas.attachment import PrivacyRequestAttachment
+from fides.api.schemas.privacy_center_config import DEFAULT_FILE_MAX_SIZE_BYTES
+from fides.api.service.storage.providers import StorageProviderFactory
+from fides.api.service.storage.providers.base import StorageProvider
+from fides.api.service.storage.util import AllowedFileType, FilesMagicBytes
+from fides.common.session_management import with_optional_sync_session
+from fides.service.privacy_request_attachments.privacy_request_attachments_exceptions import (
+    DisallowedFileTypeError,
+    FileTooLargeError,
+    StorageBucketNotConfiguredError,
+    StorageNotConfiguredError,
+)
+from fides.service.privacy_request_attachments.privacy_request_attachments_repository import (
+    AttachmentUserProvidedRepository,
+)
+
+DEFAULT_MAX_SIZE_BYTES = DEFAULT_FILE_MAX_SIZE_BYTES
+UPLOAD_READ_CHUNK_BYTES = 64 * 1024
+
+OBJECT_KEY_PREFIX = "privacy_request_attachments"
+
+
+def _bucket(storage_config: StorageConfig) -> str:
+    return (storage_config.details or {}).get("bucket", "")
+
+
+def _get_provider_and_bucket(
+    db: Session,
+) -> tuple[StorageProvider, str, StorageConfig]:
+    """Return (provider, bucket, storage_config) or raise a domain error."""
+    storage_config = get_active_default_storage_config(db)
+    if not storage_config:
+        raise StorageNotConfiguredError()
+    bucket = _bucket(storage_config)
+    if not bucket:
+        raise StorageBucketNotConfiguredError()
+    provider = StorageProviderFactory.create(storage_config)
+    return provider, bucket, storage_config
+
+
+class AttachmentUserProvidedService:
+    """Validate, store, and register data-subject-uploaded attachments."""
+
+    def __init__(self, repo: Optional[AttachmentUserProvidedRepository] = None) -> None:
+        self._repo = repo or AttachmentUserProvidedRepository()
+
+    @with_optional_sync_session
+    def upload_attachment(
+        self,
+        *,
+        file_data: bytes,
+        session: Session,
+    ) -> PrivacyRequestAttachment:
+        """Validate, store, and register a file attachment. Object key is
+        server-generated; client filename + Content-Type are discarded.
+
+        Raises ``FileTooLargeError``, ``DisallowedFileTypeError``,
+        ``StorageNotConfiguredError``, or ``StorageBucketNotConfiguredError``.
+        """
+        if len(file_data) > DEFAULT_MAX_SIZE_BYTES:
+            raise FileTooLargeError(DEFAULT_MAX_SIZE_BYTES)
+
+        allowed = FilesMagicBytes.default_public_upload_allowed_file_types()
+        sig = FilesMagicBytes.from_bytes(file_data)
+        if sig is None or sig not in allowed:
+            raise DisallowedFileTypeError(sorted(allowed))
+
+        content_type = AllowedFileType[sig].value
+        provider, bucket, storage_config = _get_provider_and_bucket(session)
+        object_key = posixpath.join(OBJECT_KEY_PREFIX, f"{uuid4()}.{sig}")
+
+        # Insert + flush DB row before the storage write. If the upload
+        # raises, the row rolls back and no orphan file is created. If
+        # the upload succeeds, the row commits alongside it; the orphan
+        # sweep keys on rows in ``uploaded`` state to catch any leftover
+        # files (see ``AttachmentUserProvidedStatus``).
+        record = self._repo.create_uploaded(
+            object_key=object_key,
+            storage_key=storage_config.key,
+            session=session,
+        )
+        result = provider.upload(
+            bucket=bucket,
+            key=object_key,
+            data=BytesIO(file_data),
+            content_type=content_type,
+        )
+
+        logger.info(
+            "Uploaded attachment id={} size={} type={}",
+            record.id,
+            result.file_size,
+            content_type,
+        )
+
+        return PrivacyRequestAttachment(id=record.id)

--- a/tests/fixtures/application_fixtures.py
+++ b/tests/fixtures/application_fixtures.py
@@ -3674,6 +3674,22 @@ def allow_custom_privacy_request_field_collection_disabled():
 
 
 @pytest.fixture(scope="function")
+def allow_custom_privacy_request_file_upload_enabled():
+    original_value = CONFIG.execution.allow_custom_privacy_request_file_upload
+    CONFIG.execution.allow_custom_privacy_request_file_upload = True
+    yield
+    CONFIG.execution.allow_custom_privacy_request_file_upload = original_value
+
+
+@pytest.fixture(scope="function")
+def allow_custom_privacy_request_file_upload_disabled():
+    original_value = CONFIG.execution.allow_custom_privacy_request_file_upload
+    CONFIG.execution.allow_custom_privacy_request_file_upload = False
+    yield
+    CONFIG.execution.allow_custom_privacy_request_file_upload = original_value
+
+
+@pytest.fixture(scope="function")
 def allow_custom_privacy_request_fields_in_request_execution_enabled():
     original_value = (
         CONFIG.execution.allow_custom_privacy_request_fields_in_request_execution

--- a/tests/ops/api/v1/endpoints/test_privacy_request_attachment_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_request_attachment_endpoints.py
@@ -132,6 +132,47 @@ class TestPostPrivacyRequestAttachment:
             )
         assert exc.value.status_code == 413
 
+    def test_upload_returns_413_when_service_raises_file_too_large(
+        self,
+        allow_custom_privacy_request_field_collection_enabled,
+        allow_custom_privacy_request_file_upload_enabled,
+        db,
+    ):
+        """Service-raised ``FileTooLargeError`` maps to HTTP 413.
+
+        The streaming guard normally fires first, so the only way to
+        reach the service-side size check from the endpoint is to pass
+        the streaming guard and have the service raise. We mock the
+        service directly to cover the except branch.
+        """
+        from fastapi import HTTPException
+
+        from fides.api.v1.endpoints.privacy_request_attachment_endpoints import (
+            upload_privacy_request_attachment,
+        )
+        from fides.service.privacy_request_attachments.privacy_request_attachments_exceptions import (
+            FileTooLargeError,
+        )
+
+        upload = MagicMock()
+        upload.file.read.side_effect = [PDF_BYTES, b""]
+        service = MagicMock()
+        service.upload_attachment.side_effect = FileTooLargeError(
+            DEFAULT_MAX_SIZE_BYTES
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            upload_privacy_request_attachment(
+                request=MagicMock(),
+                response=MagicMock(),
+                file=upload,
+                content_length=None,
+                db=db,
+                service=service,
+            )
+        assert exc.value.status_code == 413
+        assert str(DEFAULT_MAX_SIZE_BYTES) in exc.value.detail
+
     def test_upload_happy_path(
         self,
         api_client: TestClient,

--- a/tests/ops/api/v1/endpoints/test_privacy_request_attachment_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_request_attachment_endpoints.py
@@ -1,0 +1,155 @@
+"""Tests for POST /privacy-request/attachment."""
+
+import io
+from unittest.mock import MagicMock, patch
+
+import pytest
+from starlette.testclient import TestClient
+
+from fides.common.urn_registry import PRIVACY_REQUEST_ATTACHMENT, V1_URL_PREFIX
+from fides.service.privacy_request_attachments.privacy_request_attachments_service import (
+    DEFAULT_MAX_SIZE_BYTES,
+)
+
+URL = V1_URL_PREFIX + PRIVACY_REQUEST_ATTACHMENT
+PDF_BYTES = b"%PDF-1.4 minimal pdf body"
+
+
+@pytest.fixture
+def mock_provider():
+    provider = MagicMock()
+    provider.upload.return_value = MagicMock(file_size=len(PDF_BYTES))
+    return provider
+
+
+@pytest.fixture
+def patch_storage_factory(mock_provider, storage_config_default):
+    with (
+        patch(
+            "fides.service.privacy_request_attachments.privacy_request_attachments_service.StorageProviderFactory"
+        ) as factory,
+        patch(
+            "fides.service.privacy_request_attachments.privacy_request_attachments_service._get_provider_and_bucket",
+            return_value=(mock_provider, "test_bucket", storage_config_default),
+        ),
+    ):
+        factory.create.return_value = mock_provider
+        yield factory
+
+
+class TestPostPrivacyRequestAttachment:
+    def test_upload_forbidden_when_custom_fields_disabled(
+        self,
+        api_client: TestClient,
+        allow_custom_privacy_request_field_collection_disabled,
+        allow_custom_privacy_request_file_upload_enabled,
+    ):
+        # File-upload flag alone is insufficient; field-collection must
+        # also be on.
+        resp = api_client.post(URL, files={"file": ("x.pdf", io.BytesIO(PDF_BYTES))})
+        assert resp.status_code == 403
+        assert "disabled" in resp.json()["detail"].lower()
+
+    def test_upload_forbidden_when_file_upload_disabled(
+        self,
+        api_client: TestClient,
+        allow_custom_privacy_request_field_collection_enabled,
+        allow_custom_privacy_request_file_upload_disabled,
+    ):
+        # Field-collection alone is insufficient; file-upload flag is
+        # an independent gate.
+        resp = api_client.post(URL, files={"file": ("x.pdf", io.BytesIO(PDF_BYTES))})
+        assert resp.status_code == 403
+        assert "disabled" in resp.json()["detail"].lower()
+
+    def test_upload_rejects_oversize(
+        self,
+        api_client: TestClient,
+        allow_custom_privacy_request_field_collection_enabled,
+        allow_custom_privacy_request_file_upload_enabled,
+    ):
+        oversize = b"%PDF" + b"x" * (DEFAULT_MAX_SIZE_BYTES + 1)
+        resp = api_client.post(URL, files={"file": ("x.pdf", io.BytesIO(oversize))})
+        assert resp.status_code == 413
+        assert "maximum allowed size" in resp.json()["detail"]
+
+    def test_upload_rejects_bad_magic(
+        self,
+        api_client: TestClient,
+        allow_custom_privacy_request_field_collection_enabled,
+        allow_custom_privacy_request_file_upload_enabled,
+        storage_config_default,
+        patch_storage_factory,
+    ):
+        resp = api_client.post(
+            URL, files={"file": ("x.pdf", io.BytesIO(b"not a real pdf"))}
+        )
+        assert resp.status_code == 400
+        assert "not allowed" in resp.json()["detail"]
+
+    def test_upload_returns_503_without_storage_config(
+        self,
+        api_client: TestClient,
+        allow_custom_privacy_request_field_collection_enabled,
+        allow_custom_privacy_request_file_upload_enabled,
+    ):
+        with patch(
+            "fides.service.privacy_request_attachments.privacy_request_attachments_service.get_active_default_storage_config",
+            return_value=None,
+        ):
+            resp = api_client.post(
+                URL, files={"file": ("x.pdf", io.BytesIO(PDF_BYTES))}
+            )
+        assert resp.status_code == 503
+        assert resp.json()["detail"] == "File attachments are temporarily unavailable."
+
+    def test_upload_rejects_streaming_oversize_when_content_length_lies(
+        self,
+        allow_custom_privacy_request_field_collection_enabled,
+        allow_custom_privacy_request_file_upload_enabled,
+        db,
+    ):
+        # Lying Content-Length bypasses pre-check; streaming guard fires.
+        from fastapi import HTTPException
+
+        from fides.api.v1.endpoints.privacy_request_attachment_endpoints import (
+            upload_privacy_request_attachment,
+        )
+
+        upload = MagicMock()
+        upload.file.read.side_effect = [
+            b"%PDF" + b"x" * (DEFAULT_MAX_SIZE_BYTES + 1),
+            b"",
+        ]
+        with pytest.raises(HTTPException) as exc:
+            upload_privacy_request_attachment(
+                request=MagicMock(),
+                response=MagicMock(),
+                file=upload,
+                content_length=1,
+                db=db,
+                service=MagicMock(),
+            )
+        assert exc.value.status_code == 413
+
+    def test_upload_happy_path(
+        self,
+        api_client: TestClient,
+        allow_custom_privacy_request_field_collection_enabled,
+        allow_custom_privacy_request_file_upload_enabled,
+        storage_config_default,
+        patch_storage_factory,
+        mock_provider,
+    ):
+        resp = api_client.post(
+            URL, files={"file": ("original.pdf", io.BytesIO(PDF_BYTES))}
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["id"].startswith("att_")
+
+        mock_provider.upload.assert_called_once()
+        kwargs = mock_provider.upload.call_args.kwargs
+        assert kwargs["key"].startswith("privacy_request_attachments/")
+        assert kwargs["key"].endswith(".pdf")
+        assert kwargs["content_type"] == "application/pdf"

--- a/tests/ops/service/privacy_request_attachments/test_service.py
+++ b/tests/ops/service/privacy_request_attachments/test_service.py
@@ -1,0 +1,161 @@
+"""Tests for the upload service. Resolution + promotion ship in ENG-3517-1."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fides.api.models.attachment import (
+    AttachmentUserProvided,
+    AttachmentUserProvidedStatus,
+)
+from fides.service.privacy_request_attachments.privacy_request_attachments_exceptions import (
+    DisallowedFileTypeError,
+    FileTooLargeError,
+    StorageBucketNotConfiguredError,
+    StorageNotConfiguredError,
+)
+from fides.service.privacy_request_attachments.privacy_request_attachments_service import (
+    DEFAULT_MAX_SIZE_BYTES,
+    AttachmentUserProvidedService,
+    _bucket,
+    _get_provider_and_bucket,
+)
+
+PDF_BYTES = b"%PDF-1.4 minimal pdf body"
+
+
+@pytest.fixture
+def mock_provider():
+    provider = MagicMock()
+    provider.upload.return_value = MagicMock(file_size=123)
+    return provider
+
+
+@pytest.fixture
+def patch_provider_factory(mock_provider, storage_config_default):
+    """Pin provider/bucket/storage_config for deterministic asserts."""
+    with (
+        patch(
+            "fides.service.privacy_request_attachments.privacy_request_attachments_service.StorageProviderFactory"
+        ) as factory,
+        patch(
+            "fides.service.privacy_request_attachments.privacy_request_attachments_service._get_provider_and_bucket",
+            return_value=(mock_provider, "test_bucket", storage_config_default),
+        ),
+    ):
+        factory.create.return_value = mock_provider
+        yield factory
+
+
+class TestUploadAttachment:
+    def test_upload_happy_path_creates_uploaded_row(
+        self,
+        db,
+        storage_config_default,
+        patch_provider_factory,
+        mock_provider,
+    ):
+        result = AttachmentUserProvidedService().upload_attachment(
+            file_data=PDF_BYTES, session=db
+        )
+
+        assert result.id.startswith("att_")
+        row = (
+            db.query(AttachmentUserProvided)
+            .filter(AttachmentUserProvided.id == result.id)
+            .one()
+        )
+        assert row.status == AttachmentUserProvidedStatus.uploaded
+        assert row.storage_key == storage_config_default.key
+        assert row.object_key.startswith("privacy_request_attachments/")
+        assert row.object_key.endswith(".pdf")
+
+        mock_provider.upload.assert_called_once()
+        kwargs = mock_provider.upload.call_args.kwargs
+        assert kwargs["content_type"] == "application/pdf"
+
+        row.delete(db)
+
+    def test_storage_upload_failure_rolls_back_row(
+        self,
+        db,
+        storage_config_default,
+        patch_provider_factory,
+        mock_provider,
+    ):
+        """Row is flushed before upload; if upload raises, the row must
+        not be committed (no orphan file, no orphan row)."""
+        mock_provider.upload.side_effect = RuntimeError("s3 boom")
+
+        before = db.query(AttachmentUserProvided).count()
+        with pytest.raises(RuntimeError, match="s3 boom"):
+            AttachmentUserProvidedService().upload_attachment(
+                file_data=PDF_BYTES, session=db
+            )
+        # Caller-supplied session: decorator only flushes; row should not
+        # be visible after the rollback we trigger to clear the failed
+        # state.
+        db.rollback()
+        after = db.query(AttachmentUserProvided).count()
+        assert after == before
+
+    def test_upload_rejects_oversize(self, db, storage_config_default):
+        oversize = b"%PDF" + b"x" * (DEFAULT_MAX_SIZE_BYTES + 1)
+        with pytest.raises(FileTooLargeError):
+            AttachmentUserProvidedService().upload_attachment(
+                file_data=oversize, session=db
+            )
+
+    def test_upload_rejects_unknown_magic(
+        self, db, storage_config_default, patch_provider_factory
+    ):
+        with pytest.raises(DisallowedFileTypeError):
+            AttachmentUserProvidedService().upload_attachment(
+                file_data=b"not a real file format", session=db
+            )
+
+    def test_upload_without_storage_config_raises(self, db):
+        with patch(
+            "fides.service.privacy_request_attachments.privacy_request_attachments_service.get_active_default_storage_config",
+            return_value=None,
+        ):
+            with pytest.raises(StorageNotConfiguredError):
+                AttachmentUserProvidedService().upload_attachment(
+                    file_data=PDF_BYTES, session=db
+                )
+
+
+class TestProviderHelpers:
+    def test_bucket_returns_value_from_details(self):
+        config = MagicMock(details={"bucket": "my-bucket"})
+        assert _bucket(config) == "my-bucket"
+
+    def test_bucket_handles_none_details(self):
+        config = MagicMock(details=None)
+        assert _bucket(config) == ""
+
+    def test_get_provider_and_bucket_happy_path(self, db, mock_provider):
+        config = MagicMock(details={"bucket": "happy-bucket"})
+        with (
+            patch(
+                "fides.service.privacy_request_attachments.privacy_request_attachments_service.get_active_default_storage_config",
+                return_value=config,
+            ),
+            patch(
+                "fides.service.privacy_request_attachments.privacy_request_attachments_service.StorageProviderFactory.create",
+                return_value=mock_provider,
+            ),
+        ):
+            provider, bucket, returned_config = _get_provider_and_bucket(db)
+        assert provider is mock_provider
+        assert bucket == "happy-bucket"
+        assert returned_config is config
+
+    def test_get_provider_and_bucket_no_bucket_raises(self, db):
+        config = MagicMock(details={})
+        with patch(
+            "fides.service.privacy_request_attachments.privacy_request_attachments_service.get_active_default_storage_config",
+            return_value=config,
+        ):
+            with pytest.raises(StorageBucketNotConfiguredError):
+                _get_provider_and_bucket(db)

--- a/tests/ops/service/privacy_request_attachments/test_service.py
+++ b/tests/ops/service/privacy_request_attachments/test_service.py
@@ -159,3 +159,23 @@ class TestProviderHelpers:
         ):
             with pytest.raises(StorageBucketNotConfiguredError):
                 _get_provider_and_bucket(db)
+
+    def test_get_provider_and_bucket_local_no_bucket_ok(self, db, mock_provider):
+        from fides.api.schemas.storage.storage import StorageType
+
+        config = MagicMock(details={}, type=StorageType.local)
+        with (
+            patch(
+                "fides.service.privacy_request_attachments.privacy_request_attachments_service.get_active_default_storage_config",
+                return_value=config,
+            ),
+            patch(
+                "fides.service.privacy_request_attachments.privacy_request_attachments_service.StorageProviderFactory.create",
+                return_value=mock_provider,
+            ),
+        ):
+            provider, bucket, returned_config = _get_provider_and_bucket(db)
+        assert provider is mock_provider
+        assert bucket == ""
+        assert returned_config is config
+

--- a/tests/ops/service/privacy_request_attachments/test_service.py
+++ b/tests/ops/service/privacy_request_attachments/test_service.py
@@ -178,4 +178,3 @@ class TestProviderHelpers:
         assert provider is mock_provider
         assert bucket == ""
         assert returned_config is config
-


### PR DESCRIPTION
Ticket [ENG-3517](https://ethyca.atlassian.net/browse/ENG-3517)

### Description Of Changes

Adds the upload service and unauthenticated `POST /privacy-request/attachment` endpoint that data subjects use to attach files to custom Privacy Center fields. Stacked on top of `ENG-3517-A` (foundation: schema, model, storage util, repo). Resolution + promotion of these uploaded rows to a real privacy request ship in `ENG-3517-1`.

The endpoint is double-gated: both `allow_custom_privacy_request_field_collection` and the new `allow_custom_privacy_request_file_upload` flag must be true, otherwise it returns 403. Size is enforced twice — a `Content-Length` pre-check, plus an authoritative streaming check (clients can lie about `Content-Length`). MIME is detected from magic bytes and matched against `PublicUploadAllowedFileTypes`; client filename and `Content-Type` are discarded. Object key is server-generated (`privacy_request_attachments/<uuid>.<ext>`). The endpoint is rate-limited via `fides_limiter` using `CONFIG.security.request_rate_limit`. If no active default storage config is present, the endpoint returns a generic 503 (internal reason logged, not leaked to unauthenticated callers).

### Code Changes

* `src/fides/api/v1/endpoints/privacy_request_attachment_endpoints.py` — new unauthenticated `POST /privacy-request/attachment` route with feature-flag gate, `Content-Length` pre-check, streaming size guard, and mapped error responses (403 / 400 / 413 / 503).
* `src/fides/service/privacy_request/attachment_user_provided_service.py` — `upload_attachment` service: magic-byte MIME check, server-generated object key, storage upload, repo `create_uploaded` row, commit. Raises `ValueError` for size/type, `RuntimeError` for missing storage config.
* `src/fides/config/execution_settings.py` — new `allow_custom_privacy_request_file_upload` config flag (default `False`).
* `src/fides/common/urn_registry.py` — register `PRIVACY_REQUEST_ATTACHMENT = "/privacy-request/attachment"`.
* `src/fides/api/v1/api.py` — wire the new router.
* `tests/ops/api/v1/endpoints/test_privacy_request_attachment_endpoints.py` — endpoint tests: feature-flag 403, oversize 413 (incl. Content-Length-lying streaming case), bad-magic 400, missing-storage 503, happy-path 200.
* `tests/ops/service/privacy_request/test_attachment_user_provided_service.py` — service tests: happy-path row creation, oversize/unknown-magic rejection, missing-storage `RuntimeError`, provider/bucket helpers.
* `changelog/8042-attachment-upload-endpoint.yaml` — changelog entry.

### Steps to Confirm

1. Set `execution.allow_custom_privacy_request_field_collection = true` and `execution.allow_custom_privacy_request_file_upload = true`, and ensure an active default storage config exists.
2. `curl -F "file=@sample.pdf" http://localhost:8080/api/v1/privacy-request/attachment` — expect 200 with `{"id": "att_..."}`.
3. Flip either flag off → expect 403 `"File attachments are disabled."`.
4. Upload a file whose magic bytes do not match an allowed type → expect 400 `"File type is not allowed..."`.
5. Upload a file larger than `DEFAULT_FILE_MAX_SIZE_BYTES` → expect 413.
6. Remove/disable the active default storage config and retry → expect 503 `"File attachments are temporarily unavailable."`.
7. Hammer the endpoint past `security.request_rate_limit` → expect rate-limit response.

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [x] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-3517]: https://ethyca.atlassian.net/browse/ENG-3517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ