### PR TITLE
Add promotion impact modal for wildcard assets

### DIFF
--- a/changelog/8075-wildcard-promotion-impact-modal.yaml
+++ b/changelog/8075-wildcard-promotion-impact-modal.yaml
@@ -1,0 +1,4 @@
+type: Added
+description: Add promotion impact modal for wildcard assets
+pr: 8075
+labels: []

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/action-center.slice.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/action-center.slice.ts
@@ -54,6 +54,15 @@ interface DiscoveredAssetsFilterValues {
   consent_aggregated?: string[];
 }
 
+export interface WildcardPromotionMatch {
+  urn: string;
+  name?: string | null;
+}
+
+export interface WildcardPromotionImpact {
+  matched_resources: WildcardPromotionMatch[];
+}
+
 const actionCenterApi = baseApi.injectEndpoints({
   endpoints: (build) => ({
     getAggregateMonitorResults: build.query<
@@ -306,6 +315,16 @@ const actionCenterApi = baseApi.injectEndpoints({
         },
       }),
       invalidatesTags: ["Discovery Monitor Results"],
+    }),
+    getWildcardPromotionImpact: build.query<
+      WildcardPromotionImpact,
+      { urnList: string[] }
+    >({
+      query: ({ urnList }) => ({
+        method: "POST",
+        url: "/plus/discovery-monitor/promotion-impact",
+        body: { staged_resource_urns: urnList },
+      }),
     }),
     ignoreMonitorResultAssets: build.mutation<string, { urnList?: string[] }>({
       query: (params) => {
@@ -642,6 +661,7 @@ export const {
   useAddMonitorResultSystemsMutation,
   useIgnoreMonitorResultSystemsMutation,
   useAddMonitorResultAssetsMutation,
+  useLazyGetWildcardPromotionImpactQuery,
   useIgnoreMonitorResultAssetsMutation,
   useRestoreMonitorResultAssetsMutation,
   useUpdateAssetsSystemMutation,

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useConfirmPromotion.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useConfirmPromotion.tsx
@@ -1,0 +1,55 @@
+import { Text, useModal } from "fidesui";
+import { useCallback } from "react";
+
+import {
+  useLazyGetWildcardPromotionImpactQuery,
+  WildcardPromotionMatch,
+} from "../action-center.slice";
+import { getActionModalProps } from "../fields/utils";
+
+const renderContent = (matches: WildcardPromotionMatch[]) => (
+  <>
+    <Text>
+      Adding this pattern will remove the following previously approved assets
+      from your inventory:
+    </Text>
+    <ul className="ml-5 mt-2 list-disc">
+      {matches.map((match) => (
+        <li key={match.urn}>
+          <Text>{match.name ?? match.urn}</Text>
+        </li>
+      ))}
+    </ul>
+  </>
+);
+
+/**
+ * Returns a function that looks up the promotion impact for the given URNs and
+ * shows a confirmation modal listing the assets that will be removed from the
+ * inventory. Resolves to `true` when the caller should proceed (no matches, or
+ * the user confirmed) and `false` when the user cancelled.
+ */
+export const useConfirmPromotion = () => {
+  const modalApi = useModal();
+  const [fetchImpact, { isFetching }] =
+    useLazyGetWildcardPromotionImpactQuery();
+
+  const confirmPromotion = useCallback(
+    async (urnList: string[]): Promise<boolean> => {
+      if (!urnList.length) {
+        return true;
+      }
+      const { data } = await fetchImpact({ urnList });
+      const matches = data?.matched_resources ?? [];
+      if (!matches.length) {
+        return true;
+      }
+      return modalApi.confirm(
+        getActionModalProps("Add", renderContent(matches)),
+      );
+    },
+    [fetchImpact, modalApi],
+  );
+
+  return { confirmPromotion, isCheckingImpact: isFetching };
+};

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useDiscoveredAssetsTable.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useDiscoveredAssetsTable.tsx
@@ -59,6 +59,7 @@ import isConsentCategory from "../utils/isConsentCategory";
 import useActionCenterTabs, {
   ActionCenterTabHash,
 } from "./useActionCenterTabs";
+import { useConfirmPromotion } from "./useConfirmPromotion";
 
 interface UseDiscoveredAssetsTableConfig {
   monitorId: string;
@@ -128,6 +129,7 @@ export const useDiscoveredAssetsTable = ({
 
   const [addMonitorResultAssetsMutation, { isLoading: isAddingResults }] =
     useAddMonitorResultAssetsMutation();
+  const { confirmPromotion, isCheckingImpact } = useConfirmPromotion();
   const [ignoreMonitorResultAssetsMutation, { isLoading: isIgnoringResults }] =
     useIgnoreMonitorResultAssetsMutation();
   const [addMonitorResultSystemsMutation, { isLoading: isAddingAllResults }] =
@@ -143,6 +145,7 @@ export const useDiscoveredAssetsTable = ({
 
   const anyBulkActionIsLoading =
     isAddingResults ||
+    isCheckingImpact ||
     isIgnoringResults ||
     isAddingAllResults ||
     isBulkUpdatingSystem ||
@@ -450,6 +453,10 @@ export const useDiscoveredAssetsTable = ({
   }, [data, systemId, systemName]);
 
   const handleBulkAdd = useCallback(async () => {
+    const confirmed = await confirmPromotion(selectedUrns);
+    if (!confirmed) {
+      return;
+    }
     const result = await addMonitorResultAssetsMutation({
       urnList: selectedUrns,
     });
@@ -479,6 +486,7 @@ export const useDiscoveredAssetsTable = ({
       resetSelections();
     }
   }, [
+    confirmPromotion,
     addMonitorResultAssetsMutation,
     selectedUrns,
     selectedRows,

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/cells/DiscoveredAssetActionsCell.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/cells/DiscoveredAssetActionsCell.tsx
@@ -22,6 +22,7 @@ import {
   useRestoreMonitorResultAssetsMutation,
 } from "../../action-center.slice";
 import { ActionCenterTabHash } from "../../hooks/useActionCenterTabs";
+import { useConfirmPromotion } from "../../hooks/useConfirmPromotion";
 import hasConsentComplianceIssue from "../../utils/hasConsentComplianceIssue";
 
 interface DiscoveredAssetActionsCellProps {
@@ -41,6 +42,7 @@ export const DiscoveredAssetActionsCell = ({
   const { assetConsentStatusLabels: isConsentStatusFlagEnabled } = flags;
   const [addMonitorResultAssetsMutation, { isLoading: isAddingResults }] =
     useAddMonitorResultAssetsMutation();
+  const { confirmPromotion, isCheckingImpact } = useConfirmPromotion();
   const [ignoreMonitorResultAssetsMutation, { isLoading: isIgnoringResults }] =
     useIgnoreMonitorResultAssetsMutation();
   const [
@@ -54,7 +56,10 @@ export const DiscoveredAssetActionsCell = ({
   const router = useRouter();
 
   const anyActionIsLoading =
-    isAddingResults || isIgnoringResults || isRestoringResults;
+    isAddingResults ||
+    isCheckingImpact ||
+    isIgnoringResults ||
+    isRestoringResults;
 
   const {
     urn,
@@ -73,9 +78,11 @@ export const DiscoveredAssetActionsCell = ({
     hasConsentComplianceIssue(consentAggregated);
 
   const handleAdd = async () => {
-    const result = await addMonitorResultAssetsMutation({
-      urnList: [urn],
-    });
+    const confirmed = await confirmPromotion([urn]);
+    if (!confirmed) {
+      return;
+    }
+    const result = await addMonitorResultAssetsMutation({ urnList: [urn] });
     if (isErrorResult(result)) {
       message.error(getErrorMessage(result.error));
     } else {


### PR DESCRIPTION
Ticket [ENG-3433]

### Description Of Changes

This PR adds a confirmation modal when the admin is adding a consolidated (wildcard) resource to the system. It's using the new `/promotion-impact` endpoint to list the monitored resources that will be superseded by this promotion.

Required `fidesplus` changes: https://github.com/ethyca/fidesplus/pull/3460

### Steps to Confirm

See the related `fidesplus` PR for confirmation steps.

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
* UX feedback:
  * [x] No UX review needed (assuming no review needed for a confirmation modal like this, though we can shop the verbiage)
* Followup issues:
  * [x] No followup issues
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)


[ENG-3433]: https://ethyca.atlassian.net/browse/ENG-3433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ