### PR TITLE
ENG-3593: Eliminate redundant System fetches in /system/upsert

### DIFF
--- a/changelog/8080-eliminate-redundant-system-fetches.yaml
+++ b/changelog/8080-eliminate-redundant-system-fetches.yaml
@@ -1,3 +1,4 @@
 type: Changed
 description: Reduce redundant System fetches per row in /system/upsert from four to one, and add per-axis change-detection logging in the system audit path.
+pr: 8080
 labels: []

--- a/changelog/eng-3593-eliminate-redundant-system-fetches.yaml
+++ b/changelog/eng-3593-eliminate-redundant-system-fetches.yaml
@@ -1,0 +1,3 @@
+type: Changed
+description: Reduce redundant System fetches per row in /system/upsert from four to one, and add per-axis change-detection logging in the system audit path.
+labels: []

--- a/src/fides/api/db/system.py
+++ b/src/fides/api/db/system.py
@@ -12,11 +12,12 @@ from fideslang.models import System as SystemSchema
 from fideslang.validation import FidesKey
 from loguru import logger as log
 from sqlalchemy import select
+from sqlalchemy import update as sql_update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 from starlette.status import HTTP_400_BAD_REQUEST, HTTP_404_NOT_FOUND
 
-from fides.api.db.crud import create_resource, get_resource, update_resource
+from fides.api.db.crud import create_resource, get_resource
 from fides.api.models.sql_models import (  # type: ignore[attr-defined]
     DataCategory,
     DataSubject,
@@ -133,7 +134,7 @@ async def upsert_system(
 
     for resource in resources:
         try:
-            await get_resource(System, resource.fides_key, db)
+            existing_system = await get_resource(System, resource.fides_key, db)
         except NotFoundError:
             log.debug(
                 f"Upsert System with fides_key {resource.fides_key} not found, will create"
@@ -146,7 +147,14 @@ async def upsert_system(
             )
             inserted += 1
             continue
-        await update_system(resource=resource, db=db, current_user_id=current_user_id)
+        # Pass the already-loaded System through so update_system doesn't
+        # re-fetch it.
+        await update_system(
+            resource=resource,
+            db=db,
+            current_user_id=current_user_id,
+            existing_system=existing_system,
+        )
         updated += 1
     return (inserted, updated)
 
@@ -186,19 +194,30 @@ async def upsert_privacy_declarations(
 
 
 async def update_system(
-    resource: SystemSchema, db: AsyncSession, current_user_id: Optional[str] = None
-) -> Tuple[Dict, bool]:
-    """Helper function to share core system update logic for wrapping endpoint functions"""
-    system: System = await get_resource(
-        sql_model=System, fides_key=resource.fides_key, async_session=db
-    )
+    resource: SystemSchema,
+    db: AsyncSession,
+    current_user_id: Optional[str] = None,
+    existing_system: Optional[System] = None,
+) -> Tuple[System, bool]:
+    """Helper function to share core system update logic for wrapping endpoint functions.
+
+    If ``existing_system`` is supplied, it is used in place of an explicit
+    ``get_resource`` call. Callers that already loaded the System (e.g.
+    ``upsert_system`` after its existence check) should pass it through to
+    avoid a redundant fetch.
+    """
+    if existing_system is None:
+        existing_system = await get_resource(
+            sql_model=System, fides_key=resource.fides_key, async_session=db
+        )
+
     existing_system_dict = copy.deepcopy(
-        SystemSchema.model_validate(system)
+        SystemSchema.model_validate(existing_system)
     ).model_dump(mode="json")
 
     # handle the privacy declaration upsert logic
     try:
-        await upsert_privacy_declarations(db, resource, system)
+        await upsert_privacy_declarations(db, resource, existing_system)
     except Exception as e:
         log.error(
             f"Error adding privacy declarations, reverting system creation: {str(e)}"
@@ -209,21 +228,35 @@ async def update_system(
         resource, "privacy_declarations"
     )  # remove the attribute on the system since we've already updated declarations
 
-    # perform any updates on the system resource itself
-    updated_system = await update_resource(System, resource.model_dump(), db)
+    # Inline the UPDATE rather than calling ``crud.update_resource``, which
+    # otherwise issues two extra ``get_resource`` calls (one before the
+    # UPDATE and one to return the post-UPDATE row). We already hold the
+    # ORM object and ``db.refresh`` below picks up any DB-side coercions.
+    resource_dict = resource.model_dump()
+    async with db.begin():
+        log.debug(
+            "Updating resource",
+            sql_model="System",
+            fides_key=resource.fides_key,
+        )
+        await db.execute(
+            sql_update(System.__table__)
+            .where(System.fides_key == resource.fides_key)
+            .values(resource_dict)
+        )
 
     async with db.begin():
-        await db.refresh(updated_system)
+        await db.refresh(existing_system)
 
         system_updated: bool = _audit_system_changes(
             db,
-            system.id,
+            existing_system.id,
             current_user_id,
             existing_system_dict,
-            SystemSchema.model_validate(updated_system).model_dump(mode="json"),
+            SystemSchema.model_validate(existing_system).model_dump(mode="json"),
         )
 
-    return updated_system, system_updated
+    return existing_system, system_updated
 
 
 def _audit_system_changes(
@@ -259,8 +292,18 @@ def _audit_system_changes(
 
     system_updated: bool = False
 
+    # Compute each axis's diff once so we can both gate the SystemHistory
+    # write and emit observability around how often each axis actually
+    # changes. These logs help quantify the steady-state no-op rate before
+    # we consider skipping the UPDATE for unchanged systems.
+    general_diff = DeepDiff(existing_system, updated_system, ignore_order=True)
+    privacy_diff = DeepDiff(privacy_existing, privacy_updated, ignore_order=True)
+    data_flow_diff = DeepDiff(
+        egress_ingress_existing, egress_ingress_updated, ignore_order=True
+    )
+
     # Create a SystemHistory entry for general changes
-    if DeepDiff(existing_system, updated_system, ignore_order=True):
+    if general_diff:
         system_updated = True
 
         SystemHistory(
@@ -272,7 +315,7 @@ def _audit_system_changes(
         ).save(db=db)
 
     # Create a SystemHistory entry for changes to privacy_declarations
-    if DeepDiff(privacy_existing, privacy_updated, ignore_order=True):
+    if privacy_diff:
         system_updated = True
 
         SystemHistory(
@@ -284,7 +327,7 @@ def _audit_system_changes(
         ).save(db=db)
 
     # Create a SystemHistory entry for changes to egress and ingress
-    if DeepDiff(egress_ingress_existing, egress_ingress_updated, ignore_order=True):
+    if data_flow_diff:
         system_updated = True
 
         SystemHistory(
@@ -294,6 +337,20 @@ def _audit_system_changes(
             after=egress_ingress_updated,
             created_at=now,
         ).save(db=db)
+
+    log.debug(
+        "System change detection",
+        system_id=system_id,
+        general_changed=bool(general_diff),
+        privacy_declarations_changed=bool(privacy_diff),
+        data_flow_changed=bool(data_flow_diff),
+        any_changed=system_updated,
+        general_diff_keys=len(general_diff.affected_paths) if general_diff else 0,
+        privacy_diff_keys=len(privacy_diff.affected_paths) if privacy_diff else 0,
+        data_flow_diff_keys=(
+            len(data_flow_diff.affected_paths) if data_flow_diff else 0
+        ),
+    )
 
     return system_updated
 

--- a/src/fides/api/db/system.py
+++ b/src/fides/api/db/system.py
@@ -206,8 +206,6 @@ async def update_system(
     ``upsert_system`` after its existence check) should pass it through to
     avoid a redundant fetch.
     """
-    # Local variable with explicit type so mypy narrows correctly even though
-    # crud.get_resource is inferred as returning Any.
     system: System
     if existing_system is None:
         system = await get_resource(

--- a/src/fides/api/db/system.py
+++ b/src/fides/api/db/system.py
@@ -13,6 +13,7 @@ from fideslang.validation import FidesKey
 from loguru import logger as log
 from sqlalchemy import select
 from sqlalchemy import update as sql_update
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 from starlette.status import HTTP_400_BAD_REQUEST, HTTP_404_NOT_FOUND
@@ -26,6 +27,7 @@ from fides.api.models.sql_models import (  # type: ignore[attr-defined]
     System,
 )
 from fides.api.models.system_history import SystemHistory
+from fides.api.util import errors
 from fides.api.util.errors import NotFoundError
 
 
@@ -242,11 +244,16 @@ async def update_system(
             sql_model="System",
             fides_key=resource.fides_key,
         )
-        await db.execute(
-            sql_update(System.__table__)
-            .where(System.fides_key == resource.fides_key)
-            .values(resource_dict)
-        )
+        try:
+            await db.execute(
+                sql_update(System.__table__)
+                .where(System.fides_key == resource.fides_key)
+                .values(resource_dict)
+            )
+        except SQLAlchemyError as exc:
+            # Mirrors the guard the prior `crud.update_resource` call had.
+            log.exception(f"Failed to update System with error: '{exc}'")
+            raise errors.QueryError()
 
     async with db.begin():
         await db.refresh(system)

--- a/src/fides/api/db/system.py
+++ b/src/fides/api/db/system.py
@@ -206,18 +206,23 @@ async def update_system(
     ``upsert_system`` after its existence check) should pass it through to
     avoid a redundant fetch.
     """
+    # Local variable with explicit type so mypy narrows correctly even though
+    # crud.get_resource is inferred as returning Any.
+    system: System
     if existing_system is None:
-        existing_system = await get_resource(
+        system = await get_resource(
             sql_model=System, fides_key=resource.fides_key, async_session=db
         )
+    else:
+        system = existing_system
 
     existing_system_dict = copy.deepcopy(
-        SystemSchema.model_validate(existing_system)
+        SystemSchema.model_validate(system)
     ).model_dump(mode="json")
 
     # handle the privacy declaration upsert logic
     try:
-        await upsert_privacy_declarations(db, resource, existing_system)
+        await upsert_privacy_declarations(db, resource, system)
     except Exception as e:
         log.error(
             f"Error adding privacy declarations, reverting system creation: {str(e)}"
@@ -246,17 +251,17 @@ async def update_system(
         )
 
     async with db.begin():
-        await db.refresh(existing_system)
+        await db.refresh(system)
 
         system_updated: bool = _audit_system_changes(
             db,
-            existing_system.id,
+            system.id,
             current_user_id,
             existing_system_dict,
-            SystemSchema.model_validate(existing_system).model_dump(mode="json"),
+            SystemSchema.model_validate(system).model_dump(mode="json"),
         )
 
-    return existing_system, system_updated
+    return system, system_updated
 
 
 def _audit_system_changes(

--- a/tests/ctl/core/test_system_history.py
+++ b/tests/ctl/core/test_system_history.py
@@ -1,4 +1,3 @@
-import logging
 from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
@@ -220,18 +219,16 @@ class TestUpsertSystemFetchOptimization:
         assert len(system_histories) == 1
 
     async def test_upsert_system_emits_one_fetch_per_updated_system(
-        self, async_session, loguru_caplog
+        self, async_session
     ):
         """Regression guard for ENG-3593: each updated system on the UPDATE
-        path should emit exactly one 'Fetching resource' debug log for its
-        fides_key. Before the fix this was four. If a future change re-
-        introduces a redundant get_resource call, this test fails loudly.
+        path should issue exactly one `crud.get_resource` call (the existence
+        check in `upsert_system`). Before the fix this was four. If a future
+        change re-introduces a redundant call, this test fails loudly.
 
         Uses two systems to also catch any accidental constant-cost bug
         (e.g., loading systems once but counting wrong).
         """
-        loguru_caplog.set_level(logging.DEBUG)
-
         # Stable fides_keys across both passes so the second pass hits the
         # rows the first pass created. The schema instances themselves must
         # be rebuilt because `update_system` mutates inputs (it does a
@@ -257,25 +254,23 @@ class TestUpsertSystemFetchOptimization:
             current_user_id=CONFIG.security.oauth_root_client_id,
         )
 
-        # Drop log lines from the prime so the count below reflects only the
-        # measure pass.
-        loguru_caplog.clear()
-
-        # Measure: every row exists, every row hits the UPDATE path.
-        await upsert_system(
-            resources=build_payload(),
-            db=async_session,
-            current_user_id=CONFIG.security.oauth_root_client_id,
-        )
-
-        for fides_key in fides_keys:
-            matching = [
-                line
-                for line in loguru_caplog.text.splitlines()
-                if "Fetching resource" in line and fides_key in line
-            ]
-            assert len(matching) == 1, (
-                f"Expected exactly 1 'Fetching resource' log for "
-                f"{fides_key} on the UPDATE path, found "
-                f"{len(matching)}:\n" + "\n".join(matching)
+        # Measure: every row exists, every row hits the UPDATE path. Patch
+        # `get_resource` at the call site (system.py) and wrap the original
+        # so behavior is unchanged but invocations are counted.
+        with patch(
+            "fides.api.db.system.get_resource", wraps=get_resource
+        ) as mock_get_resource:
+            await upsert_system(
+                resources=build_payload(),
+                db=async_session,
+                current_user_id=CONFIG.security.oauth_root_client_id,
             )
+
+        # One call per system: `upsert_system`'s existence check. The
+        # `update_system` call no longer needs to fetch because
+        # `existing_system` is threaded through.
+        assert mock_get_resource.call_count == len(fides_keys), (
+            f"Expected {len(fides_keys)} get_resource calls on the UPDATE "
+            f"path (one existence check per system), got "
+            f"{mock_get_resource.call_count}."
+        )

--- a/tests/ctl/core/test_system_history.py
+++ b/tests/ctl/core/test_system_history.py
@@ -1,3 +1,5 @@
+import logging
+from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
 import pytest
@@ -6,7 +8,8 @@ from fideslang.models import PrivacyDeclaration as PrivacyDeclarationSchema
 from fideslang.models import System as SystemSchema
 from sqlalchemy import delete
 
-from fides.api.db.system import create_system, update_system
+from fides.api.db.crud import get_resource
+from fides.api.db.system import create_system, update_system, upsert_system
 from fides.api.models.sql_models import System
 from fides.api.models.system_history import SystemHistory
 from fides.config import get_config
@@ -137,3 +140,135 @@ class TestSystemHistory:
         ).all()
 
         assert system_histories[0].edited_by == "automatic_system_update"
+
+
+class TestUpsertSystemFetchOptimization:
+    """Regression coverage for the ENG-3593 fetch-count reduction in
+    /system/upsert. Each updated system used to fan out to 4 get_resource
+    calls; after the fix it should be exactly 1."""
+
+    @pytest.fixture()
+    async def system(self, async_session):
+        resource = SystemSchema(
+            fides_key=str(uuid4()),
+            organization_fides_key="default_organization",
+            name="upsert_fetch_opt_system",
+            system_type="test",
+            privacy_declarations=[],
+        )
+
+        system = await create_system(
+            resource, async_session, CONFIG.security.oauth_root_client_id
+        )
+        yield system
+        delete(System).where(System.id == system.id)
+
+    async def test_upsert_passes_existing_system_to_update(
+        self, async_session, system: System
+    ):
+        """upsert_system must pass the System loaded by its existence check
+        through to update_system as `existing_system`. If this contract is
+        broken, the redundant fetch the optimization removed is silently
+        re-introduced via update_system's fallback path."""
+        system_schema = SystemSchema.model_validate(system)
+
+        with patch(
+            "fides.api.db.system.update_system",
+            new=AsyncMock(return_value=(system, False)),
+        ) as mock_update:
+            await upsert_system(
+                resources=[system_schema],
+                db=async_session,
+                current_user_id=CONFIG.security.oauth_root_client_id,
+            )
+
+        mock_update.assert_called_once()
+        call_kwargs = mock_update.call_args.kwargs
+        assert call_kwargs.get("existing_system") is not None, (
+            "update_system was called without existing_system - this defeats "
+            "the ENG-3593 fetch optimization."
+        )
+        assert call_kwargs["existing_system"].fides_key == system.fides_key
+
+    async def test_update_system_with_existing_system_persists_changes(
+        self, db, async_session, system: System
+    ):
+        """When update_system is called with an explicit existing_system
+        (the new ENG-3593 code path), the inline UPDATE + db.refresh still
+        persist the change to the DB and emit the expected audit entry."""
+        pre_loaded = await get_resource(System, system.fides_key, async_session)
+
+        system_schema = SystemSchema.model_validate(system)
+        system_schema.description = "Modified via explicit existing_system path"
+
+        _, updated = await update_system(
+            resource=system_schema,
+            db=async_session,
+            current_user_id=CONFIG.security.oauth_root_client_id,
+            existing_system=pre_loaded,
+        )
+        assert updated
+
+        # The DB row was actually updated.
+        fresh = await get_resource(System, system.fides_key, async_session)
+        assert fresh.description == "Modified via explicit existing_system path"
+
+        # An audit entry on the general axis was created.
+        system_histories = SystemHistory.filter(
+            db=db, conditions=(SystemHistory.system_id == system.id)
+        ).all()
+        assert len(system_histories) == 1
+
+    async def test_upsert_system_emits_one_fetch_per_updated_system(
+        self, async_session, loguru_caplog
+    ):
+        """Regression guard for ENG-3593: each updated system on the UPDATE
+        path should emit exactly one 'Fetching resource' debug log for its
+        fides_key. Before the fix this was four. If a future change re-
+        introduces a redundant get_resource call, this test fails loudly.
+
+        Uses two systems to also catch any accidental constant-cost bug
+        (e.g., loading systems once but counting wrong).
+        """
+        loguru_caplog.set_level(logging.DEBUG)
+
+        payload = [
+            SystemSchema(
+                fides_key=f"fetch_count_{uuid4()}",
+                organization_fides_key="default_organization",
+                name=f"Fetch count test {i}",
+                system_type="test",
+                privacy_declarations=[],
+            )
+            for i in range(2)
+        ]
+
+        # Prime: this run creates the rows (INSERT path); not what we measure.
+        await upsert_system(
+            resources=payload,
+            db=async_session,
+            current_user_id=CONFIG.security.oauth_root_client_id,
+        )
+
+        # Drop log lines from the prime so the count below reflects only the
+        # measure pass.
+        loguru_caplog.clear()
+
+        # Measure: every row exists, every row hits the UPDATE path.
+        await upsert_system(
+            resources=payload,
+            db=async_session,
+            current_user_id=CONFIG.security.oauth_root_client_id,
+        )
+
+        for resource in payload:
+            matching = [
+                line
+                for line in loguru_caplog.text.splitlines()
+                if "Fetching resource" in line and resource.fides_key in line
+            ]
+            assert len(matching) == 1, (
+                f"Expected exactly 1 'Fetching resource' log for "
+                f"{resource.fides_key} on the UPDATE path, found "
+                f"{len(matching)}:\n" + "\n".join(matching)
+            )

--- a/tests/ctl/core/test_system_history.py
+++ b/tests/ctl/core/test_system_history.py
@@ -232,20 +232,27 @@ class TestUpsertSystemFetchOptimization:
         """
         loguru_caplog.set_level(logging.DEBUG)
 
-        payload = [
-            SystemSchema(
-                fides_key=f"fetch_count_{uuid4()}",
-                organization_fides_key="default_organization",
-                name=f"Fetch count test {i}",
-                system_type="test",
-                privacy_declarations=[],
-            )
-            for i in range(2)
-        ]
+        # Stable fides_keys across both passes so the second pass hits the
+        # rows the first pass created. The schema instances themselves must
+        # be rebuilt because `update_system` mutates inputs (it does a
+        # `delattr(resource, "privacy_declarations")` after upserting them).
+        fides_keys = [f"fetch_count_{uuid4()}" for _ in range(2)]
+
+        def build_payload() -> list[SystemSchema]:
+            return [
+                SystemSchema(
+                    fides_key=fk,
+                    organization_fides_key="default_organization",
+                    name=f"Fetch count test {i}",
+                    system_type="test",
+                    privacy_declarations=[],
+                )
+                for i, fk in enumerate(fides_keys)
+            ]
 
         # Prime: this run creates the rows (INSERT path); not what we measure.
         await upsert_system(
-            resources=payload,
+            resources=build_payload(),
             db=async_session,
             current_user_id=CONFIG.security.oauth_root_client_id,
         )
@@ -256,19 +263,19 @@ class TestUpsertSystemFetchOptimization:
 
         # Measure: every row exists, every row hits the UPDATE path.
         await upsert_system(
-            resources=payload,
+            resources=build_payload(),
             db=async_session,
             current_user_id=CONFIG.security.oauth_root_client_id,
         )
 
-        for resource in payload:
+        for fides_key in fides_keys:
             matching = [
                 line
                 for line in loguru_caplog.text.splitlines()
-                if "Fetching resource" in line and resource.fides_key in line
+                if "Fetching resource" in line and fides_key in line
             ]
             assert len(matching) == 1, (
                 f"Expected exactly 1 'Fetching resource' log for "
-                f"{resource.fides_key} on the UPDATE path, found "
+                f"{fides_key} on the UPDATE path, found "
                 f"{len(matching)}:\n" + "\n".join(matching)
             )

--- a/tests/ctl/core/test_system_history.py
+++ b/tests/ctl/core/test_system_history.py
@@ -6,11 +6,13 @@ from fideslang.models import DataFlow as DataFlowSchema
 from fideslang.models import PrivacyDeclaration as PrivacyDeclarationSchema
 from fideslang.models import System as SystemSchema
 from sqlalchemy import delete
+from sqlalchemy.exc import SQLAlchemyError
 
 from fides.api.db.crud import get_resource
 from fides.api.db.system import create_system, update_system, upsert_system
 from fides.api.models.sql_models import System
 from fides.api.models.system_history import SystemHistory
+from fides.api.util import errors
 from fides.config import get_config
 
 CONFIG = get_config()
@@ -274,3 +276,52 @@ class TestUpsertSystemFetchOptimization:
             f"path (one existence check per system), got "
             f"{mock_get_resource.call_count}."
         )
+
+    async def test_update_system_raises_query_error_on_sqlalchemy_error(
+        self, async_session
+    ):
+        """When the inlined UPDATE raises a SQLAlchemyError, update_system
+        must wrap it in a domain-level errors.QueryError. This mirrors the
+        guard the prior `crud.update_resource` call provided and prevents
+        raw SQLAlchemy exceptions from propagating to API callers.
+
+        Builds the System inline rather than using the class `system`
+        fixture: ``async with db.begin()`` auto-rolls back when the
+        injected error propagates, which expires ORM objects bound to the
+        shared session-scoped fixture. The fixture's teardown then tries
+        to access ``system.id`` and triggers a lazy reload that fails
+        outside an async greenlet context.
+        """
+        fides_key = f"qe_test_{uuid4()}"
+        resource = SystemSchema(
+            fides_key=fides_key,
+            organization_fides_key="default_organization",
+            name="query_error_test_system",
+            system_type="test",
+            privacy_declarations=[],
+        )
+        await create_system(
+            resource, async_session, CONFIG.security.oauth_root_client_id
+        )
+        pre_loaded = await get_resource(System, fides_key, async_session)
+
+        system_schema = SystemSchema.model_validate(pre_loaded)
+        system_schema.description = "Should fail"
+
+        original_execute = async_session.execute
+
+        async def execute_or_fail(stmt, *args, **kwargs):
+            # Fail only on the System UPDATE so we don't break transaction
+            # control or other internal session machinery.
+            if getattr(stmt, "table", None) is System.__table__:
+                raise SQLAlchemyError("simulated DB failure")
+            return await original_execute(stmt, *args, **kwargs)
+
+        with patch.object(async_session, "execute", side_effect=execute_or_fail):
+            with pytest.raises(errors.QueryError):
+                await update_system(
+                    resource=system_schema,
+                    db=async_session,
+                    current_user_id=CONFIG.security.oauth_root_client_id,
+                    existing_system=pre_loaded,
+                )


### PR DESCRIPTION
Ticket [ENG-3593]

### Description Of Changes

Reduces per-row `get_resource` calls in `/system/upsert` from **4 → 1** on the UPDATE path, and adds per-axis change-detection logging in `_audit_system_changes` so we can quantify the steady-state no-op rate before considering a "skip-unchanged" optimization.

Each updated system on the UPDATE path was previously issuing four `Fetching resource` round-trips:

1. `upsert_system` — existence check
2. `update_system` — re-fetch with relationships
3. `update_resource` — pre-UPDATE sanity (inside `crud.update_resource`)
4. `update_resource` — post-UPDATE return (inside `crud.update_resource`)

Three are pure dedup: none of them inspect the row for anything except "does it exist" or "what is its current state," both of which the caller already has by step (1).

This was identified as a contributor to the system memory baseline during the recent `system/upsert` perf investigation; reducing fetches lowers both wall time and peak memory on this endpoint.

### Code Changes

* `upsert_system` keeps the `System` returned by its existence check and threads it to `update_system` via a new optional `existing_system=` parameter. The direct `PUT /system` endpoint caller (no pre-loaded System) continues to work — the parameter defaults to `None` and falls back to the original fetch.
* `update_system` replaces its call to `crud.update_resource` with an inline `sql_update(System.__table__).where(...).values(resource_dict)` plus `db.refresh(existing_system)`. The refresh re-reads the row so DB-side coercions (timestamps, JSONB normalization, etc.) are still picked up; the `_audit_system_changes` comparison stays equivalent to the prior behavior.
* `_audit_system_changes` captures each `DeepDiff` once into named variables (`general_diff`, `privacy_diff`, `data_flow_diff`) and emits a structured `System change detection` debug log per system with `general_changed`, `privacy_declarations_changed`, `data_flow_changed`, `any_changed`, plus affected-paths counts per axis. **No behavior change** — same `if`-gates, same `SystemHistory` writes; this is purely observability.
* `db.refresh()` does **not** flow through `crud.get_resource`, so it does **not** emit a `Fetching resource` log line. The `Fetching resource` count on the same payload drops from ~4N to ~N (the remaining one is `upsert_system`'s existence check, which a follow-up could batch).

### Performance verification (local benchmark)

[reproduce_upsert_perf.py](https://github.com/user-attachments/files/27260787/reproduce_upsert_perf.py)

Methodology: build a payload of N Systems × M declarations, prime once (INSERT path), then upsert the **same payload** three times to exercise the UPDATE path on every row with zero data drift. Run on `main` and this branch in turn against the same local backend / DB. Backend at DEBUG log level so `Fetching resource` / `Updating resource` lines emit. Reproduction script will be attached as a comment on this PR.

Payload: 180 systems × 3 declarations each.

| Metric | `main` | This PR | Δ |
|---|---|---|---|
| Wall time min | 2.92s | 1.51s | **−48%** |
| Wall time avg (n=3) | 3.05s | 1.65s | **−46%** |
| Wall time max | 3.19s | 1.83s | −43% |
| `Fetching resource` per call | 720 | **180** | **−75%** (4N → N, exactly as predicted) |
| `Updating resource` per call | 180 | 180 | unchanged ✓ |
| `System change detection` per call | 0 | 180 | new observability ✓ |

The fetch reduction matches the call-graph trace exactly. The wall-time reduction (~46%) is less than the fetch-count reduction (~75%), meaning roughly half of the original UPDATE-path wall time is non-fetch work (DeepDiff, model_dump, deepcopy of existing snapshot) — which is exactly the headroom available for the higher-risk "skip-unchanged" follow-up.

### Steps to Confirm

1. Run `tests/ctl/core/test_system_history.py` — covers `update_system` + `_audit_system_changes` directly. The critical case is `test_no_changes` (idempotent upsert ⇒ zero `SystemHistory` rows). All six cases should pass: `test_system_information_changes`, `test_privacy_declaration_changes`, `test_ingress_egress_changes`, `test_multiple_changes`, `test_no_changes`, `test_automatic_system_update`.
2. Run `tests/ctl/core/test_system.py` and `tests/ops/api/v1/endpoints/test_system.py` for broader coverage and to exercise the `PUT /system` path (which uses the `existing_system=None` fallback).
3. Reproduce the perf measurement above using the script attached as a PR comment. With 180 systems × 3 declarations × 3 measure runs, expect ~180 `Fetching resource` logs per measure call (down from ~720), wall time roughly halved on local Postgres, and one `System change detection` line per row with `any_changed=False` on idempotent payloads.

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [x] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required

### Followups

- Replace `upsert_system`'s per-row existence check with a single batched `SELECT ... WHERE fides_key IN (...)` plus `selectinload(System.privacy_declarations)`. Collapses the remaining N fetches to ~1.
- Skip the UPDATE + audit pipeline entirely for unchanged systems. Higher correctness risk (equivalence checks, `updated_at` semantics) — the `System change detection` logs added here will quantify the opportunity first. The benchmark above shows ~1.65s/call of non-fetch wall time still on the table.
- Add automated regression tests: (1) functional coverage on the upsert/update endpoints (mostly already present in `test_system_history.py`), and (2) DB-call-count assertions to prevent silent regression of the fetch-count reduction.

[ENG-3593]: https://ethyca.atlassian.net/browse/ENG-3593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ