### PR TITLE
ENG-3252: Remove redundant and flickering tooltip from Action Center view

### DIFF
--- a/changelog/8094-action-center-fields-tooltip-removal.yaml
+++ b/changelog/8094-action-center-fields-tooltip-removal.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Removed redundant and flickering tooltip from breadcrumb paths in the Action Center monitor fields view.
+pr: 8094
+labels: []

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorFieldListItem.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorFieldListItem.tsx
@@ -10,7 +10,6 @@ import {
   SparkleIcon,
   Tag,
   Text,
-  Tooltip,
 } from "fidesui";
 import _ from "lodash";
 
@@ -171,17 +170,15 @@ const renderMonitorFieldListItem: RenderMonitorFieldListItem = ({
                 {MAP_DIFF_STATUS_TO_RESOURCE_STATUS_LABEL[diff_status].label}
               </Tag>
             )}
-            <Tooltip title={urn} mouseEnterDelay={0.5}>
-              <Breadcrumb
-                className={styles["monitor-field__breadcrumb"]}
-                items={parseResourceBreadcrumbs(urn).map(renderBreadcrumbItem)}
-                // @ts-expect-error - role works here, but Ant's type system doesn't know that
-                role="presentation"
-                style={{
-                  overflow: "hidden",
-                }}
-              />
-            </Tooltip>
+            <Breadcrumb
+              className={styles["monitor-field__breadcrumb"]}
+              items={parseResourceBreadcrumbs(urn).map(renderBreadcrumbItem)}
+              // @ts-expect-error - role works here, but Ant's type system doesn't know that
+              role="presentation"
+              style={{
+                overflow: "hidden",
+              }}
+            />
           </Flex>
         }
         description={


### PR DESCRIPTION
Ticket [ENG-3252] <!-- simply paste the ticket number between the brackets and it will auto-convert to a link -->

### Description Of Changes

The full URN tooltip on Action Center monitor field rows duplicated the path already shown in each row's visible breadcrumb, and was reported as flickering while hovering/scrolling. This PR removes it, following the precedent of #7962 (ENG-3428) which removed a similarly redundant/buggy tooltip from the Activity tab.

### How it looked before
<img width="1142" height="452" alt="image" src="https://github.com/user-attachments/assets/80a2825f-350d-4c2d-9511-e7714dc155dd" />

The `Cookie_House_BigQuery.prj-bqextract-419116.cms_publisher.users.last_login` visibile in the image's tooltip doesn't add any information to the breadcrumb. 


### Code Changes

* Removed the `<Tooltip title={urn}>` wrapper around the breadcrumb in `MonitorFieldListItem.tsx`.
* Removed the now-unused `Tooltip` import from `fidesui` in the same file.
* Added a `Fixed` changelog fragment.

### Steps to Confirm

1. Run the admin UI against a Plus backend with discovery monitor data.
2. Navigate to Detection & Discovery → Action center, then open a datastore monitor (e.g., a BigQuery monitor with field-level results).
3. Hover over the breadcrumb paths in the field rows and confirm no URN tooltip appears.
4. Confirm the breadcrumb itself still renders the dataset / schema / table path inline as before.

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-3252]: https://ethyca.atlassian.net/browse/ENG-3252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
