### PR TITLE
ENG-3466 Relax username validation to allow email addresses 

### DIFF
--- a/changelog/8049-fix-username-validation.yaml
+++ b/changelog/8049-fix-username-validation.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Fixed username validation so email addresses can be used as usernames
+pr: 8049
+labels: []

--- a/clients/admin-ui/src/features/common/form/validation.ts
+++ b/clients/admin-ui/src/features/common/form/validation.ts
@@ -2,9 +2,9 @@ export const usernameRules = [
   { required: true, message: "Username is required" },
   { max: 100, message: "Username must be 100 characters or fewer." },
   {
-    pattern: /^[a-zA-Z0-9._-]+$/,
+    pattern: /^[a-zA-Z0-9._\-+@]+$/,
     message:
-      "Usernames may only contain letters, numbers, periods, underscores, and hyphens.",
+      "Usernames may only contain letters, numbers, and the following characters: . @ + _ -",
   },
 ];
 

--- a/clients/admin-ui/src/features/common/form/validation.ts
+++ b/clients/admin-ui/src/features/common/form/validation.ts
@@ -1,6 +1,7 @@
 export const usernameRules = [
   { required: true, message: "Username is required" },
-  { max: 100, message: "Username must be 100 characters or fewer." },
+  { max: 100, message: "Username must have 100 characters or fewer." },
+  { min: 3, message: "Username must have at least 3 characters." },
   {
     pattern: /^[a-zA-Z0-9._\-+@]+$/,
     message:

--- a/src/fides/api/schemas/user.py
+++ b/src/fides/api/schemas/user.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from fides.api.models.fides_user import FidesUser
     from fides.api.models.fides_user_invite import FidesUserInvite
 
-USERNAME_PATTERN = r"[a-zA-Z0-9._\-+@]{1,100}"
+USERNAME_PATTERN = r"[a-zA-Z0-9._\-+@]{3,100}"
 
 
 class PrivacyRequestUser(FidesSchema):

--- a/src/fides/api/schemas/user.py
+++ b/src/fides/api/schemas/user.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from fides.api.models.fides_user import FidesUser
     from fides.api.models.fides_user_invite import FidesUserInvite
 
-USERNAME_PATTERN = r"[a-zA-Z0-9._-]{1,100}"
+USERNAME_PATTERN = r"[a-zA-Z0-9._\-+@]{1,100}"
 
 
 class PrivacyRequestUser(FidesSchema):
@@ -44,7 +44,7 @@ class UserCreate(FidesSchema):
         if not re.fullmatch(USERNAME_PATTERN, username):
             raise ValueError(
                 "Usernames must be 1-100 characters and may only contain "
-                "letters, numbers, periods, underscores, and hyphens."
+                "letters, numbers, and the following characters: . @ + _ - "
             )
         return username
 

--- a/tests/lib/test_oauth_schemas_user.py
+++ b/tests/lib/test_oauth_schemas_user.py
@@ -32,14 +32,7 @@ def test_bad_password(password, message):
 
 @pytest.mark.parametrize(
     "username",
-    [
-        "some user",
-        "user&name",
-        "user=name",
-        "user<name",
-        "",
-        "a" * 101,
-    ],
+    ["some user", "user&name", "user=name", "user<name", "", "a" * 101, "a", "aa"],
 )
 def test_user_create_invalid_username(username):
     with pytest.raises(ValueError, match="Usernames must be"):
@@ -60,7 +53,7 @@ def test_user_create_invalid_username(username):
         "test_user",
         "Test_User-123",
         "john.doe",
-        "a",
+        "abc",
         "a" * 100,
         "john.doe@example.com",
         "john+doe@example.com",

--- a/tests/lib/test_oauth_schemas_user.py
+++ b/tests/lib/test_oauth_schemas_user.py
@@ -37,7 +37,6 @@ def test_bad_password(password, message):
         "user&name",
         "user=name",
         "user<name",
-        "user@name",
         "",
         "a" * 101,
     ],
@@ -63,6 +62,9 @@ def test_user_create_invalid_username(username):
         "john.doe",
         "a",
         "a" * 100,
+        "john.doe@example.com",
+        "john+doe@example.com",
+        "johnny@example.uy",
     ],
 )
 def test_user_create_valid_username(username):


### PR DESCRIPTION
Ticket [ENG-3466] <!-- simply paste the ticket number between the brackets and it will auto-convert to a link -->

### Description Of Changes

Follow up to ENG-3466 and ENG-3455 (PRs https://github.com/ethyca/fides/pull/7957 and https://github.com/ethyca/fides/pull/7953): we added username validation but it is preventing users being created with their email as their username. This is standard in a lot of Fides deployments so this PR relaxes the validation to allow `+` and `@` characters as well. 

### Steps to Confirm

1. Pull down this branch 
2. Configure Fides to use mailgun for emails if you haven't already
3. Set the following in your `fides.toml`
```
[notifications]
notification_service_type = "mailgun"

[admin_ui]
url = "http://localhost:3000"
```
4. Invite a new user with your email set as the username (or `youremail+test@ethyca.com`)
5. Make sure you receive the invite and when you click it , the username is populated correctly 
6. Set up your password and login 

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-3466]: https://ethyca.atlassian.net/browse/ENG-3466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ