### PR TITLE
ENG-3517: Per-field FileUpload size/type limits + context-bound attachments

### DIFF
--- a/changelog/8090-file-upload-per-field-limits.yaml
+++ b/changelog/8090-file-upload-per-field-limits.yaml
@@ -1,0 +1,4 @@
+type: Added
+description: Per-field upload size/file-type limits + context-bound privacy-request attachments
+pr: 8090
+labels: []

--- a/src/fides/api/schemas/privacy_center_config.py
+++ b/src/fides/api/schemas/privacy_center_config.py
@@ -106,29 +106,27 @@ class LocationCustomPrivacyRequestField(BaseCustomPrivacyRequestField):
         return values
 
 
-DEFAULT_FILE_MAX_SIZE_BYTES = 10 * 1024 * 1024  # 10 MB
+def _default_file_max_size_bytes() -> int:
+    # Local import: avoid pulling storage modules at schema import time.
+    from fides.api.service.storage.util import DEFAULT_FILE_MAX_SIZE_BYTES
+
+    return DEFAULT_FILE_MAX_SIZE_BYTES
 
 
-def _default_allowed_mime_types() -> list[str]:
-    # Import locally to avoid pulling storage/service modules at schema import time.
-    from fides.api.service.storage.util import AllowedFileType, FilesMagicBytes
+def _default_allowed_file_types() -> list[str]:
+    from fides.api.service.storage.util import AllowedFileType
 
-    return sorted(
-        {
-            AllowedFileType[ext].value
-            for ext in FilesMagicBytes.default_public_upload_allowed_file_types()
-        }
-    )
+    return sorted(AllowedFileType.default_public_upload_allowed_file_types())
 
 
 class FileUploadCustomPrivacyRequestField(BaseCustomPrivacyRequestField):
-    """File upload field. ``max_size_bytes`` + ``allowed_mime_types`` are
-    client-side hints; upload endpoint enforces the global defaults."""
+    """File upload field. ``max_size_bytes`` and ``allowed_file_types``
+    drive client hints and per-field upload enforcement."""
 
     field_type: Literal["file"] = "file"
     required: Optional[bool] = False
-    max_size_bytes: int = Field(default=DEFAULT_FILE_MAX_SIZE_BYTES, gt=0)
-    allowed_mime_types: list[str] = Field(default_factory=_default_allowed_mime_types)
+    max_size_bytes: int = Field(default_factory=_default_file_max_size_bytes, gt=0)
+    allowed_file_types: list[str] = Field(default_factory=_default_allowed_file_types)
 
     @model_validator(mode="before")
     @classmethod
@@ -137,16 +135,18 @@ class FileUploadCustomPrivacyRequestField(BaseCustomPrivacyRequestField):
             raise ValueError("file fields do not support options")
         return values
 
-    @field_validator("allowed_mime_types")
+    @field_validator("allowed_file_types")
     @classmethod
-    def validate_allowed_mime_types(cls, v: list[str]) -> list[str]:
-        supported = set(_default_allowed_mime_types())
+    def validate_allowed_file_types(cls, v: list[str]) -> list[str]:
+        from fides.api.service.storage.util import AllowedFileType
+
+        supported = AllowedFileType.supported_file_types()
         if not v:
-            raise ValueError("allowed_mime_types must not be empty")
-        unsupported = [mime for mime in v if mime not in supported]
+            raise ValueError("allowed_file_types must not be empty")
+        unsupported = [ext for ext in v if ext not in supported]
         if unsupported:
             raise ValueError(
-                f"Unsupported MIME types: {sorted(unsupported)}. "
+                f"Unsupported file types: {sorted(unsupported)}. "
                 f"Supported: {sorted(supported)}"
             )
         return v

--- a/src/fides/api/service/storage/util.py
+++ b/src/fides/api/service/storage/util.py
@@ -1,5 +1,6 @@
 import os
 from collections import defaultdict
+from dataclasses import dataclass
 from enum import Enum as EnumType
 from typing import Any, Callable, Optional
 from urllib.parse import quote
@@ -7,6 +8,8 @@ from urllib.parse import quote
 from loguru import logger
 
 from fides.api.util.storage_util import format_size
+
+DEFAULT_FILE_MAX_SIZE_BYTES = 10 * 1024 * 1024  # 10 MB
 
 
 class FilesMagicBytes:
@@ -32,11 +35,6 @@ class FilesMagicBytes:
                 return ext
         return None
 
-    @classmethod
-    def default_public_upload_allowed_file_types(cls) -> set[str]:
-        """Default extensions accepted on public (unauthenticated) upload endpoints."""
-        return {"pdf", "jpg", "png"}
-
 
 # This is the max file size for downloading the content of an attachment.
 # This is an industry standard used by companies like Google and Microsoft.
@@ -60,10 +58,51 @@ class AllowedFileType(EnumType):
     csv = "text/csv"
     zip = "application/zip"
 
+    @classmethod
+    def default_public_upload_allowed_file_types(cls) -> set[str]:
+        """Default extensions accepted on public (unauthenticated) upload endpoints."""
+        return {"pdf", "jpg", "png"}
+
+    @classmethod
+    def supported_file_types(cls) -> set[str]:
+        """File extensions that have a known ``AllowedFileType`` enum entry."""
+        return set(cls.__members__.keys())
+
 
 MIME_TO_EXTENSION: dict[str, str] = {
     member.value: member.name for member in AllowedFileType
 }
+
+
+@dataclass(frozen=True)
+class FileUploadConstraints:
+    """Resolved upload constraints; self-validates ``allowed_file_types``
+    against :class:`AllowedFileType` keys."""
+
+    max_size_bytes: int
+    allowed_file_types: frozenset[str]
+
+    def __post_init__(self) -> None:
+        if self.max_size_bytes <= 0:
+            raise ValueError("max_size_bytes must be greater than 0")
+        if not self.allowed_file_types:
+            raise ValueError("allowed_file_types must not be empty")
+        supported = AllowedFileType.supported_file_types()
+        unsupported = self.allowed_file_types - supported
+        if unsupported:
+            raise ValueError(
+                f"Unsupported file types: {sorted(unsupported)}. "
+                f"Supported: {sorted(supported)}"
+            )
+
+    @classmethod
+    def defaults(cls) -> "FileUploadConstraints":
+        return cls(
+            max_size_bytes=DEFAULT_FILE_MAX_SIZE_BYTES,
+            allowed_file_types=frozenset(
+                AllowedFileType.default_public_upload_allowed_file_types()
+            ),
+        )
 
 
 def extension_for_mime(mime: str) -> str:

--- a/src/fides/api/v1/endpoints/privacy_request_attachment_endpoints.py
+++ b/src/fides/api/v1/endpoints/privacy_request_attachment_endpoints.py
@@ -1,6 +1,15 @@
 """Unauthenticated upload endpoint for privacy-request file attachments."""
 
-from fastapi import Depends, File, Header, HTTPException, Request, Response, UploadFile
+from fastapi import (
+    Depends,
+    File,
+    Form,
+    Header,
+    HTTPException,
+    Request,
+    Response,
+    UploadFile,
+)
 from loguru import logger
 from sqlalchemy.orm import Session
 from starlette.status import (
@@ -26,9 +35,9 @@ from fides.service.privacy_request_attachments.privacy_request_attachments_excep
     StorageNotConfiguredError,
 )
 from fides.service.privacy_request_attachments.privacy_request_attachments_service import (
-    DEFAULT_MAX_SIZE_BYTES,
     UPLOAD_READ_CHUNK_BYTES,
     AttachmentUserProvidedService,
+    resolve_upload_constraints,
 )
 
 router = APIRouter(tags=["Privacy Requests"], prefix=V1_URL_PREFIX)
@@ -44,6 +53,9 @@ def upload_privacy_request_attachment(
     request: Request,  # required for rate limiting
     response: Response,  # required for rate limiting
     file: UploadFile = File(...),
+    property_id: str = Form(...),
+    policy_key: str = Form(...),
+    field_name: str = Form(...),
     content_length: int | None = Header(default=None),
     db: Session = Depends(get_db),
     service: AttachmentUserProvidedService = Depends(
@@ -51,7 +63,9 @@ def upload_privacy_request_attachment(
     ),
 ) -> PrivacyRequestAttachment:
     """Upload a file attachment for a custom privacy request field. Returns
-    an ``id`` to echo back in the field's ``value`` list. Gated on
+    an ``id`` to echo back in the field's ``value`` list. The
+    ``(property_id, policy_key, field_name)`` triple is persisted so
+    submission can verify the upload context. Gated on
     ``allow_custom_privacy_request_field_collection`` and
     ``allow_custom_privacy_request_file_upload``."""
     if not (
@@ -63,13 +77,20 @@ def upload_privacy_request_attachment(
             detail="File attachments are disabled.",
         )
 
+    constraints = resolve_upload_constraints(
+        db,
+        property_id=property_id,
+        policy_key=policy_key,
+        field_name=field_name,
+    )
+
     # Content-Length pre-check — clients can lie, so the streaming check
     # below is the authoritative guard.
-    if content_length is not None and content_length > DEFAULT_MAX_SIZE_BYTES:
+    if content_length is not None and content_length > constraints.max_size_bytes:
         raise HTTPException(
             status_code=HTTP_413_CONTENT_TOO_LARGE,
             detail=(
-                f"File exceeds maximum allowed size of {DEFAULT_MAX_SIZE_BYTES} bytes"
+                f"File exceeds maximum allowed size of {constraints.max_size_bytes} bytes"
             ),
         )
 
@@ -80,11 +101,11 @@ def upload_privacy_request_attachment(
         if not chunk:
             break
         total += len(chunk)
-        if total > DEFAULT_MAX_SIZE_BYTES:
+        if total > constraints.max_size_bytes:
             raise HTTPException(
                 status_code=HTTP_413_CONTENT_TOO_LARGE,
                 detail=(
-                    f"File exceeds maximum allowed size of {DEFAULT_MAX_SIZE_BYTES} bytes"
+                    f"File exceeds maximum allowed size of {constraints.max_size_bytes} bytes"
                 ),
             )
         chunks.append(chunk)
@@ -92,7 +113,14 @@ def upload_privacy_request_attachment(
     file_data = b"".join(chunks)
 
     try:
-        result = service.upload_attachment(file_data=file_data, session=db)
+        result = service.upload_attachment(
+            file_data=file_data,
+            session=db,
+            constraints=constraints,
+            field_name=field_name,
+            property_id=property_id,
+            policy_key=policy_key,
+        )
         db.commit()
         return result
     except FileTooLargeError as exc:

--- a/src/fides/service/privacy_request/privacy_request_service.py
+++ b/src/fides/service/privacy_request/privacy_request_service.py
@@ -426,10 +426,17 @@ class PrivacyRequestService:
             else set()
         )
         attachment_service = self.attachment_user_provided_service
+        if file_field_names and not privacy_request_data.property_id:
+            raise PrivacyRequestError(
+                "property_id is required when the submission includes file fields.",
+                privacy_request_data.model_dump(mode="json"),
+            )
         try:
             attachment_rows = attachment_service.resolve_file_attachments(
                 privacy_request_data.custom_privacy_request_fields,
                 file_field_names,
+                privacy_request_data.property_id or "",
+                privacy_request_data.policy_key or "",
                 session=self.db,
             )
         except AttachmentsServiceError as exc:

--- a/src/fides/service/privacy_request_attachments/privacy_request_attachments_entities.py
+++ b/src/fides/service/privacy_request_attachments/privacy_request_attachments_entities.py
@@ -18,6 +18,9 @@ class AttachmentUserProvidedRecord:
     storage_key: str
     status: AttachmentUserProvidedStatus
     created_at: datetime
+    field_name: str
+    property_id: str
+    policy_key: str
 
     @classmethod
     def from_orm(cls, obj: AttachmentUserProvided) -> "AttachmentUserProvidedRecord":
@@ -27,4 +30,7 @@ class AttachmentUserProvidedRecord:
             storage_key=obj.storage_key,  # type: ignore[arg-type]
             status=obj.status,  # type: ignore[arg-type]
             created_at=obj.created_at,  # type: ignore[arg-type]
+            field_name=obj.field_name,  # type: ignore[arg-type]
+            property_id=obj.property_id,  # type: ignore[arg-type]
+            policy_key=obj.policy_key,  # type: ignore[arg-type]
         )

--- a/src/fides/service/privacy_request_attachments/privacy_request_attachments_exceptions.py
+++ b/src/fides/service/privacy_request_attachments/privacy_request_attachments_exceptions.py
@@ -75,3 +75,33 @@ class InvalidAttachmentValueError(AttachmentsServiceError):
         super().__init__(
             f"File attachment for field '{field_name}' must be a list of attachment ids."
         )
+
+
+class AttachmentContextMismatchError(AttachmentsServiceError):
+    """Stored ``(field_name, property_id, policy_key)`` does not match
+    the submission context."""
+
+    def __init__(
+        self,
+        attachment_id: str,
+        expected_field: str,
+        actual_field: str,
+        expected_property: str,
+        actual_property: str,
+        expected_policy: str,
+        actual_policy: str,
+    ):
+        self.attachment_id = attachment_id
+        self.expected_field = expected_field
+        self.actual_field = actual_field
+        self.expected_property = expected_property
+        self.actual_property = actual_property
+        self.expected_policy = expected_policy
+        self.actual_policy = actual_policy
+        super().__init__(
+            f"Attachment '{attachment_id}' was uploaded for field "
+            f"'{actual_field}' / property '{actual_property}' / "
+            f"policy '{actual_policy}', but submitted under field "
+            f"'{expected_field}' / property '{expected_property}' / "
+            f"policy '{expected_policy}'."
+        )

--- a/src/fides/service/privacy_request_attachments/privacy_request_attachments_repository.py
+++ b/src/fides/service/privacy_request_attachments/privacy_request_attachments_repository.py
@@ -27,6 +27,9 @@ class AttachmentUserProvidedRepository:
         *,
         object_key: str,
         storage_key: str,
+        field_name: str,
+        property_id: str,
+        policy_key: str,
         session: Session,
     ) -> AttachmentUserProvidedRecord:
         """Insert a new ``uploaded`` row; flush so ``id`` is populated."""
@@ -34,6 +37,9 @@ class AttachmentUserProvidedRepository:
             object_key=object_key,
             status=AttachmentUserProvidedStatus.uploaded,
             storage_key=storage_key,
+            field_name=field_name,
+            property_id=property_id,
+            policy_key=policy_key,
         )
         session.add(row)
         session.flush()

--- a/src/fides/service/privacy_request_attachments/privacy_request_attachments_service.py
+++ b/src/fides/service/privacy_request_attachments/privacy_request_attachments_service.py
@@ -117,7 +117,7 @@ def resolve_upload_constraints(
 
     try:
         cfg = PrivacyCenterConfigSchema.model_validate(config_dict)
-    except ValidationError as exc:
+    except (ValidationError, ValueError, TypeError) as exc:
         logger.warning("Could not parse Privacy Center config for upload: {}", exc)
         return FileUploadConstraints.defaults()
 

--- a/src/fides/service/privacy_request_attachments/privacy_request_attachments_service.py
+++ b/src/fides/service/privacy_request_attachments/privacy_request_attachments_service.py
@@ -7,6 +7,7 @@ from typing import Any, Optional
 from uuid import uuid4
 
 from loguru import logger
+from pydantic import ValidationError
 from sqlalchemy.orm import Session
 
 from fides.api.models.attachment import (
@@ -15,19 +16,32 @@ from fides.api.models.attachment import (
     AttachmentUserProvided,
     AttachmentUserProvidedStatus,
 )
+from fides.api.models.privacy_center_config import (
+    PrivacyCenterConfig as PrivacyCenterConfigModel,
+)
 from fides.api.models.privacy_request.privacy_request import PrivacyRequest
+from fides.api.models.property import Property
 from fides.api.models.storage import StorageConfig, get_active_default_storage_config
 from fides.api.schemas.attachment import PrivacyRequestAttachment
-from fides.api.schemas.privacy_center_config import DEFAULT_FILE_MAX_SIZE_BYTES
+from fides.api.schemas.privacy_center_config import FileUploadCustomPrivacyRequestField
+from fides.api.schemas.privacy_center_config import (
+    PrivacyCenterConfig as PrivacyCenterConfigSchema,
+)
 from fides.api.schemas.redis_cache import CustomPrivacyRequestField
 from fides.api.schemas.storage.storage import StorageType
 from fides.api.service.storage.providers import StorageProviderFactory
 from fides.api.service.storage.providers.base import StorageProvider
-from fides.api.service.storage.util import AllowedFileType, FilesMagicBytes
+from fides.api.service.storage.util import (
+    DEFAULT_FILE_MAX_SIZE_BYTES,
+    AllowedFileType,
+    FilesMagicBytes,
+    FileUploadConstraints,
+)
 from fides.common.session_management import with_optional_sync_session
 from fides.config import CONFIG
 from fides.service.attachment_service import AttachmentService
 from fides.service.privacy_request_attachments.privacy_request_attachments_exceptions import (
+    AttachmentContextMismatchError,
     AttachmentNotFoundError,
     DisallowedFileTypeError,
     FileTooLargeError,
@@ -63,6 +77,64 @@ def _get_provider_and_bucket(
     return provider, bucket, storage_config
 
 
+def _resolve_privacy_center_config_dict(
+    db: Session, property_id: Optional[str]
+) -> Optional[dict[str, Any]]:
+    """Return privacy-center config: property_id → default property → global table."""
+    if property_id:
+        prop = Property.get_by(db, field="id", value=property_id)
+        cfg = prop.privacy_center_config if prop else None
+        if cfg:
+            return cfg
+    default_prop = Property.get_by(db, field="is_default", value=True)
+    cfg = default_prop.privacy_center_config if default_prop else None
+    if cfg:
+        return cfg
+    record = PrivacyCenterConfigModel.filter(
+        db=db,
+        conditions=PrivacyCenterConfigModel.single_row,  # type: ignore[arg-type]
+    ).first()
+    if record:
+        return record.config  # type: ignore[return-value]
+    return None
+
+
+def resolve_upload_constraints(
+    db: Session,
+    *,
+    property_id: str,
+    policy_key: str,
+    field_name: str,
+) -> FileUploadConstraints:
+    """Return constraints for the action's file field, else defaults.
+
+    Mirrors submission-time action scoping so upload and submission
+    enforce identical limits.
+    """
+    config_dict = _resolve_privacy_center_config_dict(db, property_id)
+    if not config_dict:
+        return FileUploadConstraints.defaults()
+
+    try:
+        cfg = PrivacyCenterConfigSchema.model_validate(config_dict)
+    except ValidationError as exc:
+        logger.warning("Could not parse Privacy Center config for upload: {}", exc)
+        return FileUploadConstraints.defaults()
+
+    for action in cfg.actions:
+        if action.policy_key != policy_key:
+            continue
+        fields = action.custom_privacy_request_fields or {}
+        candidate = fields.get(field_name)
+        if isinstance(candidate, FileUploadCustomPrivacyRequestField):
+            return FileUploadConstraints(
+                max_size_bytes=candidate.max_size_bytes,
+                allowed_file_types=frozenset(candidate.allowed_file_types),
+            )
+        break
+    return FileUploadConstraints.defaults()
+
+
 class AttachmentUserProvidedService:
     """Validate, store, and register data-subject-uploaded attachments."""
 
@@ -75,20 +147,25 @@ class AttachmentUserProvidedService:
         *,
         file_data: bytes,
         session: Session,
+        constraints: "FileUploadConstraints",
+        field_name: str,
+        property_id: str,
+        policy_key: str,
     ) -> PrivacyRequestAttachment:
         """Validate, store, and register a file attachment. Object key is
         server-generated; client filename + Content-Type are discarded.
+        ``(field_name, property_id, policy_key)`` is persisted so submission
+        can verify the upload context.
 
         Raises ``FileTooLargeError``, ``DisallowedFileTypeError``,
         ``StorageNotConfiguredError``, or ``StorageBucketNotConfiguredError``.
         """
-        if len(file_data) > DEFAULT_MAX_SIZE_BYTES:
-            raise FileTooLargeError(DEFAULT_MAX_SIZE_BYTES)
+        if len(file_data) > constraints.max_size_bytes:
+            raise FileTooLargeError(constraints.max_size_bytes)
 
-        allowed = FilesMagicBytes.default_public_upload_allowed_file_types()
         sig = FilesMagicBytes.from_bytes(file_data)
-        if sig is None or sig not in allowed:
-            raise DisallowedFileTypeError(sorted(allowed))
+        if sig is None or sig not in constraints.allowed_file_types:
+            raise DisallowedFileTypeError(sorted(constraints.allowed_file_types))
 
         content_type = AllowedFileType[sig].value
         provider, bucket, storage_config = _get_provider_and_bucket(session)
@@ -102,6 +179,9 @@ class AttachmentUserProvidedService:
         record = self._repo.create_uploaded(
             object_key=object_key,
             storage_key=storage_config.key,
+            field_name=field_name,
+            property_id=property_id,
+            policy_key=policy_key,
             session=session,
         )
         result = provider.upload(
@@ -125,15 +205,16 @@ class AttachmentUserProvidedService:
         self,
         custom_privacy_request_fields: Optional[dict[str, CustomPrivacyRequestField]],
         file_field_names: set[str],
+        property_id: str,
+        policy_key: str,
         *,
         session: Session,
     ) -> list[AttachmentUserProvided]:
         """Resolve file-field values to ``uploaded`` rows under ``FOR UPDATE``.
 
-        Returns the locked ORM rows so :meth:`promote_rows_to_attachments`
-        can mutate them in the same transaction. The lock holds until the
-        caller's next commit/rollback. Returns ``[]`` if the
-        ``allow_custom_privacy_request_field_collection`` flag is off.
+        Each row's ``(field_name, property_id, policy_key)`` must match
+        the submission's; mismatches raise :class:`AttachmentContextMismatchError`.
+        Returns ``[]`` if ``allow_custom_privacy_request_field_collection`` is off.
         """
         if not custom_privacy_request_fields or not file_field_names:
             return []
@@ -163,6 +244,20 @@ class AttachmentUserProvidedService:
                 row = pending.get(item)
                 if row is None:
                     raise AttachmentNotFoundError(name)
+                if (
+                    row.field_name != name
+                    or row.property_id != property_id
+                    or row.policy_key != policy_key
+                ):
+                    raise AttachmentContextMismatchError(
+                        attachment_id=row.id,
+                        expected_field=name,
+                        actual_field=row.field_name,
+                        expected_property=property_id,
+                        actual_property=row.property_id,
+                        expected_policy=policy_key,
+                        actual_policy=row.policy_key,
+                    )
                 rows.append(row)
 
         return rows
@@ -175,9 +270,25 @@ class AttachmentUserProvidedService:
         *,
         session: Session,
     ) -> None:
-        """Transition pending rows → ``promoted`` and create ``Attachment`` records."""
+        """Transition pending rows → ``promoted`` and create ``Attachment`` records.
+        Re-validates context per row (defense in depth)."""
         if not rows:
             return
+
+        for row in rows:
+            if (
+                row.property_id != privacy_request.property_id
+                or row.policy_key != privacy_request.policy.key
+            ):
+                raise AttachmentContextMismatchError(
+                    attachment_id=row.id,
+                    expected_field=row.field_name,
+                    actual_field=row.field_name,
+                    expected_property=privacy_request.property_id or "",
+                    actual_property=row.property_id,
+                    expected_policy=privacy_request.policy.key,
+                    actual_policy=row.policy_key,
+                )
 
         self._repo.assert_all_uploaded(rows)
 

--- a/tests/ops/api/v1/endpoints/test_privacy_request_attachment_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_request_attachment_endpoints.py
@@ -302,7 +302,11 @@ class TestPostPrivacyRequestAttachment:
             resp = api_client.post(
                 URL,
                 files={"file": ("original.pdf", io.BytesIO(PDF_BYTES))},
-                data={"field_name": "passport"},
+                data={
+                    "property_id": "test_prop",
+                    "policy_key": "default_access_policy",
+                    "field_name": "passport",
+                },
             )
         assert resp.status_code == 413
         assert "8 bytes" in resp.json()["detail"]
@@ -329,7 +333,11 @@ class TestPostPrivacyRequestAttachment:
             resp = api_client.post(
                 URL,
                 files={"file": ("original.pdf", io.BytesIO(PDF_BYTES))},
-                data={"field_name": "headshot"},
+                data={
+                    "property_id": "test_prop",
+                    "policy_key": "default_access_policy",
+                    "field_name": "headshot",
+                },
             )
         assert resp.status_code == 400
         assert "not allowed" in resp.json()["detail"]

--- a/tests/ops/api/v1/endpoints/test_privacy_request_attachment_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_request_attachment_endpoints.py
@@ -46,7 +46,11 @@ class TestPostPrivacyRequestAttachment:
     ):
         # File-upload flag alone is insufficient; field-collection must
         # also be on.
-        resp = api_client.post(URL, files={"file": ("x.pdf", io.BytesIO(PDF_BYTES))})
+        resp = api_client.post(
+            URL,
+            files={"file": ("x.pdf", io.BytesIO(PDF_BYTES))},
+            data={"property_id": "p", "policy_key": "k", "field_name": "f"},
+        )
         assert resp.status_code == 403
         assert "disabled" in resp.json()["detail"].lower()
 
@@ -58,7 +62,11 @@ class TestPostPrivacyRequestAttachment:
     ):
         # Field-collection alone is insufficient; file-upload flag is
         # an independent gate.
-        resp = api_client.post(URL, files={"file": ("x.pdf", io.BytesIO(PDF_BYTES))})
+        resp = api_client.post(
+            URL,
+            files={"file": ("x.pdf", io.BytesIO(PDF_BYTES))},
+            data={"property_id": "p", "policy_key": "k", "field_name": "f"},
+        )
         assert resp.status_code == 403
         assert "disabled" in resp.json()["detail"].lower()
 
@@ -69,7 +77,11 @@ class TestPostPrivacyRequestAttachment:
         allow_custom_privacy_request_file_upload_enabled,
     ):
         oversize = b"%PDF" + b"x" * (DEFAULT_MAX_SIZE_BYTES + 1)
-        resp = api_client.post(URL, files={"file": ("x.pdf", io.BytesIO(oversize))})
+        resp = api_client.post(
+            URL,
+            files={"file": ("x.pdf", io.BytesIO(oversize))},
+            data={"property_id": "p", "policy_key": "k", "field_name": "f"},
+        )
         assert resp.status_code == 413
         assert "maximum allowed size" in resp.json()["detail"]
 
@@ -82,7 +94,9 @@ class TestPostPrivacyRequestAttachment:
         patch_storage_factory,
     ):
         resp = api_client.post(
-            URL, files={"file": ("x.pdf", io.BytesIO(b"not a real pdf"))}
+            URL,
+            files={"file": ("x.pdf", io.BytesIO(b"not a real pdf"))},
+            data={"property_id": "p", "policy_key": "k", "field_name": "f"},
         )
         assert resp.status_code == 400
         assert "not allowed" in resp.json()["detail"]
@@ -98,7 +112,9 @@ class TestPostPrivacyRequestAttachment:
             return_value=None,
         ):
             resp = api_client.post(
-                URL, files={"file": ("x.pdf", io.BytesIO(PDF_BYTES))}
+                URL,
+                files={"file": ("x.pdf", io.BytesIO(PDF_BYTES))},
+                data={"property_id": "p", "policy_key": "k", "field_name": "f"},
             )
         assert resp.status_code == 503
         assert resp.json()["detail"] == "File attachments are temporarily unavailable."
@@ -126,6 +142,9 @@ class TestPostPrivacyRequestAttachment:
                 request=MagicMock(),
                 response=MagicMock(),
                 file=upload,
+                property_id="p",
+                policy_key="k",
+                field_name="f",
                 content_length=1,
                 db=db,
                 service=MagicMock(),
@@ -166,12 +185,43 @@ class TestPostPrivacyRequestAttachment:
                 request=MagicMock(),
                 response=MagicMock(),
                 file=upload,
+                property_id="p",
+                policy_key="k",
+                field_name="f",
                 content_length=None,
                 db=db,
                 service=service,
             )
         assert exc.value.status_code == 413
         assert str(DEFAULT_MAX_SIZE_BYTES) in exc.value.detail
+
+    @pytest.mark.parametrize(
+        "form_data",
+        [
+            pytest.param(
+                {"policy_key": "k", "field_name": "f"}, id="missing_property_id"
+            ),
+            pytest.param(
+                {"property_id": "p", "field_name": "f"}, id="missing_policy_key"
+            ),
+            pytest.param(
+                {"property_id": "p", "policy_key": "k"}, id="missing_field_name"
+            ),
+        ],
+    )
+    def test_upload_rejects_missing_required_form_field(
+        self,
+        api_client: TestClient,
+        allow_custom_privacy_request_field_collection_enabled,
+        allow_custom_privacy_request_file_upload_enabled,
+        form_data,
+    ):
+        resp = api_client.post(
+            URL,
+            files={"file": ("x.pdf", io.BytesIO(PDF_BYTES))},
+            data=form_data,
+        )
+        assert resp.status_code == 422
 
     def test_upload_happy_path(
         self,
@@ -183,7 +233,9 @@ class TestPostPrivacyRequestAttachment:
         mock_provider,
     ):
         resp = api_client.post(
-            URL, files={"file": ("original.pdf", io.BytesIO(PDF_BYTES))}
+            URL,
+            files={"file": ("original.pdf", io.BytesIO(PDF_BYTES))},
+            data={"property_id": "p", "policy_key": "k", "field_name": "f"},
         )
         assert resp.status_code == 200, resp.text
         body = resp.json()
@@ -194,3 +246,90 @@ class TestPostPrivacyRequestAttachment:
         assert kwargs["key"].startswith("privacy_request_attachments/")
         assert kwargs["key"].endswith(".pdf")
         assert kwargs["content_type"] == "application/pdf"
+
+    def test_upload_passes_property_id_policy_key_field_name_to_resolver(
+        self,
+        api_client: TestClient,
+        allow_custom_privacy_request_field_collection_enabled,
+        allow_custom_privacy_request_file_upload_enabled,
+        storage_config_default,
+        patch_storage_factory,
+    ):
+        from fides.service.privacy_request_attachments.privacy_request_attachments_service import (
+            FileUploadConstraints,
+        )
+
+        with patch(
+            "fides.api.v1.endpoints.privacy_request_attachment_endpoints.resolve_upload_constraints",
+            return_value=FileUploadConstraints.defaults(),
+        ) as resolver:
+            resp = api_client.post(
+                URL,
+                files={"file": ("original.pdf", io.BytesIO(PDF_BYTES))},
+                data={
+                    "property_id": "prop_xyz",
+                    "policy_key": "default_access_policy",
+                    "field_name": "passport",
+                },
+            )
+        assert resp.status_code == 200, resp.text
+        resolver.assert_called_once()
+        kwargs = resolver.call_args.kwargs
+        assert kwargs == {
+            "property_id": "prop_xyz",
+            "policy_key": "default_access_policy",
+            "field_name": "passport",
+        }
+
+    def test_upload_rejects_per_field_oversize_via_content_length(
+        self,
+        api_client: TestClient,
+        allow_custom_privacy_request_field_collection_enabled,
+        allow_custom_privacy_request_file_upload_enabled,
+        storage_config_default,
+    ):
+        from fides.service.privacy_request_attachments.privacy_request_attachments_service import (
+            FileUploadConstraints,
+        )
+
+        with patch(
+            "fides.api.v1.endpoints.privacy_request_attachment_endpoints.resolve_upload_constraints",
+            return_value=FileUploadConstraints(
+                max_size_bytes=8,
+                allowed_file_types=frozenset({"pdf", "png", "jpg"}),
+            ),
+        ):
+            resp = api_client.post(
+                URL,
+                files={"file": ("original.pdf", io.BytesIO(PDF_BYTES))},
+                data={"field_name": "passport"},
+            )
+        assert resp.status_code == 413
+        assert "8 bytes" in resp.json()["detail"]
+
+    def test_upload_rejects_per_field_disallowed_file_type(
+        self,
+        api_client: TestClient,
+        allow_custom_privacy_request_field_collection_enabled,
+        allow_custom_privacy_request_file_upload_enabled,
+        storage_config_default,
+        patch_storage_factory,
+    ):
+        from fides.service.privacy_request_attachments.privacy_request_attachments_service import (
+            FileUploadConstraints,
+        )
+
+        with patch(
+            "fides.api.v1.endpoints.privacy_request_attachment_endpoints.resolve_upload_constraints",
+            return_value=FileUploadConstraints(
+                max_size_bytes=DEFAULT_MAX_SIZE_BYTES,
+                allowed_file_types=frozenset({"png"}),
+            ),
+        ):
+            resp = api_client.post(
+                URL,
+                files={"file": ("original.pdf", io.BytesIO(PDF_BYTES))},
+                data={"field_name": "headshot"},
+            )
+        assert resp.status_code == 400
+        assert "not allowed" in resp.json()["detail"]

--- a/tests/ops/schemas/test_privacy_center_config.py
+++ b/tests/ops/schemas/test_privacy_center_config.py
@@ -4,18 +4,18 @@ import pytest
 from pydantic import ValidationError
 
 from fides.api.schemas.privacy_center_config import (
-    DEFAULT_FILE_MAX_SIZE_BYTES,
     ConsentConfigPage,
     CustomPrivacyRequestField,
     FileUploadCustomPrivacyRequestField,
     IdentityInputs,
     LocationCustomPrivacyRequestField,
     PrivacyCenterConfig,
-    _default_allowed_mime_types,
+    _default_allowed_file_types,
     get_field_type_discriminator,
     reorder_custom_privacy_request_fields,
 )
 from fides.api.schemas.privacy_center_field_base import BaseCustomPrivacyRequestField
+from fides.api.service.storage.util import DEFAULT_FILE_MAX_SIZE_BYTES
 from fides.api.util.saas_util import load_as_string
 
 
@@ -745,31 +745,35 @@ class TestFileUploadCustomPrivacyRequestField:
         assert field.field_type == "file"
         assert field.required is False
         assert field.max_size_bytes == DEFAULT_FILE_MAX_SIZE_BYTES
-        assert field.allowed_mime_types == sorted(_default_allowed_mime_types())
+        assert field.allowed_file_types == sorted(_default_allowed_file_types())
 
-    def test_explicit_allowed_mime_types(self):
+    def test_explicit_allowed_file_types(self):
         field = FileUploadCustomPrivacyRequestField(
-            label="Receipt", allowed_mime_types=["application/pdf"]
+            label="Receipt", allowed_file_types=["pdf"]
         )
-        assert field.allowed_mime_types == ["application/pdf"]
+        assert field.allowed_file_types == ["pdf"]
 
     def test_rejects_options(self):
         with pytest.raises(ValidationError, match="do not support options"):
             FileUploadCustomPrivacyRequestField(label="Receipt", options=["a"])
 
-    def test_rejects_empty_allowed_mime_types(self):
+    def test_rejects_empty_allowed_file_types(self):
         with pytest.raises(ValidationError, match="must not be empty"):
-            FileUploadCustomPrivacyRequestField(label="Receipt", allowed_mime_types=[])
+            FileUploadCustomPrivacyRequestField(label="Receipt", allowed_file_types=[])
 
-    def test_rejects_unsupported_mime(self):
-        with pytest.raises(ValidationError, match="Unsupported MIME types"):
+    def test_rejects_unsupported_file_type(self):
+        with pytest.raises(ValidationError, match="Unsupported file types"):
             FileUploadCustomPrivacyRequestField(
-                label="Receipt", allowed_mime_types=["application/x-fake"]
+                label="Receipt", allowed_file_types=["exe"]
             )
 
     def test_rejects_zero_max_size(self):
         with pytest.raises(ValidationError):
             FileUploadCustomPrivacyRequestField(label="Receipt", max_size_bytes=0)
+
+    def test_rejects_negative_max_size(self):
+        with pytest.raises(ValidationError):
+            FileUploadCustomPrivacyRequestField(label="Receipt", max_size_bytes=-1)
 
 
 class TestFieldTypeDiscriminator:

--- a/tests/ops/service/privacy_request_attachments/test_repository.py
+++ b/tests/ops/service/privacy_request_attachments/test_repository.py
@@ -14,12 +14,18 @@ class TestAttachmentUserProvidedRepository:
         record = AttachmentUserProvidedRepository().create_uploaded(
             object_key="privacy_request_attachments/flush.pdf",
             storage_key=storage_config_default.key,
+            field_name="passport",
+            property_id="prop_xyz",
+            policy_key="default_access_policy",
             session=db,
         )
         assert record.id is not None
         assert record.status == AttachmentUserProvidedStatus.uploaded
         assert record.storage_key == storage_config_default.key
         assert record.object_key == "privacy_request_attachments/flush.pdf"
+        assert record.field_name == "passport"
+        assert record.property_id == "prop_xyz"
+        assert record.policy_key == "default_access_policy"
 
         row = (
             db.query(AttachmentUserProvided)

--- a/tests/ops/service/privacy_request_attachments/test_service.py
+++ b/tests/ops/service/privacy_request_attachments/test_service.py
@@ -589,6 +589,9 @@ class TestPromoteRowsToAttachments:
             repo.create_uploaded(
                 object_key=f"privacy_request_attachments/multi_{i}.pdf",
                 storage_key=storage_config_default.key,
+                field_name="file",
+                property_id="test_prop",
+                policy_key="example_access_request_policy",
                 session=db,
             )
             for i in range(2)
@@ -776,7 +779,7 @@ class TestCreatePrivacyRequestFileResolution:
             svc.create_privacy_request(req, authenticated=True)
         assert captured["names"] == {"doc"}
         assert captured["property_id"] == "test_prop"
-        assert captured["policy_key"] == "default_access_policy"
+        assert captured["policy_key"] == "example_access_request_policy"
 
     def test_rejects_when_property_id_missing(self, file_svc_req):
         from fides.api.common_exceptions import PrivacyRequestError

--- a/tests/ops/service/privacy_request_attachments/test_service.py
+++ b/tests/ops/service/privacy_request_attachments/test_service.py
@@ -1,6 +1,7 @@
 """Tests for the upload, resolve, and promote attachment service paths."""
 
 import io
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -27,6 +28,7 @@ from fides.service.privacy_request_attachments.privacy_request_attachments_repos
 from fides.service.privacy_request_attachments.privacy_request_attachments_service import (
     DEFAULT_MAX_SIZE_BYTES,
     AttachmentUserProvidedService,
+    FileUploadConstraints,
     _bucket,
     _get_provider_and_bucket,
 )
@@ -67,7 +69,12 @@ class TestUploadAttachment:
         mock_provider,
     ):
         result = AttachmentUserProvidedService().upload_attachment(
-            file_data=PDF_BYTES, session=db
+            file_data=PDF_BYTES,
+            session=db,
+            constraints=FileUploadConstraints.defaults(),
+            field_name="file",
+            property_id="test_prop",
+            policy_key="default_access_policy",
         )
 
         assert result.id.startswith("att_")
@@ -101,7 +108,12 @@ class TestUploadAttachment:
         before = db.query(AttachmentUserProvided).count()
         with pytest.raises(RuntimeError, match="s3 boom"):
             AttachmentUserProvidedService().upload_attachment(
-                file_data=PDF_BYTES, session=db
+                file_data=PDF_BYTES,
+                session=db,
+                constraints=FileUploadConstraints.defaults(),
+                field_name="file",
+                property_id="test_prop",
+                policy_key="default_access_policy",
             )
         # Caller-supplied session: decorator only flushes; row should not
         # be visible after the rollback we trigger to clear the failed
@@ -114,7 +126,12 @@ class TestUploadAttachment:
         oversize = b"%PDF" + b"x" * (DEFAULT_MAX_SIZE_BYTES + 1)
         with pytest.raises(FileTooLargeError):
             AttachmentUserProvidedService().upload_attachment(
-                file_data=oversize, session=db
+                file_data=oversize,
+                session=db,
+                constraints=FileUploadConstraints.defaults(),
+                field_name="file",
+                property_id="test_prop",
+                policy_key="default_access_policy",
             )
 
     def test_upload_rejects_unknown_magic(
@@ -122,7 +139,12 @@ class TestUploadAttachment:
     ):
         with pytest.raises(DisallowedFileTypeError):
             AttachmentUserProvidedService().upload_attachment(
-                file_data=b"not a real file format", session=db
+                file_data=b"not a real file format",
+                session=db,
+                constraints=FileUploadConstraints.defaults(),
+                field_name="file",
+                property_id="test_prop",
+                policy_key="default_access_policy",
             )
 
     def test_upload_without_storage_config_raises(self, db):
@@ -132,8 +154,45 @@ class TestUploadAttachment:
         ):
             with pytest.raises(StorageNotConfiguredError):
                 AttachmentUserProvidedService().upload_attachment(
-                    file_data=PDF_BYTES, session=db
+                    file_data=PDF_BYTES,
+                    session=db,
+                    constraints=FileUploadConstraints.defaults(),
+                    field_name="file",
+                    property_id="test_prop",
+                    policy_key="default_access_policy",
                 )
+
+    def test_upload_respects_per_field_max_size(
+        self, db, storage_config_default, patch_provider_factory
+    ):
+        with pytest.raises(FileTooLargeError):
+            AttachmentUserProvidedService().upload_attachment(
+                file_data=PDF_BYTES,
+                session=db,
+                constraints=FileUploadConstraints(
+                    max_size_bytes=1,
+                    allowed_file_types=frozenset({"pdf", "png", "jpg"}),
+                ),
+                field_name="file",
+                property_id="test_prop",
+                policy_key="default_access_policy",
+            )
+
+    def test_upload_respects_per_field_allowed_file_types(
+        self, db, storage_config_default, patch_provider_factory
+    ):
+        with pytest.raises(DisallowedFileTypeError):
+            AttachmentUserProvidedService().upload_attachment(
+                file_data=PDF_BYTES,
+                session=db,
+                constraints=FileUploadConstraints(
+                    max_size_bytes=DEFAULT_MAX_SIZE_BYTES,
+                    allowed_file_types=frozenset({"png"}),
+                ),
+                field_name="file",
+                property_id="test_prop",
+                policy_key="default_access_policy",
+            )
 
 
 class TestProviderHelpers:
@@ -215,7 +274,11 @@ class TestResolveFileAttachments:
             request.getfixturevalue(fixture)
         assert (
             AttachmentUserProvidedService().resolve_file_attachments(
-                fields, names, session=db
+                fields,
+                names,
+                "test_prop",
+                "default_access_policy",
+                session=db,
             )
             == []
         )
@@ -229,13 +292,16 @@ class TestResolveFileAttachments:
         record = AttachmentUserProvidedRepository().create_uploaded(
             object_key="privacy_request_attachments/one.pdf",
             storage_key=storage_config_default.key,
+            field_name="file",
+            property_id="test_prop",
+            policy_key="default_access_policy",
             session=db,
         )
         db.commit()
 
         fields = {"file": CustomPrivacyRequestField(label="file", value=[record.id])}
         rows = AttachmentUserProvidedService().resolve_file_attachments(
-            fields, {"file"}, session=db
+            fields, {"file"}, "test_prop", "default_access_policy", session=db
         )
         assert [r.id for r in rows] == [record.id]
 
@@ -252,7 +318,7 @@ class TestResolveFileAttachments:
         }
         with pytest.raises(AttachmentNotFoundError):
             AttachmentUserProvidedService().resolve_file_attachments(
-                fields, {"file"}, session=db
+                fields, {"file"}, "test_prop", "default_access_policy", session=db
             )
 
     def test_non_list_value_raises(
@@ -264,7 +330,7 @@ class TestResolveFileAttachments:
         fields = {"file": CustomPrivacyRequestField(label="file", value="not a list")}
         with pytest.raises(InvalidAttachmentValueError):
             AttachmentUserProvidedService().resolve_file_attachments(
-                fields, {"file"}, session=db
+                fields, {"file"}, "test_prop", "default_access_policy", session=db
             )
 
     @pytest.mark.parametrize(
@@ -283,10 +349,97 @@ class TestResolveFileAttachments:
     ):
         assert (
             AttachmentUserProvidedService().resolve_file_attachments(
-                fields, {"file"}, session=db
+                fields, {"file"}, "test_prop", "default_access_policy", session=db
             )
             == []
         )
+
+    @pytest.mark.parametrize(
+        "uploaded, submitted",
+        [
+            pytest.param(
+                {
+                    "field_name": "other_field",
+                    "property_id": "test_prop",
+                    "policy_key": "default_access_policy",
+                },
+                {
+                    "field_name": "file",
+                    "property_id": "test_prop",
+                    "policy_key": "default_access_policy",
+                },
+                id="field_name",
+            ),
+            pytest.param(
+                {
+                    "field_name": "file",
+                    "property_id": "prop_uploaded",
+                    "policy_key": "default_access_policy",
+                },
+                {
+                    "field_name": "file",
+                    "property_id": "prop_submitted",
+                    "policy_key": "default_access_policy",
+                },
+                id="property_id",
+            ),
+            pytest.param(
+                {
+                    "field_name": "file",
+                    "property_id": "test_prop",
+                    "policy_key": "default_access_policy",
+                },
+                {
+                    "field_name": "file",
+                    "property_id": "test_prop",
+                    "policy_key": "default_erasure_policy",
+                },
+                id="policy_key",
+            ),
+        ],
+    )
+    def test_context_mismatch_raises(
+        self,
+        db,
+        storage_config_default,
+        allow_custom_privacy_request_field_collection_enabled,
+        uploaded,
+        submitted,
+    ):
+        from fides.service.privacy_request_attachments.privacy_request_attachments_exceptions import (
+            AttachmentContextMismatchError,
+        )
+
+        record = AttachmentUserProvidedRepository().create_uploaded(
+            object_key=f"privacy_request_attachments/mismatch_{uploaded['field_name']}.pdf",
+            storage_key=storage_config_default.key,
+            session=db,
+            **uploaded,
+        )
+        db.commit()
+
+        fields = {
+            submitted["field_name"]: CustomPrivacyRequestField(
+                label=submitted["field_name"], value=[record.id]
+            )
+        }
+        try:
+            with pytest.raises(AttachmentContextMismatchError):
+                AttachmentUserProvidedService().resolve_file_attachments(
+                    fields,
+                    {submitted["field_name"]},
+                    submitted["property_id"],
+                    submitted["policy_key"],
+                    session=db,
+                )
+        finally:
+            db.rollback()
+            row = (
+                db.query(AttachmentUserProvided)
+                .filter(AttachmentUserProvided.id == record.id)
+                .one()
+            )
+            row.delete(db)
 
 
 class TestPromoteRowsToAttachments:
@@ -309,6 +462,9 @@ class TestPromoteRowsToAttachments:
         record = AttachmentUserProvidedRepository().create_uploaded(
             object_key="privacy_request_attachments/promote.pdf",
             storage_key=storage_config_default.key,
+            field_name="file",
+            property_id="test_prop",
+            policy_key="example_access_request_policy",
             session=db,
         )
         db.commit()
@@ -319,6 +475,8 @@ class TestPromoteRowsToAttachments:
         )
         if delete_raises:
             mock_provider.delete.side_effect = RuntimeError("storage offline")
+        privacy_request.property_id = "test_prop"
+        db.commit()
         # AttachmentService.upload would hit S3 — short-circuit it.
         with patch(
             "fides.service.privacy_request_attachments.privacy_request_attachments_service.AttachmentService.upload",
@@ -349,6 +507,41 @@ class TestPromoteRowsToAttachments:
         db.delete(attachment)
         row.delete(db)
 
+    def test_promote_rejects_property_id_mismatch(
+        self,
+        db,
+        storage_config_default,
+        privacy_request,
+        patch_provider_factory,
+    ):
+        from fides.service.privacy_request_attachments.privacy_request_attachments_exceptions import (
+            AttachmentContextMismatchError,
+        )
+
+        record = AttachmentUserProvidedRepository().create_uploaded(
+            object_key="privacy_request_attachments/mismatch.pdf",
+            storage_key=storage_config_default.key,
+            field_name="file",
+            property_id="prop_uploaded",
+            policy_key="example_access_request_policy",
+            session=db,
+        )
+        db.commit()
+        row = (
+            db.query(AttachmentUserProvided)
+            .filter(AttachmentUserProvided.id == record.id)
+            .one()
+        )
+        privacy_request.property_id = "prop_submitted"
+        db.commit()
+
+        with pytest.raises(AttachmentContextMismatchError):
+            AttachmentUserProvidedService().promote_rows_to_attachments(
+                privacy_request, [row], session=db
+            )
+
+        row.delete(db)
+
     def test_promote_rejects_non_uploaded_row(
         self,
         db,
@@ -359,6 +552,9 @@ class TestPromoteRowsToAttachments:
         record = AttachmentUserProvidedRepository().create_uploaded(
             object_key="privacy_request_attachments/bad.pdf",
             storage_key=storage_config_default.key,
+            field_name="file",
+            property_id="test_prop",
+            policy_key="example_access_request_policy",
             session=db,
         )
         row = (
@@ -367,6 +563,7 @@ class TestPromoteRowsToAttachments:
             .one()
         )
         row.status = AttachmentUserProvidedStatus.deleted
+        privacy_request.property_id = "test_prop"
         db.commit()
 
         with pytest.raises(InvalidAttachmentStateError):
@@ -454,11 +651,17 @@ class TestPromoteRowsToAttachments:
         rec1 = repo.create_uploaded(
             object_key="privacy_request_attachments/p1.pdf",
             storage_key=storage_config_default.key,
+            field_name="file",
+            property_id="test_prop",
+            policy_key="example_access_request_policy",
             session=db,
         )
         rec2 = repo.create_uploaded(
             object_key="privacy_request_attachments/p2.pdf",
             storage_key=storage_config_default.key,
+            field_name="file",
+            property_id="test_prop",
+            policy_key="example_access_request_policy",
             session=db,
         )
         db.commit()
@@ -474,6 +677,8 @@ class TestPromoteRowsToAttachments:
         )
 
         first = MagicMock(id="att_partial")
+        privacy_request.property_id = "test_prop"
+        db.commit()
         with patch(
             "fides.service.privacy_request_attachments.privacy_request_attachments_service.AttachmentService"
         ) as svc_cls:
@@ -528,7 +733,8 @@ def file_svc_req():
     svc._validate_field_visibility = MagicMock()
     return svc, PrivacyRequestCreate(
         identity=Identity(email="x@y.z"),
-        policy_key="default_access_policy",
+        policy_key="example_access_request_policy",
+        property_id="test_prop",
         custom_privacy_request_fields={"doc": {"label": "Doc", "value": ["att_123"]}},
     )
 
@@ -552,8 +758,10 @@ class TestCreatePrivacyRequestFileResolution:
         svc, req = file_svc_req
         captured: dict = {}
 
-        def _capture(_self, _fields, names, *, session):
+        def _capture(_self, _fields, names, property_id, policy_key, *, session):
             captured["names"] = names
+            captured["property_id"] = property_id
+            captured["policy_key"] = policy_key
             return []
 
         with (
@@ -567,10 +775,21 @@ class TestCreatePrivacyRequestFileResolution:
         ):
             svc.create_privacy_request(req, authenticated=True)
         assert captured["names"] == {"doc"}
+        assert captured["property_id"] == "test_prop"
+        assert captured["policy_key"] == "default_access_policy"
+
+    def test_rejects_when_property_id_missing(self, file_svc_req):
+        from fides.api.common_exceptions import PrivacyRequestError
+
+        svc, req = file_svc_req
+        req = req.model_copy(update={"property_id": None})
+        with pytest.raises(
+            PrivacyRequestError,
+            match="property_id is required when the submission includes file fields",
+        ):
+            svc.create_privacy_request(req, authenticated=True)
 
     def test_resolve_not_found_wraps_as_privacy_request_error(self, file_svc_req):
-        # Any ``AttachmentsServiceError`` from resolve must surface with the
-        # field name in the message rather than the generic record-add wrap.
         from fides.api.common_exceptions import PrivacyRequestError
 
         svc, req = file_svc_req
@@ -614,6 +833,7 @@ class TestCreatePrivacyRequestFileResolution:
                 return_value=[],
             ),
             patch(f"{_PRS}.Policy.get_by", return_value=policy),
+            patch(f"{_PRS}.Property.get_by", return_value=MagicMock(id="prop-1")),
             patch(f"{_PRS}.build_required_privacy_request_kwargs", return_value={}),
             patch(f"{_PRS}.PrivacyRequest.create", return_value=privacy_request),
             patch(f"{_PRS}._create_or_update_custom_fields", side_effect=_capture),
@@ -660,3 +880,182 @@ class TestCreatePrivacyRequestFileResolution:
         names_arg = attachment_svc.resolve_file_attachments.call_args.args[1]
         assert names_arg == set()
         attachment_svc.promote_rows_to_attachments.assert_not_called()
+
+
+class TestResolveUploadConstraints:
+    """Cover ``resolve_upload_constraints`` precedence + first-match resolution."""
+
+    _MODULE = (
+        "fides.service.privacy_request_attachments.privacy_request_attachments_service"
+    )
+
+    def _file_field(self, label, *, max_size_bytes, allowed_file_types):
+        from fides.api.schemas.privacy_center_config import (
+            FileUploadCustomPrivacyRequestField,
+        )
+
+        return FileUploadCustomPrivacyRequestField(
+            label=label,
+            max_size_bytes=max_size_bytes,
+            allowed_file_types=list(allowed_file_types),
+        )
+
+    def _faux_action(self, fields, *, policy_key="default_access_policy"):
+        action = MagicMock(custom_privacy_request_fields=fields)
+        action.policy_key = policy_key
+        return action
+
+    def _faux_config(self, actions):
+        cfg = MagicMock()
+        cfg.actions = actions
+        return cfg
+
+    @contextmanager
+    def _stub_config(self, cfg=None, *, config_dict={"actions": []}, parse_raises=None):
+        with (
+            patch(
+                f"{self._MODULE}._resolve_privacy_center_config_dict",
+                return_value=config_dict,
+            ) as resolver,
+            patch(f"{self._MODULE}.PrivacyCenterConfigSchema") as cfg_cls,
+        ):
+            if parse_raises:
+                cfg_cls.model_validate.side_effect = parse_raises
+            else:
+                cfg_cls.model_validate.return_value = cfg
+            yield resolver
+
+    @pytest.mark.parametrize(
+        "stub_kwargs, field_name",
+        [
+            pytest.param({"config_dict": None}, "passport", id="no_config"),
+            pytest.param(
+                {"parse_raises": ValueError("bad")}, "passport", id="unparseable_config"
+            ),
+            pytest.param({"cfg": "_no_match_cfg"}, "passport", id="no_matching_field"),
+            pytest.param(
+                {"cfg": "_text_field_cfg"},
+                "passport",
+                id="non_file_field_with_matching_name",
+            ),
+        ],
+    )
+    def test_returns_defaults(self, db, stub_kwargs, field_name):
+        from fides.api.schemas.privacy_center_config import CustomPrivacyRequestField
+        from fides.service.privacy_request_attachments.privacy_request_attachments_service import (
+            FileUploadConstraints,
+            resolve_upload_constraints,
+        )
+
+        if stub_kwargs.get("cfg") == "_no_match_cfg":
+            stub_kwargs["cfg"] = self._faux_config(
+                [self._faux_action({"other": MagicMock()})]
+            )
+        elif stub_kwargs.get("cfg") == "_text_field_cfg":
+            stub_kwargs["cfg"] = self._faux_config(
+                [
+                    self._faux_action(
+                        {
+                            "passport": CustomPrivacyRequestField(
+                                label="Reason", field_type="text"
+                            )
+                        }
+                    )
+                ]
+            )
+
+        with self._stub_config(**stub_kwargs):
+            assert (
+                resolve_upload_constraints(
+                    db,
+                    property_id="",
+                    policy_key="default_access_policy",
+                    field_name=field_name,
+                )
+                == FileUploadConstraints.defaults()
+            )
+
+    def test_single_action_returns_field_limits(self, db):
+        from fides.service.privacy_request_attachments.privacy_request_attachments_service import (
+            FileUploadConstraints,
+            resolve_upload_constraints,
+        )
+
+        field = self._file_field(
+            "Passport", max_size_bytes=2048, allowed_file_types=["pdf", "png"]
+        )
+        with self._stub_config(
+            self._faux_config([self._faux_action({"passport": field})])
+        ):
+            assert resolve_upload_constraints(
+                db,
+                property_id="",
+                policy_key="default_access_policy",
+                field_name="passport",
+            ) == FileUploadConstraints(
+                max_size_bytes=2048,
+                allowed_file_types=frozenset({"pdf", "png"}),
+            )
+
+    def test_property_id_passed_through(self, db):
+        from fides.service.privacy_request_attachments.privacy_request_attachments_service import (
+            resolve_upload_constraints,
+        )
+
+        field = self._file_field(
+            "Passport", max_size_bytes=512, allowed_file_types=["pdf"]
+        )
+        with self._stub_config(
+            self._faux_config([self._faux_action({"passport": field})])
+        ) as resolver:
+            resolve_upload_constraints(
+                db,
+                property_id="prop_xyz",
+                policy_key="default_access_policy",
+                field_name="passport",
+            )
+        resolver.assert_called_once_with(db, "prop_xyz")
+
+
+class TestFileUploadConstraintsValidation:
+    """Self-validation invariants enforced by ``__post_init__``."""
+
+    @pytest.mark.parametrize(
+        "max_size_bytes, allowed, match",
+        [
+            pytest.param(
+                0,
+                frozenset({"pdf"}),
+                "max_size_bytes must be greater than 0",
+                id="zero_size",
+            ),
+            pytest.param(
+                -1,
+                frozenset({"pdf"}),
+                "max_size_bytes must be greater than 0",
+                id="negative_size",
+            ),
+            pytest.param(
+                1024,
+                frozenset(),
+                "allowed_file_types must not be empty",
+                id="empty_allowed",
+            ),
+            pytest.param(
+                1024,
+                frozenset({"exe"}),
+                "Unsupported file types",
+                id="unsupported_type",
+            ),
+        ],
+    )
+    def test_rejects_invalid(self, max_size_bytes, allowed, match):
+        with pytest.raises(ValueError, match=match):
+            FileUploadConstraints(
+                max_size_bytes=max_size_bytes, allowed_file_types=allowed
+            )
+
+    def test_defaults_pass_validation(self):
+        c = FileUploadConstraints.defaults()
+        assert c.max_size_bytes > 0
+        assert c.allowed_file_types

--- a/tests/ops/service/storage/test_util.py
+++ b/tests/ops/service/storage/test_util.py
@@ -453,11 +453,16 @@ class TestFilesMagicBytes:
         assert FilesMagicBytes.from_bytes(b"not a real file") is None
 
     def test_default_public_upload_allowed_file_types(self):
-        assert FilesMagicBytes.default_public_upload_allowed_file_types() == {
+        assert AllowedFileType.default_public_upload_allowed_file_types() == {
             "pdf",
             "jpg",
             "png",
         }
+
+    def test_supported_file_types(self):
+        assert AllowedFileType.supported_file_types() == set(
+            AllowedFileType.__members__.keys()
+        )
 
 
 class TestExtensionForMime:


### PR DESCRIPTION
Ticket [ENG-3517]

### Description Of Changes

Adds per-field upload constraints (`max_size_bytes`, `allowed_file_types`) to `FileUploadCustomPrivacyRequestField` and resolves them at upload time so the privacy-center upload endpoint enforces the same limits the privacy-center config declares for that field.

Binds each `AttachmentUserProvided` row to its upload context (`field_name`, `property_id`, `policy_key`) at upload time and re-validates the triple at submission so an upload made under one (property, policy, field) cannot be claimed under another.

### Code Changes

* `FileUploadCustomPrivacyRequestField`: new `max_size_bytes` (>0, default 10 MB) and `allowed_file_types` (non-empty subset of `AllowedFileType`, default `{pdf, jpg, png}`) fields.
* New `FileUploadConstraints` dataclass — self-validates `max_size_bytes > 0`, allow-list non-empty, all entries in `AllowedFileType`.
* New `resolve_upload_constraints(db, *, property_id, policy_key, field_name)` — looks up the privacy-center config, finds the matching action + field, returns its constraints; falls back to defaults on any miss.
* `AttachmentUserProvidedService.upload_attachment` now takes `constraints`, `field_name`, `property_id`, `policy_key`; enforces `constraints.max_size_bytes` and `constraints.allowed_file_types`; persists the context triple on the row.
* `resolve_file_attachments` re-validates `(field_name, property_id, policy_key)` against the submission context; mismatch raises `AttachmentContextMismatchError`. `promote_rows_to_attachments` re-asserts the same triple before flipping rows.
* Upload endpoint resolves constraints, enforces them via `Content-Length` + streaming chunked check, and forwards the context triple to the service.

### Steps to Confirm

1. Configure a privacy-center action with a `FileUploadCustomPrivacyRequestField` of `field_type: file`, `required: true`, `max_size_bytes: 1048576`, `allowed_file_types: [pdf]`.
2. `POST /api/v1/privacy-request/attachment` with a `.pdf` file (≤1 MB), the action's `policy_key`, the action's `property_id`, and `field_name` matching the field — expect 200 with an attachment id.
3. Repeat with a `.png` of any size — expect 400 (`Disallowed file type`).
4. Repeat with a `.pdf` >1 MB — expect 413 (`File exceeds maximum allowed size`).
5. Submit a privacy request referencing the uploaded id under the matching `(property_id, policy_key, field_name)` — expect submission to succeed.
6. Submit referencing a different `policy_key` or `property_id` — expect `AttachmentContextMismatchError`.

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a [db-migration](https://github.com/ethyca/fides/labels/db-migration) label to the entry if your change includes a DB migration
  * [ ] Add a [high-risk](https://github.com/ethyca/fides/labels/high-risk) label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [x] No migrations (DB columns landed in [#8040](https://github.com/ethyca/fides/pull/8040))
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [x] No documentation updates required

[ENG-3517]: https://ethyca.atlassian.net/browse/ENG-3517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
