### PR TITLE
ENG-3517: Promote file to attachment

### DIFF
--- a/changelog/8047-attachment-promotion.yaml
+++ b/changelog/8047-attachment-promotion.yaml
@@ -1,0 +1,4 @@
+type: Added
+description: Resolve + promote uploaded attachments
+pr: 8047
+labels: []

--- a/src/fides/api/deps.py
+++ b/src/fides/api/deps.py
@@ -21,6 +21,12 @@ from fides.service.dataset.dataset_service import DatasetService
 from fides.service.event_audit_service import EventAuditService
 from fides.service.messaging.messaging_service import MessagingService
 from fides.service.privacy_request.privacy_request_service import PrivacyRequestService
+from fides.service.privacy_request_attachments.privacy_request_attachments_deps import (
+    get_attachment_user_provided_service,
+)
+from fides.service.privacy_request_attachments.privacy_request_attachments_service import (
+    AttachmentUserProvidedService,
+)
 from fides.service.system.system_service import SystemService
 from fides.service.taxonomy.taxonomy_service import TaxonomyService
 from fides.service.user.user_service import UserService
@@ -93,8 +99,13 @@ def get_privacy_request_service(
     db: Session = Depends(get_db),
     config_proxy: ConfigProxy = Depends(get_config_proxy),
     messaging_service: MessagingService = Depends(get_messaging_service),
+    attachment_user_provided_service: AttachmentUserProvidedService = Depends(
+        get_attachment_user_provided_service
+    ),
 ) -> PrivacyRequestService:
-    return PrivacyRequestService(db, config_proxy, messaging_service)
+    return PrivacyRequestService(
+        db, config_proxy, messaging_service, attachment_user_provided_service
+    )
 
 
 def get_dataset_service(

--- a/src/fides/api/v1/endpoints/consent_request_endpoints.py
+++ b/src/fides/api/v1/endpoints/consent_request_endpoints.py
@@ -68,6 +68,9 @@ from fides.config import CONFIG
 from fides.config.config_proxy import ConfigProxy
 from fides.service.messaging.messaging_service import MessagingService
 from fides.service.privacy_request.privacy_request_service import PrivacyRequestService
+from fides.service.privacy_request_attachments.privacy_request_attachments_service import (
+    AttachmentUserProvidedService,
+)
 
 router = APIRouter(tags=["Consent"], prefix=V1_URL_PREFIX)
 
@@ -409,7 +412,10 @@ def queue_privacy_request_to_propagate_consent_old_workflow(
     # It's a bit weird to initialize the privacy request service here,
     # but this logic is slated for deprecation so it's not worth doing a larger refactor
     privacy_request_service = PrivacyRequestService(
-        db, ConfigProxy(db), MessagingService(db, CONFIG, ConfigProxy(db))
+        db,
+        ConfigProxy(db),
+        MessagingService(db, CONFIG, ConfigProxy(db)),
+        AttachmentUserProvidedService(),
     )
 
     privacy_request_results: BulkPostPrivacyRequests = privacy_request_service.create_bulk_privacy_requests(

--- a/src/fides/api/v1/endpoints/privacy_request_endpoints.py
+++ b/src/fides/api/v1/endpoints/privacy_request_endpoints.py
@@ -189,6 +189,9 @@ from fides.service.privacy_request.privacy_request_service import (
     handle_approval,
     queue_privacy_request,
 )
+from fides.service.privacy_request_attachments.privacy_request_attachments_service import (
+    AttachmentUserProvidedService,
+)
 
 router = APIRouter(tags=["Privacy Requests"], prefix=V1_URL_PREFIX)
 
@@ -199,7 +202,10 @@ def get_privacy_request_or_error(
     """Load the privacy request or throw a 404"""
     logger.debug("Finding privacy request with id '{}'", privacy_request_id)
     privacy_request_service = PrivacyRequestService(
-        db, ConfigProxy(db), MessagingService(db, CONFIG, ConfigProxy(db))
+        db,
+        ConfigProxy(db),
+        MessagingService(db, CONFIG, ConfigProxy(db)),
+        AttachmentUserProvidedService(),
     )
     privacy_request = privacy_request_service.get_privacy_request(privacy_request_id)
 
@@ -512,7 +518,10 @@ def get_request_status(
         sort_direction=sort_direction,
     )
     privacy_request_service = PrivacyRequestService(
-        db, ConfigProxy(db), MessagingService(db, CONFIG, ConfigProxy(db))
+        db,
+        ConfigProxy(db),
+        MessagingService(db, CONFIG, ConfigProxy(db)),
+        AttachmentUserProvidedService(),
     )
     return _shared_privacy_request_search(
         db=db,
@@ -550,7 +559,10 @@ def privacy_request_search(
         privacy_request_filter = PrivacyRequestFilter()
 
     privacy_request_service = PrivacyRequestService(
-        db, ConfigProxy(db), MessagingService(db, CONFIG, ConfigProxy(db))
+        db,
+        ConfigProxy(db),
+        MessagingService(db, CONFIG, ConfigProxy(db)),
+        AttachmentUserProvidedService(),
     )
     return _shared_privacy_request_search(
         db=db,

--- a/src/fides/service/privacy_request/privacy_request_service.py
+++ b/src/fides/service/privacy_request/privacy_request_service.py
@@ -33,6 +33,7 @@ from fides.api.schemas.api import BulkUpdateFailed
 from fides.api.schemas.messaging.messaging import MessagingActionType
 from fides.api.schemas.policy import ActionType, CurrentStep
 from fides.api.schemas.privacy_center_config import (
+    FileUploadCustomPrivacyRequestField,
     LocationCustomPrivacyRequestField,
     PrivacyRequestOption,
     reorder_custom_privacy_request_fields,
@@ -84,6 +85,12 @@ from fides.service.privacy_request.privacy_request_query_utils import (
     resolve_request_ids_from_filters,
     sort_privacy_request_queryset,
 )
+from fides.service.privacy_request_attachments.privacy_request_attachments_exceptions import (
+    AttachmentsServiceError,
+)
+from fides.service.privacy_request_attachments.privacy_request_attachments_service import (
+    AttachmentUserProvidedService,
+)
 
 
 class PrivacyRequestService:
@@ -92,10 +99,12 @@ class PrivacyRequestService:
         db: Session,
         config_proxy: ConfigProxy,
         messaging_service: MessagingService,
+        attachment_user_provided_service: AttachmentUserProvidedService,
     ):
         self.db = db
         self.config_proxy = config_proxy
         self.messaging_service = messaging_service
+        self.attachment_user_provided_service = attachment_user_provided_service
 
     def get_privacy_request(self, privacy_request_id: str) -> Optional[PrivacyRequest]:
         privacy_request: Optional[PrivacyRequest] = (
@@ -196,18 +205,18 @@ class PrivacyRequestService:
         return {pr.id: pr for pr in privacy_requests}
 
     def _validate_required_location_fields(
-        self, privacy_request_data: PrivacyRequestCreate
+        self,
+        privacy_request_data: PrivacyRequestCreate,
+        action: Optional[PrivacyRequestOption],
     ) -> None:
         """Validate that location is provided for required location fields.
 
-        Looks up the actual Privacy Center configuration to check if any location
-        fields are marked as required for the specified policy.
+        Caller must resolve ``action`` via :meth:`_resolve_action_for_request`
+        and pass it in. ``None`` short-circuits.
         """
-        # If location is already provided, no validation needed
         if privacy_request_data.location:
             return
 
-        action = self._resolve_action_for_request(privacy_request_data)
         if not action or not action.custom_privacy_request_fields:
             return
 
@@ -317,11 +326,15 @@ class PrivacyRequestService:
         return action
 
     def _validate_field_visibility(
-        self, privacy_request_data: PrivacyRequestCreate
+        self,
+        privacy_request_data: PrivacyRequestCreate,
+        action: Optional[PrivacyRequestOption],
     ) -> None:
         """Reject payloads that violate the action's display_condition
-        contract; translate :class:`DisplayConditionViolation` to ``PrivacyRequestError``."""
-        action = self._resolve_action_for_request(privacy_request_data)
+        contract; translate :class:`DisplayConditionViolation` to
+        ``PrivacyRequestError``. Caller must resolve ``action`` via
+        :meth:`_resolve_action_for_request` and pass it in; ``None``
+        short-circuits."""
         if not action or not action.custom_privacy_request_fields:
             return
 
@@ -402,6 +415,27 @@ class PrivacyRequestService:
                 privacy_request_data.model_dump(mode="json"),
             )
 
+        action = self._resolve_action_for_request(privacy_request_data)
+        file_field_names: set[str] = (
+            {
+                name
+                for name, cfg in (action.custom_privacy_request_fields or {}).items()
+                if isinstance(cfg, FileUploadCustomPrivacyRequestField)
+            }
+            if action and action.custom_privacy_request_fields
+            else set()
+        )
+        attachment_service = self.attachment_user_provided_service
+        try:
+            attachment_rows = attachment_service.resolve_file_attachments(
+                privacy_request_data.custom_privacy_request_fields,
+                file_field_names,
+                session=self.db,
+            )
+        except AttachmentsServiceError as exc:
+            raise PrivacyRequestError(
+                str(exc), privacy_request_data.model_dump(mode="json")
+            ) from exc
         if privacy_request_data.property_id:
             valid_property = Property.get_by(
                 self.db, field="id", value=privacy_request_data.property_id
@@ -413,10 +447,21 @@ class PrivacyRequestService:
                 )
 
         # Validate location is provided for required location fields
-        self._validate_required_location_fields(privacy_request_data)
+        self._validate_required_location_fields(privacy_request_data, action)
 
-        # Validate display_condition visibility: no gated-off fields submitted,
-        self._validate_field_visibility(privacy_request_data)
+        # Validate display_condition visibility BEFORE stripping file fields so
+        # required FileUpload fields are seen as having a submitted value.
+        self._validate_field_visibility(privacy_request_data, action)
+
+        if file_field_names and privacy_request_data.custom_privacy_request_fields:
+            non_file = {
+                k: v
+                for k, v in privacy_request_data.custom_privacy_request_fields.items()
+                if k not in file_field_names
+            }
+            privacy_request_data = privacy_request_data.model_copy(
+                update={"custom_privacy_request_fields": non_file or None}
+            )
 
         policy = Policy.get_by(
             db=self.db,
@@ -505,6 +550,36 @@ class PrivacyRequestService:
                 )
                 privacy_request.persist_masking_secrets(masking_secrets)
 
+            # Promote data-subject-uploaded files to Attachment records.
+            # Must happen before _handle_notifications_and_processing so a
+            # failure here deletes the just-created privacy request — files
+            # are required, not supplementary, so a request missing its
+            # attachments must not be processed.
+            if attachment_rows:
+                try:
+                    attachment_service.promote_rows_to_attachments(
+                        privacy_request, attachment_rows, session=self.db
+                    )
+                except Exception as promotion_exc:
+                    logger.exception(
+                        "Attachment promotion failed for privacy request {} — "
+                        "deleting the request to preserve the 'files required' invariant",
+                        privacy_request.id,
+                    )
+                    try:
+                        privacy_request.delete(self.db)
+                    except Exception:
+                        logger.exception(
+                            "Failed to delete privacy request {} after promotion failure",
+                            privacy_request.id,
+                        )
+                    # Surface the attachment-specific reason directly instead
+                    # of letting the outer broad except wrap it in the generic
+                    # "This record could not be added" message.
+                    raise PrivacyRequestError(
+                        f"Attachment processing failed: {promotion_exc}", kwargs
+                    ) from promotion_exc
+
             check_and_dispatch_error_notifications(db=self.db)
 
             _handle_notifications_and_processing(
@@ -530,6 +605,10 @@ class PrivacyRequestService:
             raise PrivacyRequestError(
                 "Verification message could not be sent.", kwargs
             ) from exc
+        except PrivacyRequestError:
+            # Already carries a specific reason (e.g. attachment promotion
+            # failure) — don't rewrap with the generic message below.
+            raise
         except Exception as exc:
             logger.error(f"{exc.__class__.__name__}: {str(exc)}")
             raise PrivacyRequestError("This record could not be added", kwargs) from exc

--- a/src/fides/service/privacy_request_attachments/privacy_request_attachments_exceptions.py
+++ b/src/fides/service/privacy_request_attachments/privacy_request_attachments_exceptions.py
@@ -41,3 +41,37 @@ class DisallowedFileTypeError(AttachmentsServiceError):
         super().__init__(
             f"File type is not allowed. Allowed extensions: {sorted(allowed_extensions)}"
         )
+
+
+class InvalidAttachmentStateError(AttachmentsServiceError):
+    """Raised when an attachment is not in the expected lifecycle state."""
+
+    def __init__(self, object_key: str, status: str, expected: str = "uploaded"):
+        self.object_key = object_key
+        self.status = status
+        self.expected = expected
+        super().__init__(
+            f"Attachment '{object_key}' is in state {status}, "
+            f"expected '{expected}'. Refusing to promote."
+        )
+
+
+class AttachmentNotFoundError(AttachmentsServiceError):
+    """Raised when a referenced attachment id can't be locked as ``uploaded``."""
+
+    def __init__(self, field_name: str):
+        self.field_name = field_name
+        super().__init__(
+            f"File attachment for field '{field_name}' "
+            "has expired or is invalid. Please re-upload and resubmit."
+        )
+
+
+class InvalidAttachmentValueError(AttachmentsServiceError):
+    """Raised when a file field's value isn't a list of attachment ids."""
+
+    def __init__(self, field_name: str):
+        self.field_name = field_name
+        super().__init__(
+            f"File attachment for field '{field_name}' must be a list of attachment ids."
+        )

--- a/src/fides/service/privacy_request_attachments/privacy_request_attachments_repository.py
+++ b/src/fides/service/privacy_request_attachments/privacy_request_attachments_repository.py
@@ -1,5 +1,8 @@
 """Data-access layer for ``AttachmentUserProvided`` rows."""
 
+from datetime import datetime, timezone
+from typing import Optional
+
 from sqlalchemy.orm import Session
 
 from fides.api.models.attachment import (
@@ -9,6 +12,9 @@ from fides.api.models.attachment import (
 from fides.common.session_management import with_optional_sync_session
 from fides.service.privacy_request_attachments.privacy_request_attachments_entities import (
     AttachmentUserProvidedRecord,
+)
+from fides.service.privacy_request_attachments.privacy_request_attachments_exceptions import (
+    InvalidAttachmentStateError,
 )
 
 
@@ -33,3 +39,51 @@ class AttachmentUserProvidedRepository:
         session.flush()
         session.refresh(row)
         return AttachmentUserProvidedRecord.from_orm(row)
+
+    @with_optional_sync_session
+    def lock_uploaded_by_ids(
+        self, ids: list[str], *, session: Session
+    ) -> list[AttachmentUserProvided]:
+        """Return ``uploaded`` rows matching ``ids`` under ``FOR UPDATE``.
+
+        Returns ORM rows so the caller can mutate via :meth:`mark_promoted`
+        within the same transaction. The lock is released by the caller's
+        next ``COMMIT``/``ROLLBACK``; the authoritative concurrency guard
+        is :meth:`mark_promoted`'s ``status != uploaded`` check.
+        """
+        return (
+            session.query(AttachmentUserProvided)
+            .filter(AttachmentUserProvided.id.in_(ids))
+            .filter(
+                AttachmentUserProvided.status == AttachmentUserProvidedStatus.uploaded
+            )
+            .with_for_update()
+            .all()
+        )
+
+    @staticmethod
+    def assert_all_uploaded(rows: list[AttachmentUserProvided]) -> None:
+        """Raise :class:`InvalidAttachmentStateError` if any row is not in
+        ``uploaded``. Caller uses this to fail fast before mutating state."""
+        for row in rows:
+            if row.status != AttachmentUserProvidedStatus.uploaded:
+                raise InvalidAttachmentStateError(row.object_key, row.status)
+
+    @with_optional_sync_session
+    def mark_promoted(
+        self,
+        row: AttachmentUserProvided,
+        *,
+        promoted_at: Optional[datetime] = None,
+        session: Session,  # pylint: disable=unused-argument
+    ) -> None:
+        """Flip a single row from ``uploaded`` to ``promoted``.
+
+        Raises :class:`InvalidAttachmentStateError` if the row is not in
+        ``uploaded``. Per-row so callers can flip after each successful
+        side effect; a mid-batch failure leaves remaining rows alone.
+        """
+        if row.status != AttachmentUserProvidedStatus.uploaded:
+            raise InvalidAttachmentStateError(row.object_key, row.status)
+        row.status = AttachmentUserProvidedStatus.promoted
+        row.promoted_at = promoted_at or datetime.now(timezone.utc)

--- a/src/fides/service/privacy_request_attachments/privacy_request_attachments_service.py
+++ b/src/fides/service/privacy_request_attachments/privacy_request_attachments_service.py
@@ -1,24 +1,37 @@
-"""Upload service for data-subject-uploaded file attachments."""
+"""Upload, resolve, and promote service for data-subject-uploaded file attachments."""
 
+import os
 import posixpath
 from io import BytesIO
-from typing import Optional
+from typing import Any, Optional
 from uuid import uuid4
 
 from loguru import logger
 from sqlalchemy.orm import Session
 
+from fides.api.models.attachment import (
+    AttachmentReferenceType,
+    AttachmentType,
+    AttachmentUserProvided,
+    AttachmentUserProvidedStatus,
+)
+from fides.api.models.privacy_request.privacy_request import PrivacyRequest
 from fides.api.models.storage import StorageConfig, get_active_default_storage_config
 from fides.api.schemas.attachment import PrivacyRequestAttachment
 from fides.api.schemas.privacy_center_config import DEFAULT_FILE_MAX_SIZE_BYTES
+from fides.api.schemas.redis_cache import CustomPrivacyRequestField
 from fides.api.schemas.storage.storage import StorageType
 from fides.api.service.storage.providers import StorageProviderFactory
 from fides.api.service.storage.providers.base import StorageProvider
 from fides.api.service.storage.util import AllowedFileType, FilesMagicBytes
 from fides.common.session_management import with_optional_sync_session
+from fides.config import CONFIG
+from fides.service.attachment_service import AttachmentService
 from fides.service.privacy_request_attachments.privacy_request_attachments_exceptions import (
+    AttachmentNotFoundError,
     DisallowedFileTypeError,
     FileTooLargeError,
+    InvalidAttachmentValueError,
     StorageBucketNotConfiguredError,
     StorageNotConfiguredError,
 )
@@ -106,3 +119,129 @@ class AttachmentUserProvidedService:
         )
 
         return PrivacyRequestAttachment(id=record.id)
+
+    @with_optional_sync_session
+    def resolve_file_attachments(
+        self,
+        custom_privacy_request_fields: Optional[dict[str, CustomPrivacyRequestField]],
+        file_field_names: set[str],
+        *,
+        session: Session,
+    ) -> list[AttachmentUserProvided]:
+        """Resolve file-field values to ``uploaded`` rows under ``FOR UPDATE``.
+
+        Returns the locked ORM rows so :meth:`promote_rows_to_attachments`
+        can mutate them in the same transaction. The lock holds until the
+        caller's next commit/rollback. Returns ``[]`` if the
+        ``allow_custom_privacy_request_field_collection`` flag is off.
+        """
+        if not custom_privacy_request_fields or not file_field_names:
+            return []
+
+        if not CONFIG.execution.allow_custom_privacy_request_field_collection:
+            return []
+
+        rows: list[AttachmentUserProvided] = []
+        for name in file_field_names:
+            field = custom_privacy_request_fields.get(name)
+            if field is None:
+                continue
+
+            value = field.value
+            if not isinstance(value, list) or not all(
+                isinstance(v, str) for v in value
+            ):
+                raise InvalidAttachmentValueError(name)
+            ids: list[str] = [v for v in value if isinstance(v, str)]
+            if not ids:
+                continue
+
+            pending = {
+                r.id: r for r in self._repo.lock_uploaded_by_ids(ids, session=session)
+            }
+            for item in ids:
+                row = pending.get(item)
+                if row is None:
+                    raise AttachmentNotFoundError(name)
+                rows.append(row)
+
+        return rows
+
+    @with_optional_sync_session
+    def promote_rows_to_attachments(
+        self,
+        privacy_request: PrivacyRequest,
+        rows: list[AttachmentUserProvided],
+        *,
+        session: Session,
+    ) -> None:
+        """Transition pending rows → ``promoted`` and create ``Attachment`` records."""
+        if not rows:
+            return
+
+        self._repo.assert_all_uploaded(rows)
+
+        provider, bucket, storage_config = _get_provider_and_bucket(session)
+        attachment_service = AttachmentService(db=session)
+
+        # ``(row, attachment)`` pairs we have already promoted in-memory.
+        # On a mid-loop failure we use this to undo BOTH the Attachment
+        # records and the in-memory ``promoted`` flips so a caller commit
+        # (e.g. ``privacy_request.delete``) cannot persist a ``promoted``
+        # row that points at no Attachment.
+        created: list[tuple[AttachmentUserProvided, Any]] = []
+        try:
+            for row in rows:
+                file_content = provider.download(bucket, row.object_key)
+                file_name = os.path.basename(row.object_key)
+                attachment = attachment_service.create_and_upload(
+                    data={
+                        "file_name": file_name,
+                        "user_id": None,
+                        "username": "data_subject",
+                        "attachment_type": AttachmentType.user_provided,
+                        "storage_key": storage_config.key,
+                    },
+                    file_data=file_content,
+                    references=[
+                        {
+                            "reference_id": privacy_request.id,
+                            "reference_type": AttachmentReferenceType.privacy_request,
+                        }
+                    ],
+                )
+                # Flip only after a successful create_and_upload so the
+                # row's status invariant tracks Attachment existence.
+                self._repo.mark_promoted(row, session=session)
+                created.append((row, attachment))
+                logger.info(
+                    "Promoted attachment {} on request {} → Attachment {}",
+                    row.id,
+                    privacy_request.id,
+                    attachment.id,
+                )
+        except Exception:
+            for row, attachment in created:
+                try:
+                    attachment_service.delete(attachment)
+                except Exception:
+                    logger.warning(
+                        "Failed to clean up partially-created Attachment {} after "
+                        "promotion failure",
+                        attachment.id,
+                        exc_info=True,
+                    )
+                row.status = AttachmentUserProvidedStatus.uploaded
+                row.promoted_at = None
+            raise
+
+        # Phase 3: best-effort delete of temp objects.
+        for row in rows:
+            try:
+                provider.delete(bucket, row.object_key)
+            except Exception:
+                logger.warning(
+                    "Could not delete temporary file {} after promotion",
+                    row.object_key,
+                    exc_info=True,
+                )

--- a/tests/ops/service/privacy_request/test_duplication_detection.py
+++ b/tests/ops/service/privacy_request/test_duplication_detection.py
@@ -17,6 +17,9 @@ from fides.api.task.conditional_dependencies.schemas import ConditionGroup
 from fides.config.duplicate_detection_settings import DuplicateDetectionSettings
 from fides.service.messaging.messaging_service import MessagingService
 from fides.service.privacy_request.privacy_request_service import PrivacyRequestService
+from fides.service.privacy_request_attachments.privacy_request_attachments_service import (
+    AttachmentUserProvidedService,
+)
 
 PRIVACY_REQUEST_TASK_TIMEOUT = 5
 
@@ -773,7 +776,12 @@ class TestDuplicatePrivacyRequestService:
     def privacy_request_service(
         self, db: Session, mock_config_proxy, mock_messaging_service
     ) -> PrivacyRequestService:
-        return PrivacyRequestService(db, mock_config_proxy, mock_messaging_service)
+        return PrivacyRequestService(
+            db,
+            mock_config_proxy,
+            mock_messaging_service,
+            AttachmentUserProvidedService(),
+        )
 
     def test_privacy_request_service_duplicate_detection(
         self,

--- a/tests/ops/service/privacy_request_attachments/test_service.py
+++ b/tests/ops/service/privacy_request_attachments/test_service.py
@@ -1,18 +1,28 @@
-"""Tests for the upload service. Resolution + promotion ship in ENG-3517-1."""
+"""Tests for the upload, resolve, and promote attachment service paths."""
 
+import io
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from fides.api.models.attachment import (
+    Attachment,
+    AttachmentReference,
     AttachmentUserProvided,
     AttachmentUserProvidedStatus,
 )
+from fides.api.schemas.redis_cache import CustomPrivacyRequestField
 from fides.service.privacy_request_attachments.privacy_request_attachments_exceptions import (
+    AttachmentNotFoundError,
     DisallowedFileTypeError,
     FileTooLargeError,
+    InvalidAttachmentStateError,
+    InvalidAttachmentValueError,
     StorageBucketNotConfiguredError,
     StorageNotConfiguredError,
+)
+from fides.service.privacy_request_attachments.privacy_request_attachments_repository import (
+    AttachmentUserProvidedRepository,
 )
 from fides.service.privacy_request_attachments.privacy_request_attachments_service import (
     DEFAULT_MAX_SIZE_BYTES,
@@ -28,6 +38,7 @@ PDF_BYTES = b"%PDF-1.4 minimal pdf body"
 def mock_provider():
     provider = MagicMock()
     provider.upload.return_value = MagicMock(file_size=123)
+    provider.download.side_effect = lambda *_a, **_kw: io.BytesIO(PDF_BYTES)
     return provider
 
 
@@ -178,3 +189,474 @@ class TestProviderHelpers:
         assert provider is mock_provider
         assert bucket == ""
         assert returned_config is config
+
+
+class TestResolveFileAttachments:
+    @pytest.mark.parametrize(
+        "fields, names, fixture",
+        [
+            pytest.param(None, {"file"}, None, id="no_fields"),
+            pytest.param(
+                {"o": CustomPrivacyRequestField(label="o", value="x")},
+                set(),
+                None,
+                id="no_declared_names",
+            ),
+            pytest.param(
+                {"file": CustomPrivacyRequestField(label="file", value=["x"])},
+                {"file"},
+                "allow_custom_privacy_request_field_collection_disabled",
+                id="collection_disabled",
+            ),
+        ],
+    )
+    def test_returns_empty_short_circuits(self, db, request, fields, names, fixture):
+        if fixture:
+            request.getfixturevalue(fixture)
+        assert (
+            AttachmentUserProvidedService().resolve_file_attachments(
+                fields, names, session=db
+            )
+            == []
+        )
+
+    def test_happy_path_resolves_uploaded_rows(
+        self,
+        db,
+        storage_config_default,
+        allow_custom_privacy_request_field_collection_enabled,
+    ):
+        record = AttachmentUserProvidedRepository().create_uploaded(
+            object_key="privacy_request_attachments/one.pdf",
+            storage_key=storage_config_default.key,
+            session=db,
+        )
+        db.commit()
+
+        fields = {"file": CustomPrivacyRequestField(label="file", value=[record.id])}
+        rows = AttachmentUserProvidedService().resolve_file_attachments(
+            fields, {"file"}, session=db
+        )
+        assert [r.id for r in rows] == [record.id]
+
+        rows[0].delete(db)
+
+    def test_missing_id_raises(
+        self,
+        db,
+        storage_config_default,
+        allow_custom_privacy_request_field_collection_enabled,
+    ):
+        fields = {
+            "file": CustomPrivacyRequestField(label="file", value=["att_missing"])
+        }
+        with pytest.raises(AttachmentNotFoundError):
+            AttachmentUserProvidedService().resolve_file_attachments(
+                fields, {"file"}, session=db
+            )
+
+    def test_non_list_value_raises(
+        self,
+        db,
+        storage_config_default,
+        allow_custom_privacy_request_field_collection_enabled,
+    ):
+        fields = {"file": CustomPrivacyRequestField(label="file", value="not a list")}
+        with pytest.raises(InvalidAttachmentValueError):
+            AttachmentUserProvidedService().resolve_file_attachments(
+                fields, {"file"}, session=db
+            )
+
+    @pytest.mark.parametrize(
+        "fields",
+        [
+            {"other": CustomPrivacyRequestField(label="other", value="hi")},
+            {"file": CustomPrivacyRequestField(label="file", value=[])},
+        ],
+    )
+    def test_skipped_paths(
+        self,
+        db,
+        storage_config_default,
+        allow_custom_privacy_request_field_collection_enabled,
+        fields,
+    ):
+        assert (
+            AttachmentUserProvidedService().resolve_file_attachments(
+                fields, {"file"}, session=db
+            )
+            == []
+        )
+
+
+class TestPromoteRowsToAttachments:
+    def test_no_rows_is_noop(self, db, storage_config_default):
+        AttachmentUserProvidedService().promote_rows_to_attachments(
+            MagicMock(), [], session=db
+        )
+
+    @pytest.mark.parametrize("delete_raises", [False, True], ids=["clean", "raises"])
+    def test_promote_flips_status_and_creates_attachment(
+        self,
+        db,
+        storage_config_default,
+        privacy_request,
+        patch_provider_factory,
+        mock_provider,
+        delete_raises,
+    ):
+        # ``delete_raises=True`` exercises the Phase-3 try/except (logged-only).
+        record = AttachmentUserProvidedRepository().create_uploaded(
+            object_key="privacy_request_attachments/promote.pdf",
+            storage_key=storage_config_default.key,
+            session=db,
+        )
+        db.commit()
+        row = (
+            db.query(AttachmentUserProvided)
+            .filter(AttachmentUserProvided.id == record.id)
+            .one()
+        )
+        if delete_raises:
+            mock_provider.delete.side_effect = RuntimeError("storage offline")
+        # AttachmentService.upload would hit S3 — short-circuit it.
+        with patch(
+            "fides.service.privacy_request_attachments.privacy_request_attachments_service.AttachmentService.upload",
+            return_value=None,
+        ):
+            AttachmentUserProvidedService().promote_rows_to_attachments(
+                privacy_request, [row], session=db
+            )
+        db.refresh(row)
+        assert row.status == AttachmentUserProvidedStatus.promoted
+        assert row.promoted_at is not None
+        attachment_ref = (
+            db.query(AttachmentReference)
+            .filter(AttachmentReference.reference_id == privacy_request.id)
+            .first()
+        )
+        assert attachment_ref is not None
+        attachment = (
+            db.query(Attachment)
+            .filter(Attachment.id == attachment_ref.attachment_id)
+            .one()
+        )
+        assert attachment.file_name == "promote.pdf"
+        mock_provider.delete.assert_called_with(
+            "test_bucket", "privacy_request_attachments/promote.pdf"
+        )
+        db.delete(attachment_ref)
+        db.delete(attachment)
+        row.delete(db)
+
+    def test_promote_rejects_non_uploaded_row(
+        self,
+        db,
+        storage_config_default,
+        privacy_request,
+        patch_provider_factory,
+    ):
+        record = AttachmentUserProvidedRepository().create_uploaded(
+            object_key="privacy_request_attachments/bad.pdf",
+            storage_key=storage_config_default.key,
+            session=db,
+        )
+        row = (
+            db.query(AttachmentUserProvided)
+            .filter(AttachmentUserProvided.id == record.id)
+            .one()
+        )
+        row.status = AttachmentUserProvidedStatus.deleted
+        db.commit()
+
+        with pytest.raises(InvalidAttachmentStateError):
+            AttachmentUserProvidedService().promote_rows_to_attachments(
+                privacy_request, [row], session=db
+            )
+
+        row.delete(db)
+
+    def test_promote_multiple_rows_all_succeed(
+        self,
+        db,
+        storage_config_default,
+        privacy_request,
+        patch_provider_factory,
+        mock_provider,
+    ):
+        # Promote loop must iterate over every row, mark each ``promoted``,
+        # create one Attachment per row, and best-effort delete each temp
+        # object after the success path.
+        repo = AttachmentUserProvidedRepository()
+        records = [
+            repo.create_uploaded(
+                object_key=f"privacy_request_attachments/multi_{i}.pdf",
+                storage_key=storage_config_default.key,
+                session=db,
+            )
+            for i in range(2)
+        ]
+        db.commit()
+        rows = [
+            db.query(AttachmentUserProvided)
+            .filter(AttachmentUserProvided.id == r.id)
+            .one()
+            for r in records
+        ]
+
+        with patch(
+            "fides.service.privacy_request_attachments.privacy_request_attachments_service.AttachmentService.upload",
+            return_value=None,
+        ):
+            AttachmentUserProvidedService().promote_rows_to_attachments(
+                privacy_request, rows, session=db
+            )
+
+        for row in rows:
+            db.refresh(row)
+            assert row.status == AttachmentUserProvidedStatus.promoted
+            assert row.promoted_at is not None
+
+        attachment_refs = (
+            db.query(AttachmentReference)
+            .filter(AttachmentReference.reference_id == privacy_request.id)
+            .all()
+        )
+        assert len(attachment_refs) == 2
+
+        delete_keys = [c.args[1] for c in mock_provider.delete.call_args_list]
+        assert sorted(delete_keys) == [
+            "privacy_request_attachments/multi_0.pdf",
+            "privacy_request_attachments/multi_1.pdf",
+        ]
+
+        for ref in attachment_refs:
+            attachment = (
+                db.query(Attachment).filter(Attachment.id == ref.attachment_id).one()
+            )
+            db.delete(ref)
+            db.delete(attachment)
+        for row in rows:
+            row.delete(db)
+
+    @pytest.mark.parametrize("cleanup_raises", [False, True], ids=["clean", "raises"])
+    def test_promote_rolls_back_partial_attachments_on_failure(
+        self,
+        db,
+        storage_config_default,
+        privacy_request,
+        patch_provider_factory,
+        cleanup_raises,
+    ):
+        # Second create_and_upload raises → cleanup loop deletes the first.
+        # ``cleanup_raises`` exercises the inner try/except in that loop.
+        repo = AttachmentUserProvidedRepository()
+        rec1 = repo.create_uploaded(
+            object_key="privacy_request_attachments/p1.pdf",
+            storage_key=storage_config_default.key,
+            session=db,
+        )
+        rec2 = repo.create_uploaded(
+            object_key="privacy_request_attachments/p2.pdf",
+            storage_key=storage_config_default.key,
+            session=db,
+        )
+        db.commit()
+        row1 = (
+            db.query(AttachmentUserProvided)
+            .filter(AttachmentUserProvided.id == rec1.id)
+            .one()
+        )
+        row2 = (
+            db.query(AttachmentUserProvided)
+            .filter(AttachmentUserProvided.id == rec2.id)
+            .one()
+        )
+
+        first = MagicMock(id="att_partial")
+        with patch(
+            "fides.service.privacy_request_attachments.privacy_request_attachments_service.AttachmentService"
+        ) as svc_cls:
+            instance = svc_cls.return_value
+            instance.create_and_upload.side_effect = [first, RuntimeError("boom")]
+            if cleanup_raises:
+                instance.delete.side_effect = RuntimeError("cleanup boom")
+            with pytest.raises(RuntimeError, match="boom"):
+                AttachmentUserProvidedService().promote_rows_to_attachments(
+                    privacy_request, [row1, row2], session=db
+                )
+            instance.delete.assert_called_once_with(first)
+
+        # Both rows must remain ``uploaded`` after the failure: the first
+        # was flipped to ``promoted`` mid-loop and must be rolled back so a
+        # caller commit cannot persist a ``promoted`` row pointing at the
+        # Attachment we just deleted; the second never got that far.
+        assert row1.status == AttachmentUserProvidedStatus.uploaded
+        assert row1.promoted_at is None
+        assert row2.status == AttachmentUserProvidedStatus.uploaded
+        assert row2.promoted_at is None
+
+        row1.delete(db)
+        row2.delete(db)
+
+
+_PRS = "fides.service.privacy_request.privacy_request_service"
+
+
+@pytest.fixture
+def file_svc_req():
+    from fides.api.schemas.privacy_center_config import (
+        FileUploadCustomPrivacyRequestField,
+    )
+    from fides.api.schemas.privacy_request import PrivacyRequestCreate
+    from fides.api.schemas.redis_cache import Identity
+    from fides.service.privacy_request.privacy_request_service import (
+        PrivacyRequestService,
+    )
+
+    action = MagicMock(
+        custom_privacy_request_fields={
+            "doc": FileUploadCustomPrivacyRequestField(label="Doc")
+        }
+    )
+    svc = PrivacyRequestService(
+        MagicMock(), MagicMock(), MagicMock(), AttachmentUserProvidedService()
+    )
+    svc._resolve_privacy_center_config_dict = MagicMock(return_value={"x": 1})
+    svc._parse_privacy_center_config = MagicMock(return_value=MagicMock())
+    svc._get_matching_action = MagicMock(return_value=action)
+    svc._validate_field_visibility = MagicMock()
+    return svc, PrivacyRequestCreate(
+        identity=Identity(email="x@y.z"),
+        policy_key="default_access_policy",
+        custom_privacy_request_fields={"doc": {"label": "Doc", "value": ["att_123"]}},
+    )
+
+
+class TestCreatePrivacyRequestFileResolution:
+    def test_resolve_value_error_raises(self, file_svc_req):
+        from fides.api.common_exceptions import PrivacyRequestError
+
+        svc, req = file_svc_req
+        with patch.object(
+            AttachmentUserProvidedService,
+            "resolve_file_attachments",
+            side_effect=InvalidAttachmentValueError("doc"),
+        ):
+            with pytest.raises(PrivacyRequestError, match="doc"):
+                svc.create_privacy_request(req, authenticated=True)
+
+    def test_file_fields_stripped(self, file_svc_req):
+        from fides.api.common_exceptions import PrivacyRequestError
+
+        svc, req = file_svc_req
+        captured: dict = {}
+
+        def _capture(_self, _fields, names, *, session):
+            captured["names"] = names
+            return []
+
+        with (
+            patch.object(
+                AttachmentUserProvidedService,
+                "resolve_file_attachments",
+                _capture,
+            ),
+            patch(f"{_PRS}.Policy.get_by", return_value=None),
+            pytest.raises(PrivacyRequestError, match="does not exist"),
+        ):
+            svc.create_privacy_request(req, authenticated=True)
+        assert captured["names"] == {"doc"}
+
+    def test_resolve_not_found_wraps_as_privacy_request_error(self, file_svc_req):
+        # Any ``AttachmentsServiceError`` from resolve must surface with the
+        # field name in the message rather than the generic record-add wrap.
+        from fides.api.common_exceptions import PrivacyRequestError
+
+        svc, req = file_svc_req
+        with patch.object(
+            AttachmentUserProvidedService,
+            "resolve_file_attachments",
+            side_effect=AttachmentNotFoundError("doc"),
+        ):
+            with pytest.raises(PrivacyRequestError, match="doc"):
+                svc.create_privacy_request(req, authenticated=True)
+
+    def test_strips_file_field_keeps_non_file_field(self, file_svc_req):
+        # Strip must drop the FileUpload field but preserve sibling
+        # non-file fields so downstream persistence still sees them.
+        from fides.api.common_exceptions import PrivacyRequestError
+
+        svc, req = file_svc_req
+        req = req.model_copy(
+            update={
+                "custom_privacy_request_fields": {
+                    "doc": {"label": "Doc", "value": ["att_123"]},
+                    "reason": {"label": "Reason", "value": "needed"},
+                }
+            }
+        )
+
+        captured: dict = {}
+
+        def _capture(_db, _pr, _consent, fields):
+            captured["fields"] = fields
+            raise PrivacyRequestError("stop here", {})
+
+        privacy_request = MagicMock(id="pr-1")
+        policy = MagicMock(id="pol-1")
+        policy.generate_masking_secrets.return_value = {}
+
+        with (
+            patch.object(
+                AttachmentUserProvidedService,
+                "resolve_file_attachments",
+                return_value=[],
+            ),
+            patch(f"{_PRS}.Policy.get_by", return_value=policy),
+            patch(f"{_PRS}.build_required_privacy_request_kwargs", return_value={}),
+            patch(f"{_PRS}.PrivacyRequest.create", return_value=privacy_request),
+            patch(f"{_PRS}._create_or_update_custom_fields", side_effect=_capture),
+            pytest.raises(PrivacyRequestError, match="stop here"),
+        ):
+            svc.create_privacy_request(req, authenticated=True)
+
+        assert "doc" not in captured["fields"]
+        assert "reason" in captured["fields"]
+
+    def test_no_file_fields_skips_resolve_call_with_empty_names(self):
+        # When the configured action has no FileUpload field, the service
+        # still runs through its resolve/promote scaffolding but with an
+        # empty file_field_names set, and never invokes promote.
+        from fides.api.common_exceptions import PrivacyRequestError
+        from fides.api.schemas.privacy_request import PrivacyRequestCreate
+        from fides.api.schemas.redis_cache import Identity
+        from fides.service.privacy_request.privacy_request_service import (
+            PrivacyRequestService,
+        )
+
+        action = MagicMock(custom_privacy_request_fields=None)
+        attachment_svc = MagicMock(spec=AttachmentUserProvidedService)
+        attachment_svc.resolve_file_attachments.return_value = []
+        svc = PrivacyRequestService(
+            MagicMock(), MagicMock(), MagicMock(), attachment_svc
+        )
+        svc._resolve_privacy_center_config_dict = MagicMock(return_value=None)
+        svc._parse_privacy_center_config = MagicMock(return_value=None)
+        svc._get_matching_action = MagicMock(return_value=action)
+
+        req = PrivacyRequestCreate(
+            identity=Identity(email="x@y.z"),
+            policy_key="default_access_policy",
+        )
+
+        with (
+            patch(f"{_PRS}.Policy.get_by", return_value=None),
+            pytest.raises(PrivacyRequestError, match="does not exist"),
+        ):
+            svc.create_privacy_request(req, authenticated=True)
+
+        attachment_svc.resolve_file_attachments.assert_called_once()
+        names_arg = attachment_svc.resolve_file_attachments.call_args.args[1]
+        assert names_arg == set()
+        attachment_svc.promote_rows_to_attachments.assert_not_called()

--- a/tests/service/privacy_request/test_pre_approval_service.py
+++ b/tests/service/privacy_request/test_pre_approval_service.py
@@ -24,6 +24,9 @@ from fides.service.privacy_request.privacy_request_service import (
     _trigger_pre_approval_webhooks,
     handle_approval,
 )
+from fides.service.privacy_request_attachments.privacy_request_attachments_service import (
+    AttachmentUserProvidedService,
+)
 
 
 class TestHandleApprovalSetsAwaitingPreApproval:
@@ -146,7 +149,12 @@ class TestApproveAndDenyFromPreApprovalStatuses:
     def privacy_request_service(
         self, db: Session, mock_messaging_service: MessagingService
     ) -> PrivacyRequestService:
-        return PrivacyRequestService(db, ConfigProxy(db), mock_messaging_service)
+        return PrivacyRequestService(
+            db,
+            ConfigProxy(db),
+            mock_messaging_service,
+            AttachmentUserProvidedService(),
+        )
 
     @patch(
         "fides.api.service.privacy_request.request_runner_service.run_privacy_request.apply_async"

--- a/tests/service/privacy_request/test_privacy_request_service.py
+++ b/tests/service/privacy_request/test_privacy_request_service.py
@@ -21,6 +21,7 @@ from fides.api.oauth.roles import APPROVER
 from fides.api.schemas.policy import ActionType
 from fides.api.schemas.privacy_center_config import (
     CustomPrivacyRequestField,
+    FileUploadCustomPrivacyRequestField,
     LocationCustomPrivacyRequestField,
 )
 from fides.api.schemas.privacy_request import (
@@ -32,6 +33,9 @@ from fides.api.schemas.redis_cache import Identity
 from fides.config.config_proxy import ConfigProxy
 from fides.service.messaging.messaging_service import MessagingService
 from fides.service.privacy_request.privacy_request_service import PrivacyRequestService
+from fides.service.privacy_request_attachments.privacy_request_attachments_service import (
+    AttachmentUserProvidedService,
+)
 from tests.conftest import wait_for_tasks_to_complete
 
 
@@ -51,7 +55,12 @@ class TestPrivacyRequestService:
     def privacy_request_service(
         self, db: Session, mock_messaging_service
     ) -> PrivacyRequestService:
-        return PrivacyRequestService(db, ConfigProxy(db), mock_messaging_service)
+        return PrivacyRequestService(
+            db,
+            ConfigProxy(db),
+            mock_messaging_service,
+            AttachmentUserProvidedService(),
+        )
 
     @pytest.fixture
     def reviewing_user(self, db):
@@ -1489,23 +1498,8 @@ def _make_action(custom_fields):
     return a
 
 
-@contextmanager
-def _stub_lookups(svc, *, config_dict={"x": 1}, parsed=True, action=True):
-    """Patch the three DB-backed lookups; ``True`` → non-None default."""
-    parsed_v = MagicMock() if parsed is True else parsed
-    action_v = MagicMock() if action is True else action
-    with (
-        patch.object(
-            svc, "_resolve_privacy_center_config_dict", return_value=config_dict
-        ),
-        patch.object(svc, "_parse_privacy_center_config", return_value=parsed_v),
-        patch.object(svc, "_get_matching_action", return_value=action_v),
-    ):
-        yield
-
-
 def _svc():
-    return PrivacyRequestService(MagicMock(), MagicMock(), MagicMock())
+    return PrivacyRequestService(MagicMock(), MagicMock(), MagicMock(), MagicMock())
 
 
 def _req(custom_fields=None, **kw):
@@ -1519,31 +1513,25 @@ def _req(custom_fields=None, **kw):
 
 @pytest.mark.unit
 class TestValidateFieldVisibility:
-    """Branch-by-branch coverage of ``_validate_field_visibility`` via mocks."""
+    """Branch-by-branch coverage of ``_validate_field_visibility``. Caller
+    is now responsible for resolving ``action``; the validator just
+    short-circuits on ``None``/empty fields."""
 
     @pytest.mark.parametrize(
-        "stub_kwargs",
+        "action",
         [
-            pytest.param({"config_dict": None}, id="no_config"),
-            pytest.param({"parsed": None}, id="unparseable_config"),
-            pytest.param({"action": None}, id="no_matching_action"),
+            pytest.param(None, id="action_none"),
+            pytest.param(_make_action(None), id="action_without_custom_fields"),
             pytest.param(
-                {"action": _make_action(None)}, id="action_without_custom_fields"
-            ),
-            pytest.param(
-                {
-                    "action": _make_action(
-                        {"country": LocationCustomPrivacyRequestField(label="Country")}
-                    )
-                },
+                _make_action(
+                    {"country": LocationCustomPrivacyRequestField(label="Country")}
+                ),
                 id="only_location_fields_after_filter",
             ),
         ],
     )
-    def test_short_circuit_paths(self, stub_kwargs):
-        svc = _svc()
-        with _stub_lookups(svc, **stub_kwargs):
-            svc._validate_field_visibility(_req())
+    def test_short_circuit_paths(self, action):
+        _svc()._validate_field_visibility(_req(), action)
 
     @pytest.mark.parametrize(
         "submitted, raises",
@@ -1565,15 +1553,14 @@ class TestValidateFieldVisibility:
                 )
             }
         )
-        with _stub_lookups(svc, action=action):
-            req = _req(custom_fields=submitted)
-            if raises:
-                with pytest.raises(
-                    PrivacyRequestError, match="Required field 'reason' is missing"
-                ):
-                    svc._validate_field_visibility(req)
-            else:
-                svc._validate_field_visibility(req)
+        req = _req(custom_fields=submitted)
+        if raises:
+            with pytest.raises(
+                PrivacyRequestError, match="Required field 'reason' is missing"
+            ):
+                svc._validate_field_visibility(req, action)
+        else:
+            svc._validate_field_visibility(req, action)
 
     def test_create_privacy_request_invokes_validate_field_visibility(self):
         # Covers the call site inside ``create_privacy_request``. Stub the
@@ -1591,41 +1578,33 @@ class TestValidateFieldVisibility:
             pytest.raises(PrivacyRequestError, match="does not exist"),
         ):
             svc.create_privacy_request(req, authenticated=True)
-        visibility.assert_called_once_with(req)
+        visibility.assert_called_once()
+        assert visibility.call_args.args[0] is req
 
 
 @pytest.mark.unit
 class TestValidateRequiredLocationFields:
     @pytest.mark.parametrize(
-        "stub_kwargs",
+        "action",
         [
-            pytest.param({"config_dict": None}, id="no_config"),
-            pytest.param({"parsed": None}, id="unparseable_config"),
-            pytest.param({"action": None}, id="no_matching_action"),
+            pytest.param(None, id="action_none"),
+            pytest.param(_make_action(None), id="action_without_custom_fields"),
             pytest.param(
-                {"action": _make_action(None)}, id="action_without_custom_fields"
-            ),
-            pytest.param(
-                {
-                    "action": _make_action(
-                        {
-                            "reason": CustomPrivacyRequestField(
-                                label="Reason", field_type="text", required=True
-                            )
-                        }
-                    )
-                },
+                _make_action(
+                    {
+                        "reason": CustomPrivacyRequestField(
+                            label="Reason", field_type="text", required=True
+                        )
+                    }
+                ),
                 id="non_location_required_field_ignored",
             ),
         ],
     )
-    def test_short_circuit_paths(self, stub_kwargs):
-        svc = _svc()
-        with _stub_lookups(svc, **stub_kwargs):
-            svc._validate_required_location_fields(_req())
+    def test_short_circuit_paths(self, action):
+        _svc()._validate_required_location_fields(_req(), action)
 
     def test_missing_required_location_raises(self):
-        svc = _svc()
         action = _make_action(
             {
                 "country": LocationCustomPrivacyRequestField(
@@ -1633,9 +1612,143 @@ class TestValidateRequiredLocationFields:
                 )
             }
         )
-        with _stub_lookups(svc, action=action):
+        with pytest.raises(
+            PrivacyRequestError,
+            match="Location is required for field 'country'",
+        ):
+            _svc()._validate_required_location_fields(_req(), action)
+
+
+@pytest.mark.unit
+class TestCreatePrivacyRequestAttachmentPromotion:
+    """Cover the attachment-promotion branch in ``create_privacy_request``."""
+
+    @contextmanager
+    def _drive_to_promotion(
+        self,
+        svc,
+        *,
+        attachment_rows,
+        promote_side_effect=None,
+        delete_side_effect=None,
+    ):
+        prs = "fides.service.privacy_request.privacy_request_service"
+
+        attachment_service = svc.attachment_user_provided_service
+        attachment_service.resolve_file_attachments.return_value = attachment_rows
+        if promote_side_effect is not None:
+            attachment_service.promote_rows_to_attachments.side_effect = (
+                promote_side_effect
+            )
+        else:
+            attachment_service.promote_rows_to_attachments.return_value = None
+
+        privacy_request = MagicMock(id="pr-1")
+        if delete_side_effect is not None:
+            privacy_request.delete.side_effect = delete_side_effect
+
+        policy = MagicMock(id="pol-1")
+        policy.generate_masking_secrets.return_value = {}
+
+        with (
+            patch.object(svc, "_resolve_privacy_center_config_dict", return_value=None),
+            patch.object(svc, "_validate_required_location_fields"),
+            patch.object(svc, "_validate_field_visibility"),
+            patch(f"{prs}.Policy.get_by", return_value=policy),
+            patch(f"{prs}.build_required_privacy_request_kwargs", return_value={}),
+            patch(f"{prs}.PrivacyRequest.create", return_value=privacy_request),
+            patch(f"{prs}._create_or_update_custom_fields"),
+            patch(f"{prs}.cache_data"),
+            patch(f"{prs}.check_and_dispatch_error_notifications"),
+            patch(f"{prs}._handle_notifications_and_processing"),
+            patch(f"{prs}.check_for_duplicates"),
+        ):
+            yield attachment_service, privacy_request
+
+    def test_promote_success(self):
+        svc = _svc()
+        rows = [MagicMock()]
+        with self._drive_to_promotion(svc, attachment_rows=rows) as (
+            attachment_service,
+            privacy_request,
+        ):
+            result = svc.create_privacy_request(_req(), authenticated=True)
+        attachment_service.promote_rows_to_attachments.assert_called_once()
+        privacy_request.delete.assert_not_called()
+        assert result is privacy_request
+
+    def test_promote_failure_deletes_request_and_raises_specific_error(self):
+        svc = _svc()
+        rows = [MagicMock()]
+        with self._drive_to_promotion(
+            svc,
+            attachment_rows=rows,
+            promote_side_effect=RuntimeError("storage offline"),
+        ) as (_, privacy_request):
             with pytest.raises(
                 PrivacyRequestError,
-                match="Location is required for field 'country'",
+                match="Attachment processing failed: storage offline",
             ):
-                svc._validate_required_location_fields(_req())
+                svc.create_privacy_request(_req(), authenticated=True)
+        privacy_request.delete.assert_called_once()
+
+    def test_promote_failure_with_delete_failure_still_raises_specific_error(self):
+        svc = _svc()
+        rows = [MagicMock()]
+        with self._drive_to_promotion(
+            svc,
+            attachment_rows=rows,
+            promote_side_effect=RuntimeError("storage offline"),
+            delete_side_effect=RuntimeError("db down"),
+        ) as (_, privacy_request):
+            with pytest.raises(
+                PrivacyRequestError, match="Attachment processing failed"
+            ):
+                svc.create_privacy_request(_req(), authenticated=True)
+        privacy_request.delete.assert_called_once()
+
+    def test_required_file_field_passes_visibility_before_strip(self):
+        # Regression: required FileUpload fields were stripped before the
+        # display_condition visibility check, causing the check to falsely
+        # raise "Required field 'X' is missing" for any required file field.
+        svc = _svc()
+        prs = "fides.service.privacy_request.privacy_request_service"
+
+        action = _make_action(
+            {"doc": FileUploadCustomPrivacyRequestField(label="Doc", required=True)}
+        )
+
+        attachment_service = svc.attachment_user_provided_service
+        attachment_service.resolve_file_attachments.return_value = []
+        attachment_service.promote_rows_to_attachments.return_value = None
+
+        privacy_request = MagicMock(id="pr-1")
+        policy = MagicMock(id="pol-1")
+        policy.generate_masking_secrets.return_value = {}
+
+        with (
+            patch.object(
+                svc, "_resolve_privacy_center_config_dict", return_value={"x": 1}
+            ),
+            patch.object(svc, "_parse_privacy_center_config", return_value=MagicMock()),
+            patch.object(svc, "_get_matching_action", return_value=action),
+            patch.object(svc, "_validate_required_location_fields"),
+            patch(f"{prs}.Property.get_by", return_value=MagicMock(id="prop-1")),
+            patch(f"{prs}.Policy.get_by", return_value=policy),
+            patch(f"{prs}.build_required_privacy_request_kwargs", return_value={}),
+            patch(f"{prs}.PrivacyRequest.create", return_value=privacy_request),
+            patch(f"{prs}._create_or_update_custom_fields"),
+            patch(f"{prs}.cache_data"),
+            patch(f"{prs}.check_and_dispatch_error_notifications"),
+            patch(f"{prs}._handle_notifications_and_processing"),
+            patch(f"{prs}.check_for_duplicates"),
+        ):
+            result = svc.create_privacy_request(
+                _req(
+                    custom_fields={"doc": {"label": "Doc", "value": ["att-id-1"]}},
+                    property_id="prop-1",
+                ),
+                authenticated=True,
+            )
+
+        assert result is privacy_request


### PR DESCRIPTION
Ticket [ENG-3517]

### Description Of Changes

Resolves uploaded attachment IDs from `file_upload` custom-privacy-request fields at submission time, then promotes the temporary `AttachmentUserProvided` rows into real `Attachment` records linked to the new `PrivacyRequest`. Treats files as required: if promotion fails, the just-created `PrivacyRequest` is deleted so a request never persists without its attachments.

Concurrency: pending rows are locked `FOR UPDATE` and gated on `status == uploaded`, then flipped to `promoted` in the same transaction. Best-effort delete of the temp object follows promotion. Partially-created `Attachment` records are cleaned up on failure.

Builds on ENG-3517-B (upload endpoint + storage). Base of this PR is `ENG-3517-B`.

### Code Changes

* `privacy_request_service.py`: parses the privacy-center config to find `FileUploadCustomPrivacyRequestField` names, calls `resolve_file_attachments` before request creation, strips file fields from `custom_privacy_request_fields`, and calls `promote_rows_to_attachments` after creation. Deletes the request and re-raises a specific `PrivacyRequestError` if promotion fails (avoids the generic "This record could not be added" wrap).
* `privacy_request_attachments_service.py`:
  * `resolve_file_attachments` — validates the field value shape, locks `uploaded` rows by id, raises `AttachmentNotFoundError` / `InvalidAttachmentValueError`. Returns `[]` when `allow_custom_privacy_request_field_collection` is off.
  * `promote_rows_to_attachments` — flips status to `promoted`, downloads each temp object, creates `Attachment` records via `AttachmentService`, links them to the privacy request, then best-effort deletes the temp objects. Rolls back created `Attachment`s on failure.
* `privacy_request_attachments_repository.py`: adds `lock_uploaded_by_ids` (`SELECT … FOR UPDATE`) and `mark_promoted` (status check + `promoted_at` stamp; raises `InvalidAttachmentStateError` on a non-`uploaded` row).
* `privacy_request_attachments_exceptions.py`: adds `InvalidAttachmentStateError`, `AttachmentNotFoundError`, `InvalidAttachmentValueError`.
* `tests/ops/service/privacy_request_attachments/test_service.py`: covers resolve + promote happy-path, missing/expired ids, wrong value shape, feature flag off, partial-creation rollback, and temp-object best-effort delete.
* `changelog/8047-attachment-promotion.yaml`: Added.

### Steps to Confirm

1. With `allow_custom_privacy_request_field_collection` enabled and a privacy-center config containing a `file_upload` custom field, upload a file via the upload endpoint (from ENG-3517-B) and capture the returned attachment id.
2. Submit a privacy request whose `custom_privacy_request_fields` includes that field with `value: [<attachment_id>]`.
3. Confirm an `Attachment` record is created and linked to the new `PrivacyRequest`, the `AttachmentUserProvided` row is `promoted` with `promoted_at` set, and the temp object is gone from the configured bucket.
4. Submit another request reusing the same id — expect a `PrivacyRequestError` with the "expired or is invalid. Please re-upload" message; verify no new `PrivacyRequest` row exists.
5. Submit a request with the file field value as a non-list (e.g. a string) — expect `InvalidAttachmentValueError` surfaced as a `PrivacyRequestError`.
6. Force a promotion failure (e.g. break storage credentials) and submit — confirm the just-created `PrivacyRequest` is deleted and the error message names the attachment failure rather than the generic "This record could not be added".
7. With `allow_custom_privacy_request_field_collection` disabled, submit a request including a file field — confirm attachments are silently skipped (no promotion, no error).

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-3517]: https://ethyca.atlassian.net/browse/ENG-3517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ