### PR TITLE
Improve activity log step names

### DIFF
--- a/changelog/8088-privacy-request-activity-timeline-labels.yaml
+++ b/changelog/8088-privacy-request-activity-timeline-labels.yaml
@@ -1,0 +1,7 @@
+type: Changed
+description: >
+  Improved privacy request activity timeline labels: render policy_evaluated and
+  finished audit log actions with human-readable text, and rename
+  "Dataset reference validation" to "Planning request execution"
+pr: 8088
+labels: []

--- a/changelog/8088-privacy-request-activity-timeline-labels.yaml
+++ b/changelog/8088-privacy-request-activity-timeline-labels.yaml
@@ -2,6 +2,6 @@ type: Changed
 description: >
   Improved privacy request activity timeline labels: render policy_evaluated and
   finished audit log actions with human-readable text, and rename
-  "Dataset reference validation" to "Planning request execution"
+  "Dataset reference validation" to "Request execution plan"
 pr: 8088
 labels: []

--- a/changelog/8088-privacy-request-activity-timeline-labels.yaml
+++ b/changelog/8088-privacy-request-activity-timeline-labels.yaml
@@ -1,7 +1,7 @@
 type: Changed
 description: >
-  Improved privacy request activity timeline labels: render policy_evaluated and
-  finished audit log actions with human-readable text, and rename
-  "Dataset reference validation" to "Request execution plan"
+  Improved privacy request activity timeline labels: render email_sent,
+  finished, and policy_evaluated audit log actions with human-readable text,
+  and rename "Dataset reference validation" to "Request execution plan"
 pr: 8088
 labels: []

--- a/clients/admin-ui/cypress/fixtures/privacy-requests/with-logs.json
+++ b/clients/admin-ui/cypress/fixtures/privacy-requests/with-logs.json
@@ -81,12 +81,12 @@
             "user_id": null
           }
         ],
-        "Dataset reference validation": [
+        "Planning request execution": [
           {
             "connection_key": null,
             "collection_name": null,
             "fields_affected": null,
-            "message": "Dataset reference validation successful for privacy request: pri_96bb91d3-cdb9-46c3-9546-0c276eb05a5c",
+            "message": "Planning request execution successful for privacy request: pri_96bb91d3-cdb9-46c3-9546-0c276eb05a5c",
             "action_type": "erasure",
             "status": "complete",
             "updated_at": "2025-04-07T17:47:10.932124Z",

--- a/clients/admin-ui/cypress/fixtures/privacy-requests/with-logs.json
+++ b/clients/admin-ui/cypress/fixtures/privacy-requests/with-logs.json
@@ -81,12 +81,12 @@
             "user_id": null
           }
         ],
-        "Planning request execution": [
+        "Request execution plan": [
           {
             "connection_key": null,
             "collection_name": null,
             "fields_affected": null,
-            "message": "Planning request execution successful for privacy request: pri_96bb91d3-cdb9-46c3-9546-0c276eb05a5c",
+            "message": "Request execution plan successful for privacy request: pri_96bb91d3-cdb9-46c3-9546-0c276eb05a5c",
             "action_type": "erasure",
             "status": "complete",
             "updated_at": "2025-04-07T17:47:10.932124Z",

--- a/src/fides/api/service/privacy_request/request_runner_service.py
+++ b/src/fides/api/service/privacy_request/request_runner_service.py
@@ -606,9 +606,9 @@ def run_privacy_request(
                 privacy_request.add_success_execution_log(
                     session,
                     connection_key=None,
-                    dataset_name="Dataset reference validation",
+                    dataset_name="Planning request execution",
                     collection_name=None,
-                    message=f"Dataset reference validation successful for privacy request: {privacy_request.id}",
+                    message=f"Planning request execution successful for privacy request: {privacy_request.id}",
                     action_type=privacy_request.policy.get_action_type(),  # type: ignore
                 )
 
@@ -769,7 +769,7 @@ def run_privacy_request(
                 privacy_request.add_error_execution_log(
                     session,
                     connection_key=None,
-                    dataset_name="Dataset reference validation",
+                    dataset_name="Planning request execution",
                     collection_name=None,
                     message=str(exc),
                     action_type=privacy_request.policy.get_action_type(),  # type: ignore[arg-type]

--- a/src/fides/api/service/privacy_request/request_runner_service.py
+++ b/src/fides/api/service/privacy_request/request_runner_service.py
@@ -606,9 +606,9 @@ def run_privacy_request(
                 privacy_request.add_success_execution_log(
                     session,
                     connection_key=None,
-                    dataset_name="Planning request execution",
+                    dataset_name="Request execution plan",
                     collection_name=None,
-                    message=f"Planning request execution successful for privacy request: {privacy_request.id}",
+                    message=f"Request execution plan successful for privacy request: {privacy_request.id}",
                     action_type=privacy_request.policy.get_action_type(),  # type: ignore
                 )
 
@@ -769,7 +769,7 @@ def run_privacy_request(
                 privacy_request.add_error_execution_log(
                     session,
                     connection_key=None,
-                    dataset_name="Planning request execution",
+                    dataset_name="Request execution plan",
                     collection_name=None,
                     message=str(exc),
                     action_type=privacy_request.policy.get_action_type(),  # type: ignore[arg-type]

--- a/src/fides/api/service/privacy_request/request_service.py
+++ b/src/fides/api/service/privacy_request/request_service.py
@@ -866,6 +866,8 @@ def batch_execution_and_audit_logs_by_dataset(
     audit_log_display_names = {
         "approved": "Request approved",
         "denied": "Request denied",
+        "finished": "Request finished",
+        "policy_evaluated": "Request policy evaluated",
         "pre_approval_webhook_triggered": "Triggered pre-approval webhooks",
         "pre_approval_eligible": "Request auto-approved by pre-approval webhooks",
         "pre_approval_not_eligible": "Request flagged for manual review by pre-approval webhooks",

--- a/src/fides/api/service/privacy_request/request_service.py
+++ b/src/fides/api/service/privacy_request/request_service.py
@@ -866,6 +866,7 @@ def batch_execution_and_audit_logs_by_dataset(
     audit_log_display_names = {
         "approved": "Request approved",
         "denied": "Request denied",
+        "email_sent": "Email sent",
         "finished": "Request finished",
         "policy_evaluated": "Request policy evaluated",
         "pre_approval_webhook_triggered": "Triggered pre-approval webhooks",

--- a/src/fides/api/service/privacy_request/request_service.py
+++ b/src/fides/api/service/privacy_request/request_service.py
@@ -806,6 +806,21 @@ def requeue_polling_tasks(self: DatabaseTask) -> None:
 
 EMBEDDED_EXECUTION_LOG_LIMIT = 1000
 
+# Display names for AuditLogAction values when rendering audit log rows in the
+# privacy request activity timeline. Keys must cover every AuditLogAction;
+# missing keys fall back to a raw `f"Request {action}"` rendering. A test in
+# tests/ops/service/privacy_request/test_request_service.py guards against drift.
+AUDIT_LOG_DISPLAY_NAMES = {
+    "approved": "Request approved",
+    "denied": "Request denied",
+    "email_sent": "Email sent",
+    "finished": "Request finished",
+    "policy_evaluated": "Request policy evaluated",
+    "pre_approval_webhook_triggered": "Triggered pre-approval webhooks",
+    "pre_approval_eligible": "Request auto-approved by pre-approval webhooks",
+    "pre_approval_not_eligible": "Request flagged for manual review by pre-approval webhooks",
+}
+
 
 def batch_execution_and_audit_logs_by_dataset(
     db: Session,
@@ -863,23 +878,12 @@ def batch_execution_and_audit_logs_by_dataset(
 
     result: Dict[str, DefaultDict[str, List[Union["AuditLog", "ExecutionLog"]]]] = {}
 
-    audit_log_display_names = {
-        "approved": "Request approved",
-        "denied": "Request denied",
-        "email_sent": "Email sent",
-        "finished": "Request finished",
-        "policy_evaluated": "Request policy evaluated",
-        "pre_approval_webhook_triggered": "Triggered pre-approval webhooks",
-        "pre_approval_eligible": "Request auto-approved by pre-approval webhooks",
-        "pre_approval_not_eligible": "Request flagged for manual review by pre-approval webhooks",
-    }
-
     for log in combined.order_by(ExecutionLog.updated_at.asc()):
         pr_id = log.privacy_request_id
         if pr_id not in result:
             result[pr_id] = defaultdict(list)
 
-        dataset_name: str = log.dataset_name or audit_log_display_names.get(
+        dataset_name: str = log.dataset_name or AUDIT_LOG_DISPLAY_NAMES.get(
             log.status, f"Request {log.status}"
         )
 

--- a/tests/ops/service/privacy_request/test_postgres_privacy_requests.py
+++ b/tests/ops/service/privacy_request/test_postgres_privacy_requests.py
@@ -404,7 +404,7 @@ def test_create_and_process_access_request_postgres_with_disabled_integration(
     }
 
     assert logs == {
-        ("Dataset reference validation", "complete", None),
+        ("Planning request execution", "complete", None),
         ("Access package upload", "complete", None),
         (
             "Dataset traversal",
@@ -437,9 +437,9 @@ def test_create_and_process_access_request_postgres_with_disabled_integration(
     logs = get_sorted_execution_logs(db, pr)
 
     assert logs == [
-        ("Dataset reference validation", "complete"),
+        ("Planning request execution", "complete"),
         ("Dataset traversal", "complete"),
-        ("Dataset reference validation", "complete"),
+        ("Planning request execution", "complete"),
         ("Access package upload", "complete"),
     ]
 

--- a/tests/ops/service/privacy_request/test_postgres_privacy_requests.py
+++ b/tests/ops/service/privacy_request/test_postgres_privacy_requests.py
@@ -404,7 +404,7 @@ def test_create_and_process_access_request_postgres_with_disabled_integration(
     }
 
     assert logs == {
-        ("Planning request execution", "complete", None),
+        ("Request execution plan", "complete", None),
         ("Access package upload", "complete", None),
         (
             "Dataset traversal",
@@ -437,9 +437,9 @@ def test_create_and_process_access_request_postgres_with_disabled_integration(
     logs = get_sorted_execution_logs(db, pr)
 
     assert logs == [
-        ("Planning request execution", "complete"),
+        ("Request execution plan", "complete"),
         ("Dataset traversal", "complete"),
-        ("Planning request execution", "complete"),
+        ("Request execution plan", "complete"),
         ("Access package upload", "complete"),
     ]
 

--- a/tests/ops/service/privacy_request/test_request_runner_service.py
+++ b/tests/ops/service/privacy_request/test_request_runner_service.py
@@ -2242,7 +2242,7 @@ class TestDatasetReferenceValidation:
         validation_logs = [
             log
             for log in success_logs
-            if log.dataset_name == "Dataset reference validation"
+            if log.dataset_name == "Planning request execution"
         ]
 
         assert len(validation_logs) == 1
@@ -2251,7 +2251,7 @@ class TestDatasetReferenceValidation:
         assert log.collection_name is None
         assert (
             log.message
-            == f"Dataset reference validation successful for privacy request: {privacy_request.id}"
+            == f"Planning request execution successful for privacy request: {privacy_request.id}"
         )
         assert log.action_type == privacy_request.policy.get_action_type()
 
@@ -2289,7 +2289,7 @@ class TestDatasetReferenceValidation:
         validation_logs = [
             log
             for log in error_logs
-            if log.dataset_name == "Dataset reference validation"
+            if log.dataset_name == "Planning request execution"
         ]
 
         assert len(validation_logs) == 1

--- a/tests/ops/service/privacy_request/test_request_runner_service.py
+++ b/tests/ops/service/privacy_request/test_request_runner_service.py
@@ -2240,9 +2240,7 @@ class TestDatasetReferenceValidation:
         success_logs = privacy_request.execution_logs.filter_by(status="complete").all()
 
         validation_logs = [
-            log
-            for log in success_logs
-            if log.dataset_name == "Request execution plan"
+            log for log in success_logs if log.dataset_name == "Request execution plan"
         ]
 
         assert len(validation_logs) == 1
@@ -2287,9 +2285,7 @@ class TestDatasetReferenceValidation:
         error_logs = privacy_request.execution_logs.filter_by(status="error").all()
 
         validation_logs = [
-            log
-            for log in error_logs
-            if log.dataset_name == "Request execution plan"
+            log for log in error_logs if log.dataset_name == "Request execution plan"
         ]
 
         assert len(validation_logs) == 1

--- a/tests/ops/service/privacy_request/test_request_runner_service.py
+++ b/tests/ops/service/privacy_request/test_request_runner_service.py
@@ -2242,7 +2242,7 @@ class TestDatasetReferenceValidation:
         validation_logs = [
             log
             for log in success_logs
-            if log.dataset_name == "Planning request execution"
+            if log.dataset_name == "Request execution plan"
         ]
 
         assert len(validation_logs) == 1
@@ -2251,7 +2251,7 @@ class TestDatasetReferenceValidation:
         assert log.collection_name is None
         assert (
             log.message
-            == f"Planning request execution successful for privacy request: {privacy_request.id}"
+            == f"Request execution plan successful for privacy request: {privacy_request.id}"
         )
         assert log.action_type == privacy_request.policy.get_action_type()
 
@@ -2289,7 +2289,7 @@ class TestDatasetReferenceValidation:
         validation_logs = [
             log
             for log in error_logs
-            if log.dataset_name == "Planning request execution"
+            if log.dataset_name == "Request execution plan"
         ]
 
         assert len(validation_logs) == 1

--- a/tests/ops/service/privacy_request/test_request_runner_service.py
+++ b/tests/ops/service/privacy_request/test_request_runner_service.py
@@ -2216,12 +2216,12 @@ class TestAsyncCallbacks:
         assert pr.erasure_tasks[1].status == ExecutionLogStatus.complete
 
 
-class TestDatasetReferenceValidation:
+class TestRequestExecutionPlan:
     @pytest.mark.usefixtures("dataset_config")
     @mock.patch(
         "fides.api.service.privacy_request.request_runner_service.access_runner"
     )
-    def test_dataset_reference_validation_success(
+    def test_request_execution_plan_success(
         self,
         run_access,
         db: Session,
@@ -2229,7 +2229,7 @@ class TestDatasetReferenceValidation:
         run_privacy_request_task,
         request,
     ):
-        """Test that successful dataset reference validation is logged"""
+        """Test that a successful request execution plan is logged"""
 
         # Run privacy request
         run_privacy_request_task.delay(privacy_request.id).get(
@@ -2256,7 +2256,7 @@ class TestDatasetReferenceValidation:
     @mock.patch(
         "fides.api.service.privacy_request.request_runner_service.access_runner"
     )
-    def test_dataset_reference_validation_error(
+    def test_request_execution_plan_error(
         self,
         run_access,
         db: Session,
@@ -2265,7 +2265,7 @@ class TestDatasetReferenceValidation:
         run_privacy_request_task,
         request,
     ):
-        """Test that dataset reference validation errors are logged"""
+        """Test that request execution plan errors are logged"""
 
         # Add invalid dataset reference that will cause validation error
         dataset_config.ctl_dataset.collections[0]["fields"][0]["fides_meta"] = {

--- a/tests/ops/service/privacy_request/test_request_service.py
+++ b/tests/ops/service/privacy_request/test_request_service.py
@@ -1053,9 +1053,7 @@ class TestBatchExecutionAndAuditLogsByDataset:
             },
         )
         try:
-            result = batch_execution_and_audit_logs_by_dataset(
-                db, [privacy_request.id]
-            )
+            result = batch_execution_and_audit_logs_by_dataset(db, [privacy_request.id])
             assert expected_key in result[privacy_request.id]
         finally:
             audit_log.delete(db)

--- a/tests/ops/service/privacy_request/test_request_service.py
+++ b/tests/ops/service/privacy_request/test_request_service.py
@@ -8,6 +8,7 @@ from httpx import HTTPStatusError
 
 from fides.api.cryptography.cryptographic_util import str_to_b64_str
 from fides.api.db.seed import create_or_update_parent_user
+from fides.api.models.audit_log import AuditLog, AuditLogAction
 from fides.api.models.privacy_request import PrivacyRequest, RequestTask
 from fides.api.models.worker_task import ExecutionLogStatus
 from fides.api.schemas.policy import ActionType
@@ -15,6 +16,7 @@ from fides.api.schemas.privacy_request import PrivacyRequestStatus
 from fides.api.service.connectors.fides.fides_client import poll_server_for_completion
 from fides.api.service.privacy_request.request_service import (
     _handle_privacy_request_requeue,
+    batch_execution_and_audit_logs_by_dataset,
     build_required_privacy_request_kwargs,
     get_cached_task_id,
     poll_for_exited_privacy_request_tasks,
@@ -1010,3 +1012,50 @@ class TestRequeueInterruptedTasksAdditionalCoverage:
                     "is not in the queue or running" in call for call in warning_calls
                 )
                 mock_handle_requeue.assert_called_once_with(db, privacy_request)
+
+
+class TestBatchExecutionAndAuditLogsByDataset:
+    """Test that every AuditLogAction has a display-name mapping, so new
+    actions don't silently fall through to the raw snake_case
+    `f"Request {status}"` fallback."""
+
+    @pytest.mark.parametrize(
+        "action,expected_key",
+        [
+            (AuditLogAction.approved, "Request approved"),
+            (AuditLogAction.denied, "Request denied"),
+            (AuditLogAction.finished, "Request finished"),
+            (AuditLogAction.policy_evaluated, "Request policy evaluated"),
+            (
+                AuditLogAction.pre_approval_webhook_triggered,
+                "Triggered pre-approval webhooks",
+            ),
+            (
+                AuditLogAction.pre_approval_eligible,
+                "Request auto-approved by pre-approval webhooks",
+            ),
+            (
+                AuditLogAction.pre_approval_not_eligible,
+                "Request flagged for manual review by pre-approval webhooks",
+            ),
+        ],
+    )
+    def test_audit_log_action_display_names(
+        self, db, privacy_request, action, expected_key
+    ):
+        audit_log = AuditLog.create(
+            db=db,
+            data={
+                "user_id": "system",
+                "privacy_request_id": privacy_request.id,
+                "action": action,
+                "message": "",
+            },
+        )
+        try:
+            result = batch_execution_and_audit_logs_by_dataset(
+                db, [privacy_request.id]
+            )
+            assert expected_key in result[privacy_request.id]
+        finally:
+            audit_log.delete(db)

--- a/tests/ops/service/privacy_request/test_request_service.py
+++ b/tests/ops/service/privacy_request/test_request_service.py
@@ -1014,32 +1014,33 @@ class TestRequeueInterruptedTasksAdditionalCoverage:
                 mock_handle_requeue.assert_called_once_with(db, privacy_request)
 
 
+EXPECTED_AUDIT_LOG_DISPLAY_NAMES = [
+    (AuditLogAction.approved, "Request approved"),
+    (AuditLogAction.denied, "Request denied"),
+    (AuditLogAction.email_sent, "Email sent"),
+    (AuditLogAction.finished, "Request finished"),
+    (AuditLogAction.policy_evaluated, "Request policy evaluated"),
+    (
+        AuditLogAction.pre_approval_webhook_triggered,
+        "Triggered pre-approval webhooks",
+    ),
+    (
+        AuditLogAction.pre_approval_eligible,
+        "Request auto-approved by pre-approval webhooks",
+    ),
+    (
+        AuditLogAction.pre_approval_not_eligible,
+        "Request flagged for manual review by pre-approval webhooks",
+    ),
+]
+
+
 class TestBatchExecutionAndAuditLogsByDataset:
     """Test that every AuditLogAction has a display-name mapping, so new
     actions don't silently fall through to the raw snake_case
     `f"Request {status}"` fallback."""
 
-    @pytest.mark.parametrize(
-        "action,expected_key",
-        [
-            (AuditLogAction.approved, "Request approved"),
-            (AuditLogAction.denied, "Request denied"),
-            (AuditLogAction.finished, "Request finished"),
-            (AuditLogAction.policy_evaluated, "Request policy evaluated"),
-            (
-                AuditLogAction.pre_approval_webhook_triggered,
-                "Triggered pre-approval webhooks",
-            ),
-            (
-                AuditLogAction.pre_approval_eligible,
-                "Request auto-approved by pre-approval webhooks",
-            ),
-            (
-                AuditLogAction.pre_approval_not_eligible,
-                "Request flagged for manual review by pre-approval webhooks",
-            ),
-        ],
-    )
+    @pytest.mark.parametrize("action,expected_key", EXPECTED_AUDIT_LOG_DISPLAY_NAMES)
     def test_audit_log_action_display_names(
         self, db, privacy_request, action, expected_key
     ):
@@ -1057,3 +1058,12 @@ class TestBatchExecutionAndAuditLogsByDataset:
             assert expected_key in result[privacy_request.id]
         finally:
             audit_log.delete(db)
+
+    def test_parametrize_covers_every_audit_log_action(self):
+        """Guard against drift: every AuditLogAction enum value must appear
+        in EXPECTED_AUDIT_LOG_DISPLAY_NAMES. If this fails after adding a
+        new action, add the action + expected display name to the list."""
+        parametrized = {action for action, _ in EXPECTED_AUDIT_LOG_DISPLAY_NAMES}
+        assert set(AuditLogAction) == parametrized, (
+            f"Missing from parametrize: {set(AuditLogAction) - parametrized}"
+        )

--- a/tests/ops/service/privacy_request/test_request_service.py
+++ b/tests/ops/service/privacy_request/test_request_service.py
@@ -8,15 +8,15 @@ from httpx import HTTPStatusError
 
 from fides.api.cryptography.cryptographic_util import str_to_b64_str
 from fides.api.db.seed import create_or_update_parent_user
-from fides.api.models.audit_log import AuditLog, AuditLogAction
+from fides.api.models.audit_log import AuditLogAction
 from fides.api.models.privacy_request import PrivacyRequest, RequestTask
 from fides.api.models.worker_task import ExecutionLogStatus
 from fides.api.schemas.policy import ActionType
 from fides.api.schemas.privacy_request import PrivacyRequestStatus
 from fides.api.service.connectors.fides.fides_client import poll_server_for_completion
 from fides.api.service.privacy_request.request_service import (
+    AUDIT_LOG_DISPLAY_NAMES,
     _handle_privacy_request_requeue,
-    batch_execution_and_audit_logs_by_dataset,
     build_required_privacy_request_kwargs,
     get_cached_task_id,
     poll_for_exited_privacy_request_tasks,
@@ -1014,56 +1014,11 @@ class TestRequeueInterruptedTasksAdditionalCoverage:
                 mock_handle_requeue.assert_called_once_with(db, privacy_request)
 
 
-EXPECTED_AUDIT_LOG_DISPLAY_NAMES = [
-    (AuditLogAction.approved, "Request approved"),
-    (AuditLogAction.denied, "Request denied"),
-    (AuditLogAction.email_sent, "Email sent"),
-    (AuditLogAction.finished, "Request finished"),
-    (AuditLogAction.policy_evaluated, "Request policy evaluated"),
-    (
-        AuditLogAction.pre_approval_webhook_triggered,
-        "Triggered pre-approval webhooks",
-    ),
-    (
-        AuditLogAction.pre_approval_eligible,
-        "Request auto-approved by pre-approval webhooks",
-    ),
-    (
-        AuditLogAction.pre_approval_not_eligible,
-        "Request flagged for manual review by pre-approval webhooks",
-    ),
-]
-
-
-class TestBatchExecutionAndAuditLogsByDataset:
-    """Test that every AuditLogAction has a display-name mapping, so new
-    actions don't silently fall through to the raw snake_case
-    `f"Request {status}"` fallback."""
-
-    @pytest.mark.parametrize("action,expected_key", EXPECTED_AUDIT_LOG_DISPLAY_NAMES)
-    def test_audit_log_action_display_names(
-        self, db, privacy_request, action, expected_key
-    ):
-        audit_log = AuditLog.create(
-            db=db,
-            data={
-                "user_id": "system",
-                "privacy_request_id": privacy_request.id,
-                "action": action,
-                "message": "",
-            },
-        )
-        try:
-            result = batch_execution_and_audit_logs_by_dataset(db, [privacy_request.id])
-            assert expected_key in result[privacy_request.id]
-        finally:
-            audit_log.delete(db)
-
-    def test_parametrize_covers_every_audit_log_action(self):
-        """Guard against drift: every AuditLogAction enum value must appear
-        in EXPECTED_AUDIT_LOG_DISPLAY_NAMES. If this fails after adding a
-        new action, add the action + expected display name to the list."""
-        parametrized = {action for action, _ in EXPECTED_AUDIT_LOG_DISPLAY_NAMES}
-        assert set(AuditLogAction) == parametrized, (
-            f"Missing from parametrize: {set(AuditLogAction) - parametrized}"
-        )
+def test_audit_log_display_names_covers_every_action():
+    """Every AuditLogAction must have a display-name mapping, so new actions
+    don't silently fall through to the raw `f"Request {action}"` fallback in
+    batch_execution_and_audit_logs_by_dataset. If this fails, add the new
+    action to AUDIT_LOG_DISPLAY_NAMES in request_service.py."""
+    assert {action.value for action in AuditLogAction} == set(
+        AUDIT_LOG_DISPLAY_NAMES
+    )

--- a/tests/ops/service/privacy_request/test_request_service.py
+++ b/tests/ops/service/privacy_request/test_request_service.py
@@ -1019,6 +1019,4 @@ def test_audit_log_display_names_covers_every_action():
     don't silently fall through to the raw `f"Request {action}"` fallback in
     batch_execution_and_audit_logs_by_dataset. If this fails, add the new
     action to AUDIT_LOG_DISPLAY_NAMES in request_service.py."""
-    assert {action.value for action in AuditLogAction} == set(
-        AUDIT_LOG_DISPLAY_NAMES
-    )
+    assert {action.value for action in AuditLogAction} == set(AUDIT_LOG_DISPLAY_NAMES)


### PR DESCRIPTION
There are a few cases of audit log titles that mix human-readable sentence case with internal snake_case_identifiers.

### Description Of Changes

<!-- Write some things about the changes and any potential caveats -->

Audit log entries are surfaced in the privacy request `results` dict keyed by a synthetic dataset name. Actions missing from `audit_log_display_names` fall through to `f"Request {status}"`, exposing the raw snake_case enum value in the activity timeline (e.g. "Request policy_evaluated"). This PR adds explicit display names for actions that produce fallback snake_case_labels.

This PR also changes the ambiguous, jargon-heavy name of "Dataset reference validation" to the more understandable "Request execution plan".

<img width="601" height="252" alt="image" src="https://github.com/user-attachments/assets/6cb44b04-c451-4460-84af-262362768d16" />


### Code Changes

* <!-- list your code changes -->

### Steps to Confirm

<img width="610" height="89" alt="image" src="https://github.com/user-attachments/assets/cbf5131d-70c0-4a8d-bbe1-5c62b68dbd99" />

<img width="606" height="119" alt="image" src="https://github.com/user-attachments/assets/52801cfc-0c86-4b0d-81c7-c13342a1b4f2" />


### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
