### PR TITLE
ENG-3662: Pin first two columns of the datamap report table

### DIFF
--- a/changelog/8069-pin-datamap-report-left-columns.yaml
+++ b/changelog/8069-pin-datamap-report-left-columns.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Pinned the first two columns of the datamap report table to the left
+pr: 8069
+labels: []

--- a/clients/admin-ui/cypress/e2e/datamap-report.cy.ts
+++ b/clients/admin-ui/cypress/e2e/datamap-report.cy.ts
@@ -309,11 +309,16 @@ describe("Data map report table", () => {
       it("should cancel renaming columns", () => {
         cy.getByTestId("more-menu").click();
         cy.selectAntDropdownOption("Rename columns");
+        // data_uses is a pinned (fixed: "left") column, so its rename input
+        // sits in a sticky cell that the page-level sticky toolbar covers from
+        // Cypress's visibility check perspective. force: true bypasses that.
         cy.getByTestId("column-data_uses-input")
           .eq(0)
-          .clear()
+          .clear({ force: true })
           .then(() => {
-            cy.getByTestId("column-data_uses-input").eq(0).type("Custom Title");
+            cy.getByTestId("column-data_uses-input")
+              .eq(0)
+              .type("Custom Title", { force: true });
           });
         cy.getByTestId("rename-columns-cancel-btn").click({ force: true });
         cy.getByTestId("rename-columns-reset-btn").should("not.exist");
@@ -324,11 +329,15 @@ describe("Data map report table", () => {
       it("should reset columns", () => {
         cy.getByTestId("more-menu").click();
         cy.selectAntDropdownOption("Rename columns");
+        // See note in "should cancel renaming columns": data_uses is a pinned
+        // column, so we bypass Cypress's visibility check on its rename input.
         cy.getByTestId("column-data_uses-input")
           .eq(0)
-          .clear()
+          .clear({ force: true })
           .then(() => {
-            cy.getByTestId("column-data_uses-input").eq(0).type("Custom Title");
+            cy.getByTestId("column-data_uses-input")
+              .eq(0)
+              .type("Custom Title", { force: true });
           });
         cy.getByTestId("rename-columns-apply-btn").click({ force: true });
         cy.getByTestId("more-menu").click();

--- a/clients/admin-ui/src/features/datamap/reporting/hooks/useDatamapReportTable.tsx
+++ b/clients/admin-ui/src/features/datamap/reporting/hooks/useDatamapReportTable.tsx
@@ -40,6 +40,8 @@ const emptyResponse: Page_DatamapReport_ = {
   pages: 1,
 };
 
+const PINNED_LEFT_COLUMN_COUNT = 2;
+
 export const useDatamapReportTable = () => {
   const [form] = Form.useForm();
   const userCanSeeReports = useHasPermission([
@@ -239,16 +241,26 @@ export const useDatamapReportTable = () => {
         )
       : columnOrder;
 
+    let ordered = withVisibility;
     if (effectiveOrder.length > 0) {
       const orderMap = new Map(effectiveOrder.map((id, idx) => [id, idx]));
-      return [...withVisibility].sort((a, b) => {
+      ordered = [...withVisibility].sort((a, b) => {
         const aIdx = orderMap.get(getColKey(a)) ?? Infinity;
         const bIdx = orderMap.get(getColKey(b)) ?? Infinity;
         return aIdx - bIdx;
       });
     }
 
-    return withVisibility;
+    // Pin the first two non-hidden columns so the row identifiers stay visible
+    // while the rest of the (often very wide) table scrolls horizontally.
+    let pinned = 0;
+    return ordered.map((col) => {
+      if (pinned >= PINNED_LEFT_COLUMN_COUNT || col.hidden) {
+        return col;
+      }
+      pinned += 1;
+      return { ...col, fixed: "left" as const };
+    });
   }, [columns, columnVisibility, columnOrder, groupBy]);
 
   // Update column order when groupBy or data changes


### PR DESCRIPTION
Ticket [ENG-3662]

### Description Of Changes

The Datamap Report table can grow extremely wide once data categories, data subjects, retention, custom fields, etc. are turned on. When users scroll horizontally, the row's identifier columns scrolled out of view, making it hard to keep track of which row was being read.

This pins the first two non-hidden columns of the **effective ordered + visible** column list to the left so they stay anchored while the rest of the table scrolls. Doing the pinning in `useDatamapReportTable` (rather than baking `fixed: "left"` into specific column definitions) makes it grouping-invariant: when the user changes the **Group by** dropdown, `effectiveOrder` recomputes and the correct pair gets pinned automatically.

| `groupBy`            | Pinned columns (slots 0, 1)              |
| -------------------- | ---------------------------------------- |
| `SYSTEM_DATA_USE`    | `system_name`, `data_use`                |
| `DATA_USE_SYSTEM`    | `data_use`, `system_name`                |
| `SYSTEM_GROUP`       | `system_group`, `system_group_data_uses` |

We deliberately cap at two pinned columns regardless of grouping (the `SYSTEM_GROUP` mode has 4 forced prefix columns; pinning all of them would eat too much horizontal real estate on smaller screens).

Mirrors the existing `fixed: "left"` pattern in [`useSystemsTable.tsx`](https://github.com/ethyca/fides/blob/main/clients/admin-ui/src/features/system/table/useSystemsTable.tsx).

### Code Changes

* Extend the `visibleColumns` memo in `useDatamapReportTable.tsx` to set `fixed: "left"` on the first two non-hidden columns of the ordered list (hidden columns don't consume a pin slot).
* Add a `PINNED_LEFT_COLUMN_COUNT` constant to make the cap discoverable.

### Steps to Confirm

1. Navigate to the Datamap Report page.
2. With **Group by** set to **System / Data use** (default), expand enough columns / narrow the viewport so the table overflows horizontally.
3. Scroll horizontally — confirm `system_name` and `data_use` stay pinned to the left with antd's subtle pin shadow at the boundary.
4. Switch **Group by** to **Data use / System** — confirm the pinned pair flips to `data_use`, `system_name`.
5. Switch **Group by** to **System group** — confirm `system_group` and `system_group_data_uses` are pinned (the third and fourth prefix columns scroll with the rest).
6. Open the column-settings modal and toggle visibility / reorder — confirm pinning continues to track slots 0 and 1 of the visible list.

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-3662]: https://ethyca.atlassian.net/browse/ENG-3662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ