### PR TITLE
ENG-3590: Resurface behaviors for TCf

### DIFF
--- a/changelog/8079-fix-tcf-resurface-behavior.yaml
+++ b/changelog/8079-fix-tcf-resurface-behavior.yaml
@@ -1,0 +1,7 @@
+# Copy this file and rename it to <pr_number>-<short-description>.yaml (e.g., 1234-add-user-endpoint.yaml)
+# Fill in the required fields and delete this comment block
+
+type: Fixed # One of: Added, Changed, Developer Experience, Deprecated, Docs, Fixed, Removed, Security
+description: TCF experiences now respect resurface behavior
+pr: 8079 # PR number
+labels: [] # Optional: ["high-risk", "db-migration"]

--- a/clients/fides-js/__tests__/lib/consent-utils.test.ts
+++ b/clients/fides-js/__tests__/lib/consent-utils.test.ts
@@ -582,6 +582,63 @@ describe("shouldResurfaceBanner", () => {
       options: {},
       expected: true,
     },
+    {
+      label:
+        "returns true for TCF when version hash matches but resurface_behavior includes consentMethod",
+      experience: {
+        ...mockTCFExperience,
+        experience_config: {
+          component: ComponentType.TCF_OVERLAY,
+          resurface_behavior: ["reject"],
+        },
+      },
+      cookie: {
+        ...mockCookie,
+        fides_meta: { consentMethod: ConsentMethod.REJECT },
+        tcf_version_hash: "v1",
+      },
+      savedConsent: mockSavedConsent,
+      options: {},
+      expected: true,
+    },
+    {
+      label:
+        "returns false for TCF when version hash matches and resurface_behavior does not include consentMethod",
+      experience: {
+        ...mockTCFExperience,
+        experience_config: {
+          component: ComponentType.TCF_OVERLAY,
+          resurface_behavior: ["reject"],
+        },
+      },
+      cookie: {
+        ...mockCookie,
+        fides_meta: { consentMethod: ConsentMethod.ACCEPT },
+        tcf_version_hash: "v1",
+      },
+      savedConsent: mockSavedConsent,
+      options: {},
+      expected: false,
+    },
+    {
+      label: "returns true for TCF with no cookie and no prior consent",
+      experience: mockTCFExperience,
+      cookie: undefined,
+      savedConsent: undefined,
+      options: {},
+      expected: true,
+    },
+    {
+      label: "returns false for TCF when fidesModalDisplay is immediate",
+      experience: {
+        ...mockTCFExperience,
+        meta: { version_hash: "v2" },
+      },
+      cookie: mockCookie,
+      savedConsent: mockSavedConsent,
+      options: { fidesModalDisplay: "immediate" },
+      expected: false,
+    },
   ])("$label", ({ experience, cookie, savedConsent, options, expected }) => {
     expect(
       shouldResurfaceBanner(

--- a/clients/fides-js/src/lib/consent-utils.ts
+++ b/clients/fides-js/src/lib/consent-utils.ts
@@ -263,6 +263,14 @@ export const shouldResurfaceBanner = (
   if (!isPrivacyExperience(experience)) {
     return false;
   }
+
+  const shouldResurfaceBasedOnConfiguration = Boolean(
+    cookie?.fides_meta.consentMethod &&
+      experience.experience_config?.resurface_behavior?.includes(
+        cookie.fides_meta.consentMethod,
+      ),
+  );
+
   // Never surface banner if modal is set to show immediately
   if (options.fidesModalDisplay === "immediate") {
     return false;
@@ -276,6 +284,7 @@ export const shouldResurfaceBanner = (
   }
   // Always resurface banner for TCF unless consent was set by override
   // or the saved version_hash matches
+  // or if the banner is configured to resurface
   if (
     experience.experience_config?.component === ComponentType.TCF_OVERLAY &&
     !!cookie
@@ -284,7 +293,10 @@ export const shouldResurfaceBanner = (
       return false;
     }
     if (experience.meta?.version_hash) {
-      return experience.meta.version_hash !== cookie.tcf_version_hash;
+      return (
+        experience.meta.version_hash !== cookie.tcf_version_hash ||
+        shouldResurfaceBasedOnConfiguration
+      );
     }
     return true;
   }
@@ -311,13 +323,9 @@ export const shouldResurfaceBanner = (
   if (cookie?.fides_meta.consentMethod === ConsentMethod.GPC) {
     return true;
   }
+
   // Resurface if configured for this consent method
-  if (
-    cookie?.fides_meta.consentMethod &&
-    experience.experience_config?.resurface_behavior?.includes(
-      cookie.fides_meta.consentMethod,
-    )
-  ) {
+  if (shouldResurfaceBasedOnConfiguration) {
     return true;
   }
   // Lastly, if we do have a prior consent state, resurface if we find *any*

--- a/clients/fides-js/src/lib/consent-utils.ts
+++ b/clients/fides-js/src/lib/consent-utils.ts
@@ -266,9 +266,9 @@ export const shouldResurfaceBanner = (
 
   const shouldResurfaceBasedOnConfiguration = Boolean(
     cookie?.fides_meta.consentMethod &&
-      experience.experience_config?.resurface_behavior?.includes(
-        cookie.fides_meta.consentMethod,
-      ),
+    experience.experience_config?.resurface_behavior?.includes(
+      cookie.fides_meta.consentMethod,
+    ),
   );
 
   // Never surface banner if modal is set to show immediately


### PR DESCRIPTION
Ticket [ENG-3590] <!-- simply paste the ticket number between the brackets and it will auto-convert to a link -->

Sibling PR: https://github.com/ethyca/fidesplus/pull/3500

### Description Of Changes

TCF doesn't resurface when it is configured to resurface on dismiss or reject. This change fixes that.

There is a matching backend change for this code as the minimal TCF endpoint also needs to return the behavior array.

### Steps to Confirm

1. Configure a TCF experience
2. dismiss the TCF banner
3. check that the banner resurfaces on page reload
4. do 2-3 but with reject configured
5. do 2-3 but with no behavior's checked off 
6. observe that the banner does not resurface

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-3590]: https://ethyca.atlassian.net/browse/ENG-3590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ