### PR TITLE
ENG-3232: Enable tree node removal action in action center

### DIFF
--- a/changelog/8083-fix-tree-removal-action.yaml
+++ b/changelog/8083-fix-tree-removal-action.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Enable "Remove" action on tree nodes for endpoint removals in action center
+pr: 8083
+labels: []

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorTree.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorTree.tsx
@@ -52,6 +52,7 @@ import {
   shouldShowBadgeDot,
   updateNodeStatus,
 } from "./treeUtils";
+import { TreeResourceChangeIndicator } from "./TreeResourceChangeIndicator";
 import { CustomTreeDataNode, TreeNodeAction } from "./types";
 import { intoDiffStatus } from "./utils";
 
@@ -100,6 +101,10 @@ const mapResponseToTreeData = (
           )
         : undefined,
       diffStatus: treeNode.diff_status,
+      status:
+        treeNode.diff_status === DiffStatus.REMOVAL
+          ? TreeResourceChangeIndicator.REMOVAL
+          : undefined,
       isLeaf:
         treeNode.resource_type === StagedResourceTypeValue.FIELD ||
         !treeNode.has_grandchildren,

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorTree.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorTree.tsx
@@ -45,6 +45,7 @@ import {
 } from "./MonitorFields.const";
 import styles from "./MonitorTree.module.scss";
 import { MonitorTreeDataTitle } from "./MonitorTreeDataTitle";
+import { TreeResourceChangeIndicator } from "./TreeResourceChangeIndicator";
 import {
   collectAllDescendantUrns,
   findNodeByUrn,
@@ -52,7 +53,6 @@ import {
   shouldShowBadgeDot,
   updateNodeStatus,
 } from "./treeUtils";
-import { TreeResourceChangeIndicator } from "./TreeResourceChangeIndicator";
 import { CustomTreeDataNode, TreeNodeAction } from "./types";
 import { intoDiffStatus } from "./utils";
 


### PR DESCRIPTION
Ticket [ENG-3232]

> **Companion PR:** Requires [fidesplus#3487](https://github.com/ethyca/fidesplus/pull/3487) for backend endpoint removal detection

### Description Of Changes

Fixes a bug where the "Remove" action on tree nodes in the action center was always disabled, preventing users from promoting endpoint removals from the schema explorer tree.

The root cause: `mapResponseToTreeData` in `MonitorTree.tsx` populates `diffStatus` on tree nodes but never sets the `status` field. The disabled check in `page.tsx` reads `node.status` (type `TreeResourceChangeIndicator`), which was always `undefined`, so the "Remove" action was permanently greyed out.

### Code Changes

* **`MonitorTree.tsx`**: Add import for `TreeResourceChangeIndicator` and populate the `status` field on tree nodes when `diff_status === REMOVAL`

### Steps to Confirm

1. Set up a Salesforce (or any SaaS) monitor with a promoted endpoint
2. Delete the corresponding object from the external system
3. Run a detection scan — the endpoint should appear with `removal` status in the tree
4. Right-click the endpoint in the schema explorer tree → "Show More Resource Actions"
5. Verify the **"Remove"** action is **enabled** (not greyed out)
6. Click "Remove" — the endpoint and its fields should be deleted from staged resources and the dataset collection should be removed

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* Documentation:
  * [x] No documentation updates required
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`
  * [ ] Add a `db-migration` label to the entry if your change includes a DB migration
  * [ ] Add a `high-risk` label to the entry if your change includes a high-risk change

[ENG-3232]: https://ethyca.atlassian.net/browse/ENG-3232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ