### PR TITLE
Add dedicated Celery queue for bulk consent imports

### DIFF
--- a/src/fides/api/tasks/__init__.py
+++ b/src/fides/api/tasks/__init__.py
@@ -30,6 +30,7 @@ CONSENT_WEBHOOK_QUEUE_NAME = "fidesplus.consent_webhooks"  # This queue is used 
 DISCOVERY_MONITORS_DETECTION_QUEUE_NAME = "fidesplus.discovery_monitors_detection"  # This queue is used for running discovery monitors detection tasks
 DISCOVERY_MONITORS_CLASSIFICATION_QUEUE_NAME = "fidesplus.discovery_monitors_classification"  # This queue is used for running discovery monitors classification tasks
 DISCOVERY_MONITORS_PROMOTION_QUEUE_NAME = "fidesplus.discovery_monitors_promotion"  # This queue is used for running discovery monitors promotion tasks
+BULK_CONSENT_IMPORT_QUEUE_NAME = "fidesplus.bulk_consent_import"  # This queue is used for bulk importing pre-verified consent records
 
 
 NEW_SESSION_RETRIES = 5

--- a/src/fides/api/util/cache.py
+++ b/src/fides/api/util/cache.py
@@ -16,6 +16,7 @@ except ImportError:
 from fides.api import common_exceptions
 from fides.api.schemas.masking.masking_secrets import SecretType
 from fides.api.tasks import (
+    BULK_CONSENT_IMPORT_QUEUE_NAME,
     CONSENT_WEBHOOK_QUEUE_NAME,
     DISCOVERY_MONITORS_CLASSIFICATION_QUEUE_NAME,
     DISCOVERY_MONITORS_DETECTION_QUEUE_NAME,
@@ -565,6 +566,7 @@ def get_queue_counts() -> Dict[str, int]:
             DISCOVERY_MONITORS_DETECTION_QUEUE_NAME,
             DISCOVERY_MONITORS_CLASSIFICATION_QUEUE_NAME,
             DISCOVERY_MONITORS_PROMOTION_QUEUE_NAME,
+            BULK_CONSENT_IMPORT_QUEUE_NAME,
             default_queue_name,
         ]:
             queue_counts[queue] = redis_conn.llen(queue)

--- a/src/fides/api/worker/__init__.py
+++ b/src/fides/api/worker/__init__.py
@@ -10,6 +10,7 @@ from watchfiles.filters import DefaultFilter
 from fides.api.db.base import Base  # type: ignore
 from fides.api.service.saas_request.override_implementations import *
 from fides.api.tasks import (
+    BULK_CONSENT_IMPORT_QUEUE_NAME,
     CONSENT_WEBHOOK_QUEUE_NAME,
     DISCOVERY_MONITORS_CLASSIFICATION_QUEUE_NAME,
     DISCOVERY_MONITORS_DETECTION_QUEUE_NAME,
@@ -80,6 +81,7 @@ def start_worker(
         DISCOVERY_MONITORS_DETECTION_QUEUE_NAME,
         DISCOVERY_MONITORS_CLASSIFICATION_QUEUE_NAME,
         DISCOVERY_MONITORS_PROMOTION_QUEUE_NAME,
+        BULK_CONSENT_IMPORT_QUEUE_NAME,
     ]
 
     # Fall back to all queues if neither queues nor exclude_queues are provided.

--- a/tests/ctl/api/test_worker.py
+++ b/tests/ctl/api/test_worker.py
@@ -30,19 +30,19 @@ class TestStartWorker:
             (
                 None,
                 None,
-                "fides,fidesops.messaging,fides.privacy_preferences,fides.privacy_request_exports,fides.privacy_request_ingestion,fides.dsr,fidesplus.consent_webhooks,fidesplus.discovery_monitors_detection,fidesplus.discovery_monitors_classification,fidesplus.discovery_monitors_promotion",
+                "fides,fidesops.messaging,fides.privacy_preferences,fides.privacy_request_exports,fides.privacy_request_ingestion,fides.dsr,fidesplus.consent_webhooks,fidesplus.discovery_monitors_detection,fidesplus.discovery_monitors_classification,fidesplus.discovery_monitors_promotion,fidesplus.bulk_consent_import",
             ),
             ("fides.dsr", None, "fides.dsr"),
             (
                 None,
                 "fides.dsr,fides.privacy_preferences,fides.privacy_request_exports,fides.privacy_request_ingestion,fidesplus.discovery_monitors_detection",
-                "fides,fidesops.messaging,fidesplus.consent_webhooks,fidesplus.discovery_monitors_classification,fidesplus.discovery_monitors_promotion",
+                "fides,fidesops.messaging,fidesplus.consent_webhooks,fidesplus.discovery_monitors_classification,fidesplus.discovery_monitors_promotion,fidesplus.bulk_consent_import",
             ),
             ("fides,fides.dsr", None, "fides,fides.dsr"),
             (
                 None,
                 "fides,fides.dsr",
-                "fidesops.messaging,fides.privacy_preferences,fides.privacy_request_exports,fides.privacy_request_ingestion,fidesplus.consent_webhooks,fidesplus.discovery_monitors_detection,fidesplus.discovery_monitors_classification,fidesplus.discovery_monitors_promotion",
+                "fidesops.messaging,fides.privacy_preferences,fides.privacy_request_exports,fides.privacy_request_ingestion,fidesplus.consent_webhooks,fidesplus.discovery_monitors_detection,fidesplus.discovery_monitors_classification,fidesplus.discovery_monitors_promotion,fidesplus.bulk_consent_import",
             ),
         ],
     )

--- a/tests/ctl/core/test_api.py
+++ b/tests/ctl/core/test_api.py
@@ -3660,6 +3660,7 @@ class TestHealthchecks:
                 "fidesplus.discovery_monitors_classification": 0,
                 "fidesplus.discovery_monitors_detection": 0,
                 "fidesplus.discovery_monitors_promotion": 0,
+                "fidesplus.bulk_consent_import": 0,
                 "fides": 0,
             },
         }


### PR DESCRIPTION
## Summary
- Adds a dedicated Celery queue (`bulk_consent_import`) for bulk consent import tasks to isolate them from other Celery workloads
- Cherry-picked from `alpha-ENG-2594-fix` branch

## Test plan
- [ ] Verify Celery worker discovers the new queue
- [ ] Verify bulk consent import tasks route to the dedicated queue