### PR TITLE
ENG-3645: Default DynamoDB single_dataset to true

### DIFF
--- a/changelog/8084-dynamodb-monitor-default-single-dataset.yaml
+++ b/changelog/8084-dynamodb-monitor-default-single-dataset.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Default `single_dataset` to `true` for new DynamoDB monitors so classification no longer silently fails on duplicate schema/table names.
+pr: 8084
+labels: []

--- a/clients/admin-ui/src/features/integrations/configure-monitor/ConfigureMonitorForm.tsx
+++ b/clients/admin-ui/src/features/integrations/configure-monitor/ConfigureMonitorForm.tsx
@@ -143,7 +143,7 @@ const ConfigureMonitorForm = ({
 
     if (integrationOption.identifier === ConnectionType.DYNAMODB) {
       payload.datasource_params = {
-        single_dataset: false,
+        single_dataset: true,
       };
     }
     if (databasesAvailable) {


### PR DESCRIPTION
## Summary

- Change the frontend default for DynamoDB monitors from `single_dataset: false` to `single_dataset: true`
- This sidesteps a URN construction bug where duplicate schema/table names cause classification to silently fail
- The `single_dataset=true` mode was already recommended by the team in ENG-2579

## Companion PR

- fidesplus: ethyca/fidesplus#3503 (fixes the underlying URN construction bug for `single_dataset=false`)

## Steps to Confirm

1. Create a new DynamoDB monitor in the Admin UI
2. Verify the monitor payload includes `single_dataset: true` in `datasource_params`

🤖 Generated with [Claude Code](https://claude.com/claude-code)