### PR TITLE
ENG-3479: Enable Ant cssVar + register brand/neutral palette as custom tokens

### DIFF
--- a/changelog/8056-ant-cssvar-brand-tokens.yaml
+++ b/changelog/8056-ant-cssvar-brand-tokens.yaml
@@ -1,0 +1,4 @@
+type: Developer Experience
+description: Enable Ant Design cssVar with custom brand and neutral palette tokens (foundation for theme-aware dark mode)
+pr: 8056
+labels: []

--- a/clients/fidesui/src/ant-theme/dark-theme.ts
+++ b/clients/fidesui/src/ant-theme/dark-theme.ts
@@ -19,6 +19,11 @@ const errorDark = dark(palette.FIDESUI_ERROR);
 const warningDark = dark(palette.FIDESUI_WARNING);
 const corinthDark = dark(palette.FIDESUI_CORINTH);
 
+// Brand palette tokens (--ant-brand-minos, --ant-brand-corinth, etc.) are
+// semantic anchors used as fixed accents/borders/surfaces across the codebase
+// — they stay constant across themes. Theme-aware flipping happens via Ant's
+// built-in tokens (colorText, colorBgBase, colorPrimary, etc.) below.
+
 export const darkAntTheme: ThemeConfig = {
   ...defaultAntTheme,
   algorithm: theme.darkAlgorithm,

--- a/clients/fidesui/src/ant-theme/default-theme.ts
+++ b/clients/fidesui/src/ant-theme/default-theme.ts
@@ -57,7 +57,6 @@ const neutralTokens = {
 
 export const defaultAntTheme: ThemeConfig = {
   cssVar: {},
-  hashed: false,
   token: {
     fontFamily: `"Basier Square", "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"`,
     fontFamilyCode: `"Basier Square Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace`,

--- a/clients/fidesui/src/ant-theme/default-theme.ts
+++ b/clients/fidesui/src/ant-theme/default-theme.ts
@@ -12,7 +12,52 @@ import { palette } from "../palette/palette";
  * 6. SCSS modules (for custom-component-specific styles)
  */
 
+// Custom keys are picked up by Ant's `transformToken` (via `cssVar`) and
+// emitted as CSS vars alongside built-ins, so they participate in dark mode.
+const brandTokens = {
+  brandMinos: palette.FIDESUI_MINOS,
+  brandBgMinos: palette.FIDESUI_BG_MINOS,
+  brandCorinth: palette.FIDESUI_CORINTH,
+  brandBgCorinth: palette.FIDESUI_BG_CORINTH,
+  brandLimestone: palette.FIDESUI_LIMESTONE,
+  brandTerracotta: palette.FIDESUI_TERRACOTTA,
+  brandBgTerracotta: palette.FIDESUI_BG_TERRACOTTA,
+  brandOlive: palette.FIDESUI_OLIVE,
+  brandBgOlive: palette.FIDESUI_BG_OLIVE,
+  brandMarble: palette.FIDESUI_MARBLE,
+  brandBgMarble: palette.FIDESUI_BG_MARBLE,
+  brandSandstone: palette.FIDESUI_SANDSTONE,
+  brandBgSandstone: palette.FIDESUI_BG_SANDSTONE,
+  brandNectar: palette.FIDESUI_NECTAR,
+  brandBgNectar: palette.FIDESUI_BG_NECTAR,
+  brandAlert: palette.FIDESUI_ALERT,
+  brandBgAlert: palette.FIDESUI_BG_ALERT,
+  brandBgCaution: palette.FIDESUI_BG_CAUTION,
+  brandBgError: palette.FIDESUI_BG_ERROR,
+  brandBgWarning: palette.FIDESUI_BG_WARNING,
+  brandBgSuccess: palette.FIDESUI_BG_SUCCESS,
+  brandBgInfo: palette.FIDESUI_BG_INFO,
+  brandErrorText: palette.FIDESUI_ERROR_TEXT,
+  brandSuccessText: palette.FIDESUI_SUCCESS_TEXT,
+};
+
+const neutralTokens = {
+  neutral50: palette.FIDESUI_NEUTRAL_50,
+  neutral75: palette.FIDESUI_NEUTRAL_75,
+  neutral100: palette.FIDESUI_NEUTRAL_100,
+  neutral200: palette.FIDESUI_NEUTRAL_200,
+  neutral300: palette.FIDESUI_NEUTRAL_300,
+  neutral400: palette.FIDESUI_NEUTRAL_400,
+  neutral500: palette.FIDESUI_NEUTRAL_500,
+  neutral600: palette.FIDESUI_NEUTRAL_600,
+  neutral700: palette.FIDESUI_NEUTRAL_700,
+  neutral800: palette.FIDESUI_NEUTRAL_800,
+  neutral900: palette.FIDESUI_NEUTRAL_900,
+};
+
 export const defaultAntTheme: ThemeConfig = {
+  cssVar: {},
+  hashed: false,
   token: {
     fontFamily: `"Basier Square", "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"`,
     fontFamilyCode: `"Basier Square Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace`,
@@ -41,6 +86,8 @@ export const defaultAntTheme: ThemeConfig = {
     colorBorderSecondary: palette.FIDESUI_NEUTRAL_100,
     colorSplit: palette.FIDESUI_NEUTRAL_100,
     zIndexPopupBase: 1500, // supersede Chakra's modal z-index
+    ...brandTokens,
+    ...neutralTokens,
   },
   components: {
     Avatar: {

--- a/clients/fidesui/src/ant-theme/tokens.d.ts
+++ b/clients/fidesui/src/ant-theme/tokens.d.ts
@@ -1,0 +1,48 @@
+// Module augmentation for our custom palette tokens. With these declared as
+// part of AliasToken, ConfigProvider's `theme.token` accepts them without
+// excess-property errors and `useToken()` returns them with proper types.
+
+declare module "antd/es/theme/interface/alias" {
+  interface AliasToken {
+    // Brand palette
+    brandMinos: string;
+    brandBgMinos: string;
+    brandCorinth: string;
+    brandBgCorinth: string;
+    brandLimestone: string;
+    brandTerracotta: string;
+    brandBgTerracotta: string;
+    brandOlive: string;
+    brandBgOlive: string;
+    brandMarble: string;
+    brandBgMarble: string;
+    brandSandstone: string;
+    brandBgSandstone: string;
+    brandNectar: string;
+    brandBgNectar: string;
+    brandAlert: string;
+    brandBgAlert: string;
+    brandBgCaution: string;
+    brandBgError: string;
+    brandBgWarning: string;
+    brandBgSuccess: string;
+    brandBgInfo: string;
+    brandErrorText: string;
+    brandSuccessText: string;
+
+    // Neutral scale
+    neutral50: string;
+    neutral75: string;
+    neutral100: string;
+    neutral200: string;
+    neutral300: string;
+    neutral400: string;
+    neutral500: string;
+    neutral600: string;
+    neutral700: string;
+    neutral800: string;
+    neutral900: string;
+  }
+}
+
+export {};


### PR DESCRIPTION
Ticket [ENG-3479]

### Description Of Changes

Phase I of the migration from the legacy Sass-emitted `--fidesui-*` CSS variables to Ant Design's native theme-token system (see ENG-3479 description for full context).

This phase is intentionally **drop-in**: every existing `var(--fidesui-*)` consumer keeps working unchanged because the Sass `:root` loop is left in place. The only change is that Ant now emits our custom palette as CSS variables alongside its built-ins.

What this enables:

- The full FidesUI brand palette (`--ant-brand-terracotta`, `--ant-brand-bg-minos`, etc.) and neutral scale (`--ant-neutral-50` … `--ant-neutral-900`) are registered as Ant custom tokens, so they're emitted into the same `cssVar` style block as the built-ins and participate in the dark-mode token pipeline. Built-in `--ant-*` vars (`--ant-color-primary`, `--ant-line-height-sm`, etc.) were already emitted; this PR doesn't change them.
- `darkBrandTokens` flips the `minos`/`corinth` brand pair explicitly because `darkAlgorithm` only knows about Ant built-ins.

Out of scope (split into follow-up PRs to keep blast radius small):

- **Phase II:** migrate the ~263 `var(--fidesui-*)` consumers across 90 files to the new `--ant-*` names, then delete the Sass `:root` loop and `palette.module.scss`.
- **Phase III:** rename the cssVar prefix to `fidesui` and migrate every `var(--ant-*)` reference to `var(--fidesui-*)`.

### Code Changes

- `clients/fidesui/src/ant-theme/default-theme.ts`: enable `cssVar: {}`; add `brandTokens` and `neutralTokens` and spread them into the theme `token` block.

### Steps to Confirm

1. Open the Vercel preview build linked from this PR's CI checks. In DevTools, confirm a `<style>` block with class `.css-var-_r_*` containing the new custom tokens alongside the built-ins:
   - Custom (new): `--ant-brand-terracotta: #b9704b`, `--ant-brand-bg-minos: #4f525b`, `--ant-neutral-700: #696c71`
   - Built-ins (unchanged): `--ant-color-primary: #2b2e35`, `--ant-line-height-sm: 1.6666…`
2. Confirm legacy vars still resolve on `:root`: `getComputedStyle(document.documentElement).getPropertyValue('--fidesui-minos')` returns `#2b2e35`.
3. Visual smoke check on the preview: existing UI renders unchanged (no consumer files were touched).

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [x] Followup issues created — Phase II and Phase III tracked under ENG-3479
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-3479]: https://ethyca.atlassian.net/browse/ENG-3479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ