### PR TITLE
Require integration name when adding from system form

### DIFF
--- a/changelog/8085-require-integration-name-on-system-form.yaml
+++ b/changelog/8085-require-integration-name-on-system-form.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Integrations created from a system's Integrations tab now require a name, so they no longer appear as "(No name)" on the integrations list
+pr: 8085
+labels: []

--- a/clients/admin-ui/cypress/e2e/system-integrations.cy.ts
+++ b/clients/admin-ui/cypress/e2e/system-integrations.cy.ts
@@ -105,6 +105,7 @@ describe("System integrations", () => {
           connection_type: "postgres",
           description: "",
           key: "asdasd_postgres",
+          name: "asdasd_postgres",
           enabled_actions: [],
         });
         expect(request.body[0].disabled).to.be.undefined;

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParameters.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParameters.tsx
@@ -71,7 +71,8 @@ const createSaasConnector = async (
   systemFidesKey: string,
   createSaasConnectorFunc: any,
 ) => {
-  const connectionConfig: Omit<CreateSaasConnectionConfigRequest, "name"> = {
+  const connectionConfig: CreateSaasConnectionConfigRequest = {
+    name: values.name!,
     description: values.description || "",
     instance_key: generateIntegrationKey(systemFidesKey, connectionOption),
     saas_connector_type: connectionOption.identifier,
@@ -111,18 +112,18 @@ export const patchConnectionConfig = async (
     : generateIntegrationKey(systemFidesKey, connectionOption);
 
   // the enabled_actions are conditionally added if plus is enabled
-  const params1: Omit<ConnectionConfigurationResponse, "created_at" | "name"> =
-    {
-      access: AccessLevel.WRITE,
-      connection_type: (connectionOption.type === SystemType.SAAS
-        ? connectionOption.type
-        : connectionOption.identifier) as ConnectionType,
-      description: values.description,
-      key,
-      ...(values.enabled_actions
-        ? { enabled_actions: values.enabled_actions as ActionType[] }
-        : {}),
-    };
+  const params1: Omit<ConnectionConfigurationResponse, "created_at"> = {
+    access: AccessLevel.WRITE,
+    connection_type: (connectionOption.type === SystemType.SAAS
+      ? connectionOption.type
+      : connectionOption.identifier) as ConnectionType,
+    description: values.description,
+    key,
+    name: values.name!,
+    ...(values.enabled_actions
+      ? { enabled_actions: values.enabled_actions as ActionType[] }
+      : {}),
+  };
   const payload = await patchFunc({
     systemFidesKey,
     connectionConfigs: [params1],

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParametersForm.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParametersForm.tsx
@@ -127,7 +127,7 @@ export const ConnectorParametersForm = ({
   const initialFormValues = useMemo(() => {
     const values = { ...defaultValues };
     if (connectionConfig?.key) {
-      values.name = connectionConfig.name ?? "";
+      values.name = connectionConfig.name || connectionConfig.key;
       values.description = connectionConfig.description as string;
       values.instance_key =
         connectionConfig.connection_type === ConnectionType.SAAS
@@ -293,10 +293,14 @@ export const ConnectorParametersForm = ({
         labelAlign="left"
       >
         <Flex vertical>
-          {/* Hidden fields to preserve values in form submission */}
-          <Form.Item name="name" hidden noStyle>
-            <Input />
+          <Form.Item
+            name="name"
+            label="Name"
+            rules={[{ required: true, message: "Name is required" }]}
+          >
+            <Input data-testid="input-name" />
           </Form.Item>
+          {/* Hidden field to preserve description in form submission */}
           <Form.Item name="description" hidden noStyle>
             <Input />
           </Form.Item>


### PR DESCRIPTION
Ticket [ENG-3699](https://ethyca.atlassian.net/browse/ENG-3699)

### Description Of Changes

Previously, when a user added an integration from a system's Integrations tab (`/systems/configure/[id]` → Integrations), the form did not collect a name. The `name` field was rendered as a hidden `Form.Item` and was explicitly omitted from the create payloads. As a result, those integrations were saved without a name and showed up as "(No name)" on the standalone Integrations list.

This change makes the Name field visible and required in the system-form integration form, matching the standalone "Add Integration" flow. It also pre-fills the field with the connection key when editing an existing nameless integration, so users with pre-existing "(No name)" integrations can keep their current key as the name (or rename it) without being blocked from saving / testing / authorizing.

### Code Changes

* `clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParametersForm.tsx`:
  * Replaced the hidden `name` `Form.Item` with a visible field using `rules={[{ required: true, message: "Name is required" }]}` (matches the styling/validation of the standalone form).
  * In `initialFormValues`, fall back to `connectionConfig.key` when `connectionConfig.name` is null/empty so existing nameless integrations get a sensible default in the field.
* `clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParameters.tsx`:
  * Dropped the `Omit<..., "name">` typing on both create payloads (`createSaasConnector` and `patchConnectionConfig`) and added `name: values.name` so the user-entered name is sent to the backend.

### Steps to Confirm

1. Navigate to **Systems** → pick any system → **Integrations** tab → choose an integration type to add.
2. Confirm a **Name** field is now visible at the top of the form, marked required.
3. Try to save without filling it in — confirm the form blocks submission with "Name is required".
4. Fill in a name, save, and navigate to the **Integrations** page. Confirm the new integration appears with the name you provided (not "(No name)").
5. For an existing integration that previously had no name (e.g., one created before this change), open it from the system form. Confirm the Name field is pre-populated with the integration's key. Save the form (no other changes) and confirm it now displays its key as the name on the Integrations page.
6. Smoke-test the standalone "Add Integration" flow on `/integrations` to confirm it still works as before.

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a `db-migration` label to the entry if your change includes a DB migration
  * [ ] Add a `high-risk` label to the entry if your change includes a high-risk change
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, PR opened in fidesdocs
  * [ ] Documentation issue created in fidesdocs
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required

[ENG-3699]: https://ethyca.atlassian.net/browse/ENG-3699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ