### PR TITLE
ENG-3457: fix long field name overflow in action center monitor results

### DIFF
--- a/changelog/8095-fix-action-center-field-name-overflow.yaml
+++ b/changelog/8095-fix-action-center-field-name-overflow.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Fixed visual bug where long field names in the Action Center monitor results would overflow out of place in some components
+pr: 8095
+labels: []

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/DetailsDrawer/DetailsDrawerTitle.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/DetailsDrawer/DetailsDrawerTitle.tsx
@@ -25,13 +25,13 @@ export const DetailsDrawerTitle = ({
 
   return (
     <Flex align="center" gap="small">
-      {titleIcon}
+      {titleIcon && <span className="flex-none">{titleIcon}</span>}
       <Tooltip title={isTruncated ? title : null}>
         <span ref={titleRef} className="grow truncate">
           {title}
         </span>
       </Tooltip>
-      {titleTag && <Tag {...titleTag} />}
+      {titleTag && <Tag {...titleTag} className="flex-none" />}
     </Flex>
   );
 };

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/DetailsDrawer/DetailsDrawerTitle.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/DetailsDrawer/DetailsDrawerTitle.tsx
@@ -8,6 +8,9 @@ export const DetailsDrawerTitle = ({
   titleIcon,
   titleTag,
 }: Pick<DetailsDrawerProps, "title" | "titleIcon" | "titleTag">) => {
+  // Ant's `<Text ellipsis={{ tooltip }}>` would normally cover this, but its
+  // overflow detection doesn't fire reliably inside the drawer's animated
+  // mount path, so we drive the tooltip from a manual ResizeObserver.
   const titleRef = useRef<HTMLSpanElement>(null);
   const [isTruncated, setIsTruncated] = useState(false);
 

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/DetailsDrawer/DetailsDrawerTitle.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/DetailsDrawer/DetailsDrawerTitle.tsx
@@ -1,4 +1,5 @@
-import { Flex, Tag } from "fidesui";
+import { Flex, Tag, Tooltip } from "fidesui";
+import { useEffect, useRef, useState } from "react";
 
 import type { DetailsDrawerProps } from "./types";
 
@@ -7,10 +8,29 @@ export const DetailsDrawerTitle = ({
   titleIcon,
   titleTag,
 }: Pick<DetailsDrawerProps, "title" | "titleIcon" | "titleTag">) => {
+  const titleRef = useRef<HTMLSpanElement>(null);
+  const [isTruncated, setIsTruncated] = useState(false);
+
+  useEffect(() => {
+    const el = titleRef.current;
+    if (!el) {
+      return undefined;
+    }
+    const update = () => setIsTruncated(el.scrollWidth > el.clientWidth);
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [title]);
+
   return (
     <Flex align="center" gap="small">
       {titleIcon}
-      <span>{title}</span>
+      <Tooltip title={isTruncated ? title : null}>
+        <span ref={titleRef} className="grow truncate">
+          {title}
+        </span>
+      </Tooltip>
       {titleTag && <Tag {...titleTag} />}
     </Flex>
   );

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/DetailsDrawer/index.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/DetailsDrawer/index.tsx
@@ -29,5 +29,6 @@ export const DetailsDrawer = ({
     }
     width={width}
     {...drawerProps}
+    className={`[&_.ant-drawer-title]:min-w-0 ${drawerProps.className ?? ""}`}
   />
 );

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorFieldListItem.module.scss
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorFieldListItem.module.scss
@@ -2,8 +2,17 @@
   &__title {
     white-space: nowrap;
     font-weight: normal; // overrides Ant default title font weight
+    min-width: 0; // allow flex children to shrink below their intrinsic size
     & button {
       font-weight: 600;
+    }
+  }
+  &__name {
+    min-width: 0;
+    overflow: hidden;
+    & > span {
+      max-width: 100%;
+      overflow: hidden;
     }
   }
   &__breadcrumb {

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorFieldListItem.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/MonitorFieldListItem.tsx
@@ -156,10 +156,10 @@ const renderMonitorFieldListItem: RenderMonitorFieldListItem = ({
             <Button
               type="text"
               size="small"
-              className="-mx-2"
+              className={`-mx-2 ${styles["monitor-field__name"]}`}
               onClick={() => onNavigate && onNavigate(urn)}
             >
-              {name}
+              <Text ellipsis={{ tooltip: name }}>{name}</Text>
             </Button>
             {diff_status && diff_status !== DiffStatus.ADDITION && (
               <Tag


### PR DESCRIPTION
Ticket [ENG-3457] <!-- simply paste the ticket number between the brackets and it will auto-convert to a link -->

### Description Of Changes

Long field names in the Action Center monitor results overflowed into the Confidence and Actions area on each row, and overflowed off-screen in the resource details drawer header. This PR truncates the field name with an ellipsis in both spots and shows a tooltip with the full name only when truncation actually occurs (matching the existing schema explorer pattern, so short names don't trigger tooltip noise on hover).

### Before
<img width="786" height="322" alt="image" src="https://github.com/user-attachments/assets/be1407ed-77de-4fde-a7da-f94f38ac2906" />

<br />

<img width="854" height="526" alt="image" src="https://github.com/user-attachments/assets/8e7dafdb-4462-47e2-b6c9-7bc2befa94ee" />

### After
<img width="1086" height="376" alt="image" src="https://github.com/user-attachments/assets/552290fa-bf74-42a6-9aac-281003ebfabe" />

<br />

<img width="1131" height="471" alt="image" src="https://github.com/user-attachments/assets/eaaf140a-0284-406f-9ca8-346c5a5c0d3f" />


### Code Changes

* Wrapped the row field name in `<Text ellipsis={{ tooltip: name }}>` and added SCSS rules (`min-width: 0` on the title flex, new `monitor-field__name` rule) so the button can shrink and the inner text can ellipsize.
* Added Tailwind arbitrary variant `[&_.ant-drawer-title]:min-w-0` on `DetailsDrawer` to override Ant's default `min-width: auto` on the drawer title slot, which was preventing it from shrinking.
* Replaced the drawer title `<span>` with a `Tooltip` wrapping a `truncate`d span, with a `ResizeObserver` driving an `isTruncated` flag that gates the tooltip — Ant's `Text` ellipsis detection didn't fire reliably in the drawer's animated mount context.
* Added `flex-none` to the drawer title icon and tag wrappers so they keep their natural size when the title competes for flex space.
* Added changelog entry.

### Steps to Confirm

1. Navigate to **Detection & Discovery → Action center** and click into any datastore monitor.
2. In the monitor results list, locate a row with a field. In DevTools, edit the visible text inside the row's `<span>` to a ~200-character all-caps snake_case string to simulate a long field name.
3. Confirm the row truncates with `…` instead of overflowing into the Confidence indicator and action buttons.
4. Hover the truncated name and confirm a tooltip appears with the full text.
5. Hover a short field name (e.g. `last_login`) and confirm no tooltip appears.
6. Click the row to open the resource details drawer. Repeat the DevTools text edit on the drawer title's `<span>` to simulate a long title.
7. Confirm the drawer title truncates with `…`, the column icon and `Unlabeled` tag stay visible at full size, and hovering the truncated title shows the tooltip with the full name.

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-3457]: https://ethyca.atlassian.net/browse/ENG-3457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
