### PR TITLE
Proposal: in-application event framework — design + Phase 1 plumbing

### DIFF
--- a/docs/fides/docs/event-framework/01-design.md
+++ b/docs/fides/docs/event-framework/01-design.md
@@ -1,0 +1,425 @@
+# Event Framework — Technical Design
+
+A lightweight in-application event framework for **asynchronous reactive work** — emitting an event when something happens, and dispatching registered handlers to react asynchronously, without coupling the publisher to its consumers.
+
+## 1. TL;DR
+
+- **Transport**: Celery, with the existing Redis broker. No new infrastructure.
+- **Programming model**: typed event entities (frozen dataclasses) + decorator-registered subscribers + autodiscovery.
+- **Operational home (default)**: `fides` Celery queue, picked up by the existing "Other" worker. Subscribers can opt into a dedicated queue / worker if a deployment justifies it.
+- **Delivery semantics**: at-least-once, **not guaranteed**. Subscribers must be idempotent against current state. Where the work has correctness implications, an independent reconciler is required.
+- **Where the bones live**: fides OSS. fidesplus (and other consumers) register subscribers and emit events.
+
+The framework is purposefully narrow on what it promises. See §2 for the prescriptive when-to-use boundary, which exists to prevent accidental misuse.
+
+Although informally referred to as "pub/sub", the framework does not implement on-the-wire pub/sub semantics (Redis Pub/Sub, Streams, etc.). Fan-out is handled via the in-process subscriber registry; the wire transport is point-to-point Celery dispatch per (event, subscriber) pair. See §5.3 for why.
+
+For implementation phasing and rollout, see `02-implementation-plan.md`.
+
+## 2. When to Use vs. When NOT to Use
+
+This is the most important section in the doc. Default to *not* using the framework if a use case does not clearly map onto the left column.
+
+| ✅ Use the framework when... | ❌ Do NOT use when... |
+|---|---|
+| The work is **asynchronous reactive work**: something happens, work happens later in response. | **Request-critical or synchronous** — the publisher needs the result before responding. |
+| **Eventual consistency is acceptable** (subscriber lag of seconds-to-minutes is fine). | **Exactly-once delivery, strict ordering, or audit-grade** event-sourcing requirements. |
+| Subscribers are **idempotent** — running the same handler twice produces the same end state. | **High-frequency per-row signals** — e.g. one event per staged-resource update. Use bulk/debounced events instead. |
+| Where correctness depends on the work happening, a **reconciler** can produce the correct end state independently of event delivery. | The work needs **guaranteed delivery** with no reconciliation path. |
+| The publish point is in a **session-aware context** (so transactional safety holds). | The publish point is **detached from a session** — e.g. a background worker not associated with a transaction. |
+
+### 2.1 Non-Goals
+
+The following are explicit non-goals. Surface them when reviewing new use cases. They are listed in order of how strongly they should be stressed.
+
+- **The framework does not guarantee delivery.** Process crashes between commit and dispatch, broker unavailability, or worker errors can drop events. If your use case cannot tolerate event loss, this framework is not the right choice.
+- **The framework does not provide ordering guarantees.** Events can be observed out of order across publishers and across subscribers. Subscribers must not rely on order.
+- **The framework is not a replacement for synchronous calls.** If a route's response correctness depends on the work happening, do the work synchronously in the request.
+- **The framework does not detect missed publishes.** If a publisher forgets to emit, the framework cannot tell. The mitigation is convention (publish from a session-aware chokepoint, see §6.6 for the recommended pattern) and the per-subscriber reconciler. New mutation paths that bypass the convention will silently miss events; this is acceptable only because every correctness-sensitive subscriber recovers via reconciliation.
+- **The framework is not a generic message bus.** It is an in-application event dispatcher scoped to fides + fidesplus. It does not bridge to external systems (Kafka, SNS, webhooks, etc.).
+- **The framework is not pub/sub on the wire.** Despite the colloquial name, fan-out happens through the in-process subscriber registry, not Redis Pub/Sub or Streams.
+
+## 3. Motivation & Driving Use Cases
+
+Several upcoming features require asynchronous reactive work in response to application state changes. Each could be implemented as a one-off Celery task plus a remember-to-call-it discipline. Doing so for every such feature produces:
+
+- Coupling between the publisher (the action) and every consumer (the reaction), making it hard to add new consumers without modifying every action site.
+- An ever-growing list of "remember to call X when you do Y" rules with no architectural enforcement.
+- Inconsistent observability, retry, and reconciliation patterns across features.
+
+A small framework that standardizes the *shape* of this work — typed events, registered subscribers, explicit publish points, recommended reconciler pattern — pays off across the next several features even though the first two consumers don't strictly require it.
+
+The two driving use cases below establish the constraints. The framework is shaped to fit them well; future use cases that don't fit this shape should be questioned (per §2).
+
+### 3.1 Use Case 1: Monitor Stewardship Inheritance
+
+Per `system-integration-link/02-technical-design.md` §5 (Steward Inference Design) and [fidesplus PR #3394](https://github.com/ethyca/fidesplus/pull/3394), monitors can inherit data stewards from their linked systems.
+
+**Data model** (post-PR-3394):
+
+- `System.data_stewards` — many-to-many to `FidesUser` via `systemmanager`.
+- `monitorconfig.inherit_system_stewards: bool` (default true on new monitors; false on backfilled).
+- `monitorsteward.source` ∈ {`explicit`, `inherited`}.
+- `monitorsteward.source_system_id` — populated when `source = inherited`.
+- `system_connection_config_link` joins systems to connection configs; `monitorconfig.connection_config_id` links monitors to connection configs.
+
+**Propagation graph**:
+
+```
+System.data_stewards
+  → SystemConnectionConfigLink (system_id = $system_id)
+    → ConnectionConfig
+      → MonitorConfig (where inherit_system_stewards = TRUE)
+        → MonitorSteward rows (source = "inherited", source_system_id = $system_id)
+```
+
+**Triggers**:
+- `System.data_stewards` membership changes.
+- `system_connection_config_link` rows added / removed.
+- `monitorconfig.inherit_system_stewards` toggled on / off.
+- `MonitorConfig.connection_config_id` reassigned (rare).
+- New `MonitorConfig` created with `inherit_system_stewards = TRUE`.
+
+**Subscriber's job**: for each affected monitor, reconcile its inherited `monitorsteward` rows with the union of `data_stewards` across linked systems. Add missing inherited rows, delete now-stale inherited rows, leave explicit rows untouched.
+
+**Reconciler**: a periodic full-sweep task that re-derives inherited stewardship for every monitor with `inherit_system_stewards = TRUE`, regardless of whether events fired. Runs on an APScheduler cadence and on demand via a manual API endpoint. Cadence is product-driven and should be tight enough that *functional* staleness (see below) is bounded.
+
+**Subscriber lives in fidesplus** (under the discovery monitor service area). Events are emitted from fides OSS where `System.data_stewards` and the link table live; fidesplus may emit additional monitor-side events (e.g. `MonitorInheritanceFlagChanged`).
+
+**Why this fits the framework**:
+
+- **Eventual consistency is acceptable** — but with a tighter latency tolerance than display-only freshness. Until propagation runs, inherited stewardship is genuinely not in effect (a user expecting access via inheritance does not have it). Reconciler cadence should reflect this; "minutes" is acceptable, "hours" is not.
+- The work is **bounded and idempotent** against current state. Reconciling inherited rows for a monitor twice in a row produces the same result.
+- The publisher (the System mutation site) does not need the propagation result.
+- A **reconciler is straightforward** — full sweep over inheriting monitors. Bounded by the number of monitors with the flag set.
+
+### 3.2 Use Case 2: Monitor Aggregate Statistics Refresh
+
+Per the in-flight monitor aggregate statistics work (ENG-2780 / ENG-2923, Phase 3 of the implementation plan), the per-monitor statistics cache (`monitor_aggregate_statistics`) should be refreshed when operations affect a monitor's data, rather than purely on an interval.
+
+**Triggers**:
+- `promote` / `confirm` of staged resources.
+- `classify` / `review` actions.
+- `mute` / `unmute` of staged resources.
+- A monitor execution (detection / classification / promotion task) completing.
+- *Implicit*: any future state-changing operation on staged resources or a monitor.
+
+**Subscriber's job**: for the affected `monitor_config_key`, recompute statistics and upsert into `monitor_aggregate_statistics`. Should debounce — a single recompute within a short window (e.g. 30s) of the most recent event suffices for a burst of operations on the same monitor.
+
+**Reconciler**: already in place. `initiate_aggregate_stats_refresh` (APScheduler) periodically refreshes any rows older than the staleness skip buffer. The event-driven path reduces how often the reconciler does meaningful work; it does not replace it.
+
+**Subscriber lives in fidesplus** (alongside the existing aggregate statistics package). Events are emitted from fidesplus (the actions all live there).
+
+**Why this fits the framework**:
+
+- **Eventual consistency is acceptable** — UI showing slightly stale aggregate stats is fine. There is no functional impact, only display freshness.
+- The work is **bounded and idempotent** against current state — recomputing a monitor's stats twice gives the same result.
+- The publisher (the operation's call site) does not need the recompute result.
+- A **reconciler already exists** — the framework just reduces how often it does meaningful work.
+- The "implicit" trigger above is the staleness risk: as new ways to operate on a monitor are added, each new call site must remember to publish. The framework makes the subscription-side architectural (one handler, one event type) but cannot itself prevent missed publishes — that's on the publish convention (§6.6) plus the reconciler.
+
+## 4. Design Principles
+
+1. **Explicit publishing.** No implicit ORM or model event listeners. Publishers call `publish_after_commit(...)` directly. Visibility wins over magic.
+2. **Typed events as domain entities.** Frozen dataclasses, not Pydantic schemas. Events are internal data representation, not API surface. (Pydantic is reserved for API I/O per the established backend convention.)
+3. **Idempotent + reconcilable subscribers.** Subscribers re-read current state and converge; they do not depend on payloads being authoritative. Where correctness matters, an independent reconciler is the floor.
+4. **Operational continuity by default.** Subscribers ride existing Celery workers (the "Other" worker) by default. Dedicated workers are an opt-in tuning lever per subscriber, not a framework requirement and not a framework prohibition.
+5. **Boring transport.** Celery + existing Redis broker. No new infrastructure dependencies.
+
+## 5. Architecture
+
+### 5.1 Components
+
+```
+┌────────────────────────────┐
+│ Caller (repository,        │
+│ service, or other          │   publish_after_commit(session, event)
+│ session-aware context)     │   ──────────────────────────────►
+│   ...                      │
+│   publish_after_commit(...)│
+└────────────────────────────┘
+              │
+              ▼ (after session commits)
+┌────────────────────────────┐
+│ Dispatcher                 │   for handler in registry[type(event)]:
+│  - looks up registry       │     celery.send_task(handler.task, payload)
+│  - serializes payload      │
+│  - dispatches to Celery    │
+└────────────────────────────┘
+              │
+              ▼
+┌────────────────────────────┐
+│ Celery (existing Redis     │   one task per (event, subscriber)
+│ broker, "Other" worker     │   — or dedicated worker per opt-in queue
+│ by default)                │
+└────────────────────────────┘
+              │
+              ▼
+┌────────────────────────────┐
+│ @subscribes_to handler     │   deserialize payload → handler(event)
+│  - reads current state     │   subscriber-specific logic
+│  - writes derived state    │
+└────────────────────────────┘
+
+         (independent of event flow)
+┌────────────────────────────┐
+│ Reconciler (APScheduler)   │   periodic task that converges to the
+│  - reads source state      │   correct end state regardless of event
+│  - reconciles derived state│   delivery (required where correctness
+│                            │   depends on the subscriber)
+└────────────────────────────┘
+```
+
+### 5.2 Transport Choice: Celery + Redis (existing)
+
+Celery is the existing async work executor in both repos. Using it for event dispatch:
+
+- **Reuses retries, signals, observability, and the "Other" worker.** The transport is operationally invisible — subscribers look like Celery tasks because they are Celery tasks.
+- **Decouples publishers from subscribers via the registry**, not via the broker. Multiple subscribers per event are supported; the dispatcher fans out by enqueueing one task per registered handler.
+- **No new infrastructure.** Same Redis instance, same broker config, same worker tier.
+
+A future use case requiring different delivery characteristics (stronger guarantees, true wire-level fan-out) can introduce a *second* transport behind the same `publish_after_commit` API. The programming model does not need to change to accommodate that.
+
+### 5.3 Alternatives Considered
+
+#### 5.3.1 Redis Streams (rejected)
+
+Native at-least-once via consumer groups + on-the-wire fan-out. Rejected because:
+
+- Reinvents retry / DLQ / observability that Celery already provides.
+- Cluster-mode (`config.redis.cluster_enabled`) constrains stream keys to a single hash slot — keyspace discipline forever after.
+- No async Redis client in-tree; introducing one adds maintenance.
+- Requires long-lived consumer processes — a net-new operational tier.
+- Both day-one use cases have a single subscriber. Fan-out is satisfied by the registry without on-the-wire fan-out.
+
+#### 5.3.2 Redis Pub/Sub (rejected)
+
+Lightest weight on the wire; true fan-out semantics; at-most-once is acceptable for the day-one use cases. Rejected nevertheless because the wire-level lightness does not survive contact with a production deployment:
+
+- **Where do subscribers run?** Webserver pods are out (every pod receives every message → N-handlers-per-event unless we build per-event distributed locks or partitioning, *plus* heavy SQL recomputes would compete for request threads). Celery workers don't natively hold long-lived `SUBSCRIBE` connections, and pinning a handful of workers to do so fights the worker model. The realistic option is a dedicated singleton subscriber pod — i.e. a *new* pod tier, just to hold the wire connection.
+- **The handler work still wants to run in Celery.** DB connections, retries on transient errors, structured task observability — all of which Celery gives us. So a Pub/Sub deployment becomes Pub/Sub-on-the-wire → bridge process → Celery task dispatch → handler. That bridge process is operational overhead Celery's own dispatch does not have.
+- **No backpressure**: slow subscribers get disconnected by Redis when client output buffers exceed `client-output-buffer-limit pubsub`. This needs detection and reconnect logic.
+- **No DLQ, no metrics, no built-in retries** — would be reinvented per subscriber.
+
+Net: the protocol-level lightness pays itself back at the deployment level. For wire-level fan-out to many connected processes (cache invalidation across web pods, live SSE push to admin-UI sessions, etc.) Pub/Sub is genuinely the right tool — see §5.5 for how that future is preserved.
+
+#### 5.3.3 Postgres LISTEN/NOTIFY + transactional outbox (rejected)
+
+Strongest delivery guarantee — events written in the same transaction as the data, published via NOTIFY or polled from the outbox. Rejected because:
+
+- Both day-one use cases tolerate event loss with reconciliation; the complexity buys correctness we don't need.
+- Adds a new long-lived listener tier (LISTEN holds a session connection; pgbouncer-incompatible).
+- Additional schema (outbox table) and migration for every consumer.
+- Can be revisited as a second transport if a future use case requires it; no change to the publish API.
+
+#### 5.3.4 SQLAlchemy `event.listen` hooks (rejected)
+
+Considered as the publish trigger to avoid the "remember to call publish" problem. Rejected because:
+
+- Bypassed by core-level writes (`Session.execute(update(...))`, `bulk_insert_mappings`, raw SQL) — silent missed events.
+- Invisible at the call site — the debug story becomes "the hook fires somewhere, look at all model files."
+- Doesn't catch all the triggers we care about (e.g. composite mutations across multiple tables).
+
+### 5.4 Deployment Topology
+
+- Subscribers default to the `fides` Celery queue.
+- The existing **"Other" worker** (configured with `--exclude-queues=...` per `fides-helm/fides/templates/fides/worker-deployment.yaml`) automatically picks them up. This matches the public docs guidance: *"Always configure an 'Other' worker to handle messaging tasks and new task types released by Ethyca"* (`fidesdocs/pages/platform/workers.mdx`).
+- A subscriber can opt into a dedicated queue by overriding `@subscribes_to(queue="...")`. The deployment can then add a worker pinned to that queue — same lever already used for the optional `worker-messaging` deployment. **This is a per-subscriber, per-deployment tuning decision; the framework neither requires nor prohibits new pod types.**
+
+### 5.5 Future Transports
+
+The `publish_after_commit` API is transport-agnostic. The dispatcher reads from the registry and routes events to handlers; the wire mechanism is an implementation detail.
+
+If a future use case needs wire-level fan-out — e.g. cache invalidation across web pods, live SSE/websocket push to connected admin-UI sessions, in-memory state synchronization — the framework can grow a Redis Pub/Sub transport (or another) behind the same publish API. Subscribers for those events would declare a different transport via the decorator; existing Celery-backed subscribers are unaffected.
+
+This preserves the option without paying for it now.
+
+## 6. Programming Model
+
+### 6.1 Event Types — Frozen Dataclasses
+
+Events are **domain entities** — frozen dataclasses, not Pydantic schemas. Pydantic is reserved for API surface; events are internal data representation per the established backend convention (cf. `entities.py` per the system-integration-link package).
+
+```python
+# fides/api/events/system_events.py (or per-domain modules)
+
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class SystemDataStewardsChanged:
+    """Emitted when the data stewards on a System change.
+
+    Subscribers must read current state for the steward list — by the
+    time a subscriber runs, the membership may have changed again.
+    """
+    system_id: str
+```
+
+Conventions:
+- `frozen=True` (events are immutable values).
+- One dataclass per event type. Past-tense names: `SystemDataStewardsChanged`, `MonitorOperationCompleted`, `SystemConnectionLinkChanged`.
+- Payload contains **identifiers only**, not state. Subscribers read state at execution time.
+- Located in `events/` packages alongside the domain that emits them.
+- A dataclass field that is itself complex should be a JSON-serializable primitive or another frozen dataclass — events are serialized to Celery payloads and deserialized in worker processes.
+
+There is no central `EventType` enum. The dataclass type itself is the event identity.
+
+### 6.2 Publishing — `publish_after_commit`
+
+```python
+from fides.api.events import publish_after_commit
+from fides.api.events.system_events import SystemDataStewardsChanged
+
+class SystemRepository:
+    def set_data_stewards(self, system_id: str, user_ids: list[str]) -> None:
+        # ... write the change ...
+        publish_after_commit(
+            self.session,
+            SystemDataStewardsChanged(system_id=system_id),
+        )
+```
+
+Behavior:
+- Registers an `after_commit` callback on the SQLAlchemy session.
+- If the transaction commits → events publish in registration order (one Celery dispatch per (event, subscriber) pair).
+- If the transaction rolls back → callbacks never fire; no phantom events.
+- If the process dies between commit and dispatch → events are dropped; reconciliation recovers (where applicable).
+- Multiple `publish_after_commit` calls within one transaction → batched in registration order.
+
+The publisher must call this from a session-aware context. **Detached / sessionless publishing is intentionally not supported.** A sessionless publisher would lose the transactional guarantee (no rollback semantics), which is the whole point of `after_commit`.
+
+### 6.3 Subscribing — `@subscribes_to`
+
+```python
+from fides.api.events import subscribes_to
+from fides.api.events.system_events import SystemDataStewardsChanged
+
+@subscribes_to(SystemDataStewardsChanged)  # default queue: "fides"
+def propagate_inherited_stewardship(event: SystemDataStewardsChanged) -> None:
+    monitors = MonitorConfigRepository(...).list_inheriting_monitors_for_system(event.system_id)
+    for monitor in monitors:
+        reconcile_inherited_stewards(monitor, event.system_id)
+```
+
+Behavior:
+- Each `@subscribes_to(...)` registers an in-process handler and creates a Celery task that the dispatcher will call.
+- The handler receives a *deserialized event instance* (the dataclass).
+- A `queue=` argument overrides the default queue: `@subscribes_to(EventType, queue="fidesplus.high_volume_propagation")`.
+- Multiple subscribers per event are supported. Each runs as an independent Celery task with independent retries.
+- A subscriber for an event type defined in a different repo is supported (fidesplus subscribes to fides events) as long as the event class is importable.
+
+Subscriber autodiscovery follows the existing `autodiscover_task_locations` pattern (`fides/api/tasks/__init__.py`, extended in `fidesplus/api/worker/__init__.py`). Each app registers its subscriber package paths at import time.
+
+**Subscriber module hygiene.** Subscriber modules are imported on **both** webserver and worker:
+
+- On the webserver, so that the dispatcher's in-process registry is populated and `publish_after_commit` knows where to dispatch.
+- On the worker, so that the Celery task wrapper is registered and can execute the handler.
+
+This means import-time side effects in subscriber modules — heavy imports, network calls or DB lookups at module top level, expensive initialization — leak into the webserver boot path. Keep module-level imports minimal and side-effect-free; defer any expensive setup to inside the handler function (or to a fixture / lazy initializer). Same rule that already applies to Celery task modules.
+
+A subscriber whose module is not imported in a given process is invisible to the registry in that process, and `publish_after_commit` will treat its event type as having no subscribers there. This is correct behavior for the cross-repo case (a fides-OSS-only deployment without fidesplus loaded simply has no fidesplus subscribers registered) but is also the import-time coupling that makes "minimal module-top-level work" a hard rule, not a polite suggestion. If this coupling ever becomes load-bearing, manifest-based registration — declaring `(event_type, task_name, queue)` in a static manifest read at boot, without importing the subscriber's code — would be the path to relax it. Out of scope for v1.
+
+### 6.4 Reconciliation — Required for Correctness-Sensitive Subscribers
+
+Where the subscriber's work has **correctness implications** — that is, where the system is in a *wrong* (not just stale) state until the work runs — an independent reconciler is required.
+
+The framework's correctness contract for these subscribers:
+
+> *If event flow stops entirely, the system reaches the correct end state on the reconciler's cadence.*
+
+Implications for reviewers:
+- A new correctness-sensitive subscriber PR includes its reconciler (typically an APScheduler job) and tests for the reconciler.
+- Design review focuses on the reconciler — its scope, frequency, blast radius — at least as much as on the event-driven happy path.
+- A subscriber whose reconciler would be prohibitively expensive (full O(N) sweep over a large table on a tight cadence) is a sign the work is the wrong shape for this framework. Question the use case before optimizing the reconciler.
+
+A subscriber whose work is purely cosmetic / freshness-only (e.g. UI display) does not strictly require a reconciler — but the design review should be explicit about that classification.
+
+### 6.5 `@publishes` Marker (Optional Convention)
+
+The `@publishes(EventType, ...)` decorator is an **optional convention**, not a framework requirement. It exists to improve the visibility and reviewability of the publish discipline described in §6.6.
+
+```python
+@publishes(SystemDataStewardsChanged)
+def set_data_stewards(...) -> None:
+    ...
+    publish_after_commit(self.session, SystemDataStewardsChanged(...))
+```
+
+Three uses:
+
+1. **Documentation.** Reviewers immediately see what events the method emits. Greppable and meaningful in PR diffs.
+2. **Static registry.** A test can collect every `@publishes` marker and assert every declared event type has at least one publisher in tree, and every subscriber's event type has at least one publisher.
+3. **Test-time check.** A test helper introspects `@publishes`-marked methods and asserts each one calls `publish_after_commit` for its declared event type.
+
+The marker is not load-bearing at runtime. A method that calls `publish_after_commit` without the marker still publishes correctly. The marker is a hygiene tool, not a gate.
+
+### 6.6 Recommended Pattern: Publish from a Repository Layer
+
+This is a **recommended best practice**, not a framework requirement.
+
+The framework requires only that `publish_after_commit` be called from a session-aware context. Publishing can technically happen from a repository, a service, or even a route handler.
+
+We *recommend* publishing from a repository (or service) layer because:
+
+- It puts the publish call adjacent to the mutation that triggers it — visible in the same diff during review.
+- It centralizes the "remember to publish" decision: if a new caller of `set_data_stewards` is added, the repository method already publishes; the new caller doesn't need to remember.
+- It aligns with the broader Routes → Services → Repositories direction.
+
+A subscriber whose correctness depends on every relevant mutation publishing should pair this convention with a reconciler — the convention reduces drift but does not eliminate it.
+
+For the day-one use cases (§3), we plan to migrate the relevant mutation paths to a repository layer as part of feature implementation. See `02-implementation-plan.md`.
+
+## 7. Failure Modes & Mitigations
+
+| Failure mode | Mitigation |
+|---|---|
+| Phantom event from rolled-back transaction | `publish_after_commit` registers on `after_commit`; never fires on rollback. |
+| Process crash between commit and dispatch | Event dropped. Reconciler corrects (if subscriber has one). |
+| Broker unavailable | `send_task` raises; dispatcher logs and continues to the next event. Reconciler corrects. |
+| Subscriber raises | Standard Celery retry policy applies. After max retries the task fails into the result backend. Reconciler corrects. |
+| Slow subscriber backs up the queue | Operational lever: split the slow subscriber off to its own queue + dedicated worker. |
+| Stale payload (state changed between commit and subscriber run) | Subscribers read current state. Thin payloads remove reliance on payload contents. |
+| Duplicate dispatch (Celery `acks_late` redelivery) | Subscribers are idempotent against current state; running twice produces the same end state. |
+| Missed publish (publisher forgot to emit) | Reconciler corrects (for correctness-sensitive subscribers). For freshness-only subscribers, the next legitimate publish closes the gap. |
+
+The throughline: every failure mode either has no observable effect (reconcile and converge) or surfaces in standard Celery operational signals (failed tasks, queue depth, worker logs).
+
+## 8. Observability
+
+Three structured-logging points:
+
+- **Publish**: `event_type`, `event_id` (UUID generated at publish time), `publisher` (file:function via `inspect`), `session_id`.
+- **Dispatch** (per-subscriber, after commit): `event_id`, `event_type`, `subscriber_name`, `task_id` (Celery), `queue`.
+- **Handle** (in subscriber task): start, end, latency, outcome. Errors include stack trace.
+
+The Celery `request_id` propagation pattern in `fides/api/tasks/__init__.py` (via `before_task_publish` / `task_prerun` / `task_postrun` signals) is the model — the same mechanism extends to `event_id` propagation through the worker context.
+
+`event_id` is generated once at `publish_after_commit` time. All subscribers for that publish carry the same `event_id`. This makes it possible to trace a single logical event across multiple subscriber tasks in logs.
+
+Metrics are out of scope for v1 but the logging is structured so operators can derive volume / latency / error rate via log queries.
+
+## 9. Adding a New Event or Subscriber — Checklist
+
+When adding a new event:
+
+1. Define the dataclass in the appropriate `events/` package. Frozen, identifier-only payload, past-tense name.
+2. Identify the publish point. It MUST be called from a session-aware context. We recommend a repository or service method (see §6.6).
+3. Optionally add `@publishes(EventType)` on that method (see §6.5).
+4. Call `publish_after_commit(session, EventType(...))` after the mutation but before return.
+5. Add or extend an integration test that exercises the publish path and asserts the event is registered on the session.
+
+When adding a new subscriber:
+
+1. Define the handler function decorated with `@subscribes_to(EventType, queue=...)`. Default the queue unless deployment characteristics justify a dedicated one.
+2. The handler reads current state. Use payload only for identifiers.
+3. Decide whether the subscriber is correctness-sensitive (§6.4). If yes, define (or extend) a reconciler that produces the correct end state independently of event delivery, and wire it into APScheduler.
+4. Add subscriber tests (happy-path) and, for correctness-sensitive subscribers, reconciler tests (the case where events stopped flowing).
+5. Update operational docs if the subscriber requires a non-default queue.
+
+## 10. Open Questions
+
+1. **Marker enforcement strictness.** Should `@publishes` be required (CI-enforced) for any method that calls `publish_after_commit`, or recommended? Leaning *recommended* for v1, hardening to *required* after a stabilization period.
+2. **Reconciler cadence for stewardship inheritance.** Product-driven decision. Functional staleness (not just display staleness) gates this — until propagation runs, inherited stewardship is not in effect. Starting suggestion: every 15-30 minutes, plus on-demand API. Confirm with product.
+3. **Stats event granularity.** A single `MonitorOperationCompleted(monitor_config_key, operation_type)` vs. one event class per operation. The former is simpler and the subscriber doesn't care which operation fired; the latter is more expressive for hypothetical other subscribers. Lean toward the simpler model unless a concrete second subscriber needs the distinction.
+4. **Event package layout.** Proposal: `fides.api.events.<domain>` for events emitted from fides; `fidesplus.api.events.<domain>` for fidesplus-emitted events. Both repos can subscribe to events from either. Confirm before Phase 1 (see implementation plan).
+5. **`event_id` provenance.** Confirmed: generated at `publish_after_commit` time, shared across all subscribers for that publish. Documented here for clarity; flag if a different model is preferred.

--- a/docs/fides/docs/event-framework/02-implementation-plan.md
+++ b/docs/fides/docs/event-framework/02-implementation-plan.md
@@ -1,0 +1,170 @@
+# Event Framework — Implementation Plan
+
+Phasing for the rollout of the event framework described in `01-design.md`. Each phase is independently shippable. Phase 1 is a hard prerequisite for 2 and 3; Phases 2 and 3 are independent of each other and may be sequenced by team availability.
+
+## Phase 1 — Framework Plumbing (fides OSS)
+
+Land the framework with no consumers. Validate end-to-end with a unit-level "ping" event used in tests.
+
+### Scope
+
+- New `fides.api.events` package containing:
+  - `publish_after_commit(session, event)` — registers an `after_commit` callback on the session.
+  - `@subscribes_to(EventType, queue="fides")` — decorator that registers a handler in the in-process registry and binds a Celery task wrapper.
+  - `@publishes(EventType, ...)` — repository/service method marker for documentation, static registry, and test-time enforcement.
+  - Dispatcher: walks the registry on commit, generates `event_id`, calls `celery.send_task` per (event, subscriber).
+  - Registry: `dict[type[Event], list[Subscriber]]` populated by autodiscovery.
+  - Serialization: dataclass → dict for Celery payloads; dict → dataclass on the worker side.
+- Celery integration:
+  - Task wrappers around subscriber callables, registered with the existing Celery app.
+  - `event_id` propagation through `before_task_publish` / `task_prerun` / `task_postrun` signals (mirrors the existing `request_id` pattern in `fides/api/tasks/__init__.py`).
+- Logging:
+  - Publish, dispatch, handle log lines, structured per `01-design.md` §8.
+- Subscriber autodiscovery:
+  - Hook into the existing `autodiscover_task_locations` pattern. Subscribers are picked up the same way Celery tasks are.
+- Test helpers (in `tests/...` under fides):
+  - `assert_event_published(session, EventType)` for unit-level publish assertions.
+  - Marker-coverage test: every `@publishes(EventType)` method calls `publish_after_commit` for that type.
+  - Registry-coverage test: every event type has ≥ 1 publisher; every subscriber's event type has ≥ 1 publisher in tree.
+- Documentation:
+  - This plan + the design doc published.
+  - In-repo how-to (likely `dev-docs/events.md` or similar) showing the canonical publish + subscribe + reconciler example.
+
+### Validation
+
+A "ping" event lives only in tests. A test publishes it from inside a transactional context, commits, and asserts a corresponding Celery task was dispatched and ran. Also covers the rollback case (no dispatch).
+
+### Out of scope
+
+- Any actual event types, publishers, or subscribers in production code.
+- Metrics emission (logging-only for v1).
+- Operator-facing tooling (e.g. event replay) — the reconciler model intentionally substitutes.
+
+### Acceptance criteria
+
+- Unit + integration tests passing in fides repo.
+- Marker- and registry-coverage tests in place and green.
+- Design and how-to docs merged.
+- No subscribers or publishers in production code paths.
+
+## Phase 2 — Monitor Stewardship Inheritance
+
+Driving use case 1 from `01-design.md` §3.1. Splits across both repos: events emitted from fides (where `System.data_stewards` and `system_connection_config_link` live), subscriber + reconciler in fidesplus.
+
+### fides changes
+
+- Define event types in `fides.api.events.system_events`:
+  - `SystemDataStewardsChanged(system_id: str)`
+  - `SystemConnectionLinkChanged(system_id: str, connection_config_id: str, change: Literal["added", "removed"])`
+  - Additional events as needed for full trigger coverage.
+- Apply the recommended publish-from-repository pattern (`01-design.md` §6.6) to System-stewardship mutation paths. Where a repository method does not yet exist for a mutation site, introduce one as a targeted refactor — only the methods that mutate `systemmanager` membership and `system_connection_config_link` rows. This is a recommended pattern for these use cases, not a framework requirement.
+- Add `publish_after_commit` calls (and optionally `@publishes(...)` markers per §6.5) on those methods.
+- Tests: extend coverage so each new publish path has a unit-level assertion.
+
+### fidesplus changes
+
+- Define monitor-side event types where needed: e.g. `MonitorInheritanceFlagChanged(monitor_config_id: str, enabled: bool)`. Emit from the monitor config update repository / service.
+- Build the inheritance subscriber:
+  - Handler function decorated `@subscribes_to(SystemDataStewardsChanged)` and any other relevant event types.
+  - Reads current state via existing repositories: list inheriting monitors for the system, compute desired inherited steward set, reconcile `monitorsteward` rows (add missing, delete now-stale, leave explicit untouched).
+  - Lives under the discovery monitor service area (`fidesplus/api/service/discovery/...` or a new `monitor_stewards/` package — TBD during implementation).
+- Build the reconciler:
+  - APScheduler job: full sweep over every `MonitorConfig` with `inherit_system_stewards = TRUE`, running the same reconcile logic regardless of whether events fired.
+  - On-demand API endpoint to trigger immediately. Auth: requires existing monitor-steward write scope.
+  - Cadence: starting at 15-30 minutes, configurable via `DetectionDiscoverySettings`. Tighter than a typical reconciler because functional staleness (not just display staleness) is at stake — until propagation runs, inherited stewardship is not in effect. Confirm with product (open question §10.2 of design doc).
+- Backfill on rollout:
+  - One-off task that runs the reconciler at deploy time for any monitor with `inherit_system_stewards = TRUE` that has never been reconciled.
+
+### Tests
+
+- fides: publish-path unit tests on each new repository method.
+- fidesplus: subscriber tests (happy path, no-op when nothing changed, monitor not inheriting, multiple linked systems).
+- fidesplus: reconciler tests, including the case where events stopped flowing entirely — the reconciler must produce the correct end state.
+
+### Acceptance criteria
+
+- Subscriber + reconciler converge on identical end state for a battery of seeded scenarios.
+- Reconciler handles tenant-scale data without exceeding existing monitor-related job budget.
+- Backfill job runs idempotently.
+
+### Open / not covered
+
+- Whether to expose the on-demand reconcile endpoint in the public API or admin-only.
+- UI surfacing of "this is inherited from System X" beyond what PR #3394 already provides.
+
+## Phase 3 — Monitor Aggregate Statistics Refresh (fidesplus)
+
+Driving use case 2 from `01-design.md` §3.2. Replaces the "Phase 3" entry in the existing aggregate statistics implementation plan with a concrete, framework-driven design.
+
+### Scope
+
+- Define event type(s) in `fidesplus.api.events.monitor_events`:
+  - Recommended: `MonitorOperationCompleted(monitor_config_key: str, operation_type: str)` as a single event class.
+  - Operation types: `promote`, `confirm`, `classify`, `review`, `mute`, `unmute`, `monitor_execution`. (Granularity TBD — see open question §10.3 of design doc.)
+- Add `publish_after_commit` calls (and optionally `@publishes(...)` markers per design doc §6.5) on the relevant repository / service methods. Apply the recommended publish-from-repository pattern (§6.6) where practical. Targeted call sites:
+  - `discovery_monitor_promotion.py:promote_resources` (and the Celery task that calls it).
+  - Mute / unmute controllers: `discovery_monitor_actions_controller.py` (and equivalents under `web_monitor`, `identity_provider_monitors`).
+  - Classification / review action handlers (location to confirm during implementation).
+  - The `monitor_execution` context manager exit (lifecycle event for completed monitor runs).
+  - Bulk action variants (mute/unmute/promote in `identity_provider_monitors.py`).
+- Build the stats refresh subscriber:
+  - `@subscribes_to(MonitorOperationCompleted)` handler.
+  - Reuses the existing recompute logic in `fidesplus/api/discovery_monitor/aggregate_statistics/`.
+  - Debounces using the existing Redis lock pattern (`aggregate_stats_refresh_lock` keyed by monitor config key) — extend the existing lock helper with a per-monitor key.
+  - 30s debounce window (configurable; matches the existing skip-if-fresh buffer).
+- Reconciler: no new code. The existing `initiate_aggregate_stats_refresh` (APScheduler) keeps running with its current cadence. The event-driven path reduces how often it does meaningful work; it does not replace it.
+
+### Tests
+
+- Publish-path unit tests at each call site (assert event registered on session post-commit).
+- Subscriber tests: handler invokes recompute for the affected monitor; debounce skips back-to-back invocations within window.
+- Reconciler tests: existing tests still pass; add a "events stopped flowing" scenario verifying the reconciler still hits stale rows.
+
+### Acceptance criteria
+
+- Per-monitor stats are refreshed within (debounce_window + dispatch_latency) of any tracked operation, in steady state.
+- Reconciler-driven refreshes drop in frequency proportional to the volume of event-driven refreshes.
+- No regression on the existing aggregate stats endpoint behavior.
+
+### Out of scope (deferred to follow-up tickets)
+
+- Time-series snapshotting (Phase 3.3 of the original aggregate stats plan) — orthogonal to event-driven refresh.
+- Refresh prioritization (e.g. recently viewed monitors first) — premature without observed need.
+
+## Cross-Phase Concerns
+
+### Configuration
+
+- Add framework-level settings (if any beyond defaults) under existing config sections; do not introduce a new `events` config namespace unless multiple knobs emerge.
+- Per-subscriber tuning (queue overrides, debounce windows) lives in the subscriber's package, not the framework.
+
+### Deployment
+
+- No helm or compose changes required for Phase 1, 2, or 3. The "Other" worker covers all subscribers by default.
+- A future high-volume subscriber may motivate a dedicated queue + worker — handled per the operational lever in `01-design.md` §5.4.
+
+### Migration / backfill
+
+- Phase 1: no migration; pure code.
+- Phase 2: backfill task on rollout (see above). No schema changes required by the framework itself; PR #3394 already lands the relevant `monitorsteward` columns.
+- Phase 3: no migration; pure code.
+
+### Rollback strategy
+
+- Phase 1 has no production effect — it can be merged dark and reverted with no operational consequence.
+- Phase 2: disable by toggling all `inherit_system_stewards` to `false` (effectively halts the subscriber's effect) or by removing the subscriber registration. The reconciler is similarly togglable. Existing inherited steward rows can be cleaned up by a one-off task if rollback is permanent.
+- Phase 3: disable by removing the subscriber registration. Stats refresh falls back to pure interval-driven (current state). No data integrity concerns.
+
+## Sequencing & Dependencies
+
+```
+Phase 1 (framework plumbing, fides OSS)
+    │
+    ├─► Phase 2 (stewardship inheritance)
+    │
+    └─► Phase 3 (stats refresh)
+```
+
+Phase 1 must land before either consumer phase begins. Phase 2 and Phase 3 are independent and may run in parallel.
+
+PR #3394 (fidesplus) and its fides counterpart (#7888) are dependencies of Phase 2 specifically — Phase 2 cannot ship until those land, since they introduce the `source` / `source_system_id` / `inherit_system_stewards` schema the subscriber operates on.

--- a/docs/fides/docs/event-framework/03-phase-1-plumbing.md
+++ b/docs/fides/docs/event-framework/03-phase-1-plumbing.md
@@ -1,0 +1,347 @@
+# Phase 1 — Core Plumbing Checklist
+
+Concrete checklist for the framework plumbing PR described in `02-implementation-plan.md` Phase 1. References design decisions in `01-design.md`.
+
+Single PR, scoped to `fides/common/events/` plus minimal touches to existing Celery integration. No production publishers or subscribers — the framework's correctness is demonstrated entirely via a test-only "ping" event.
+
+## 0. Branch & PR
+
+- Branch: `event-framework/plumbing` (or similar).
+- PR title: `feat(events): add core event framework plumbing`.
+- PR description: link to `01-design.md`, `02-implementation-plan.md` Phase 1, and this checklist. State explicitly that no production code path is wired in.
+
+## 1. Package layout
+
+New package at `fides/common/events/`:
+
+```
+fides/common/events/
+    __init__.py            # public API surface
+    base.py                # event conventions + validation
+    registry.py            # in-process registry singleton
+    decorators.py          # @subscribes_to, @publishes
+    publisher.py           # publish_after_commit + after-commit hook
+    dispatcher.py          # the after-commit callback
+    celery_integration.py  # task wrapper factory + event_id signal handlers
+    autodiscover.py        # hook into existing autodiscover_task_locations
+    testing.py             # assert_event_published + fixtures
+```
+
+Config:
+- `fides/config/event_settings.py` — new `EventSettings` Pydantic config class with at least `enabled: bool = True`.
+- Wired into `fides.config.FidesConfig` as `events: EventSettings`.
+
+## 2. Components
+
+Each item below has a concrete acceptance bar. Order is logical, not strictly sequential — they all land in one PR.
+
+### 2.1 Event base + validation (`base.py`)
+
+- [ ] Define a `validate_event_class(cls)` helper that asserts `cls` is a frozen dataclass and that all fields are JSON-primitive types (str, int, float, bool, None, list, dict) or other validated event classes. Called by `@subscribes_to` and `@publishes` at decoration time.
+- [ ] Helpers `event_to_dict(event) -> dict` (uses `dataclasses.asdict`) and `dict_to_event(cls, payload: dict) -> cls` (calls `cls(**payload)`).
+- [ ] Document the field-type constraint in the module docstring; reject UUID/datetime/Enum fields with a clear error message.
+
+**Acceptance**: unit tests covering each accepted/rejected field type; round-trip serialization tests.
+
+### 2.2 Registry (`registry.py`)
+
+- [ ] Module-level `_REGISTRY: dict[type, list[Subscriber]]`.
+- [ ] `Subscriber` is a small dataclass: `func`, `task_name`, `queue`, `event_type`.
+- [ ] Helpers: `register(subscriber)`, `get_subscribers(event_type) -> list[Subscriber]`, `all_event_types() -> set[type]`, `all_subscribers() -> list[Subscriber]`.
+- [ ] `_PUBLISHES_MARKERS: dict[Callable, list[type]]` — separate registry for `@publishes`-marked methods (test-time introspection).
+
+**Acceptance**: unit tests for register / lookup; concurrent registrations from different modules.
+
+### 2.3 Decorators (`decorators.py`)
+
+- [ ] `@subscribes_to(event_type, queue="fides", max_retries=None, retry_backoff=None)`:
+  - Validates `event_type` via `validate_event_class`.
+  - Creates a Celery task wrapper (see §2.5) and registers it.
+  - Adds a `Subscriber` entry to the registry.
+  - Returns the original function unchanged.
+- [ ] `@publishes(*event_types)`:
+  - Validates each event type.
+  - Records the marker in `_PUBLISHES_MARKERS`.
+  - Returns the original function unchanged.
+  - Does **not** affect runtime behavior — see design doc §6.5.
+
+**Acceptance**: unit tests covering successful registration, invalid event class rejection, multiple subscribers per event, multiple event types per `@publishes`.
+
+### 2.4 Publisher (`publisher.py`)
+
+- [ ] `publish_after_commit(session, event)`:
+  - Validates `type(event)` is registered (or accept any event class — TBD per §4 below).
+  - Generates `event_id = uuid4().hex`.
+  - Appends `(event_id, event)` to `session.info.setdefault("pending_events", [])`.
+  - On first call per session, registers `_after_commit_dispatch` and `_after_rollback_clear` callbacks via `sqlalchemy.event.listens_for(session, "after_commit", once=True)` (and `"after_rollback"`).
+- [ ] `_after_commit_dispatch(session)`: drains `session.info["pending_events"]` and hands each entry to the dispatcher.
+- [ ] `_after_rollback_clear(session)`: clears `session.info["pending_events"]` without dispatching.
+
+**Acceptance**: unit tests covering the commit, rollback, multiple-events-per-txn, and "no events on a session that didn't publish" paths.
+
+### 2.5 Dispatcher (`dispatcher.py`)
+
+- [ ] `dispatch(event_id, event)`:
+  - Looks up subscribers via `registry.get_subscribers(type(event))`.
+  - For each subscriber: calls `celery.send_task(subscriber.task_name, args=[event_to_dict(event)], headers={"event_id": event_id}, queue=subscriber.queue)`.
+  - Wraps each `send_task` in try/except — failures log and continue.
+  - Skips dispatch entirely if `CONFIG.events.enabled is False`.
+- [ ] Structured logging at dispatch time per design doc §8.
+
+**Acceptance**: unit tests with mocked Celery — assert correct task name, args, headers, queue per subscriber. Test the kill-switch path. Test that one failing send_task doesn't block subsequent ones.
+
+### 2.6 Celery task wrapper (`celery_integration.py`)
+
+- [ ] `make_subscriber_task(subscriber)`:
+  - Returns a Celery task that:
+    - Reads `event_id` from task headers; sets it in the worker context (mirrors existing `request_id` pattern).
+    - Calls `dict_to_event(subscriber.event_type, payload)`.
+    - Invokes `subscriber.func(event)`.
+    - Logs start/end/latency/outcome.
+  - Registered with the existing `celery_app` via the standard `@celery_app.task(name=..., queue=...)` mechanism.
+- [ ] Task name format: `events.{event_class_qualname}.{subscriber_func_qualname}`.
+- [ ] Boot-time validation: every registered subscriber's `task_name` must resolve to a registered Celery task. Run after autodiscovery completes; fail loudly if any subscriber is unbound.
+
+**Acceptance**: unit tests for the wrapper (deserialization, error handling, header propagation); boot-time validation test (negative case).
+
+### 2.7 Autodiscovery (`autodiscover.py`)
+
+- [ ] Extend `autodiscover_task_locations` (or a parallel `autodiscover_event_subscriber_locations`) so that subscriber modules under `fides/common/events/` and any registered subscriber paths get imported at app boot. fidesplus extends this list the same way it extends Celery autodiscovery in `fidesplus/api/worker/__init__.py`.
+- [ ] Both webserver and worker import subscriber modules — confirmed by a test that imports the app and asserts the registry is populated.
+
+**Acceptance**: unit test that simulates app boot and asserts the registry contains expected subscribers.
+
+### 2.8 Logging + `event_id` propagation
+
+- [ ] Extend the existing `before_task_publish` / `task_prerun` / `task_postrun` signal handlers in `fides/api/tasks/__init__.py` to read/write `event_id` in task headers and propagate it into the worker's contextvar.
+- [ ] Standard `logging.LoggerAdapter` (or equivalent) makes `event_id` available to subscriber logs.
+
+**Acceptance**: integration test publishes an event, runs the subscriber inline (eager mode), and asserts the subscriber's logs include the publishing `event_id`.
+
+### 2.9 Test helpers (`testing.py`)
+
+- [ ] `assert_event_published(session, event_type, count=1) -> list[event_type]`:
+  - Inspects `session.info.get("pending_events", [])`, filters by type, asserts the count, returns the matching event instances.
+- [ ] `published_events(session) -> list`: returns all pending events for ad-hoc assertions.
+- [ ] `clear_pending_events(session)`: drops pending events without dispatching (test cleanup).
+- [ ] **Marker-coverage test** (added in `tests/common/events/`): walks `_PUBLISHES_MARKERS`, asserts each marked method's source contains a `publish_after_commit` call referencing the declared event type. Soft warning, not hard fail, in v1.
+- [ ] **Registry-coverage test**: every registered subscriber's `event_type` has at least one `@publishes` marker in tree. Hard fail.
+
+**Acceptance**: each helper has its own unit test; coverage tests run as part of the standard test suite.
+
+### 2.10 Public API (`__init__.py`)
+
+Re-export:
+
+```python
+from fides.common.events.publisher import publish_after_commit
+from fides.common.events.decorators import subscribes_to, publishes
+from fides.common.events.testing import (
+    assert_event_published,
+    published_events,
+    clear_pending_events,
+)
+```
+
+Internal modules (`registry`, `dispatcher`, `celery_integration`, `autodiscover`) are not re-exported. Consumers go through the public API.
+
+## 3. End-to-end "ping" validation
+
+The PR's primary correctness demonstration. Lives entirely under `tests/common/events/`.
+
+### 3.1 Ping fixtures (`tests/common/events/_ping.py`)
+
+```python
+"""Test-only event + subscriber + publisher.
+
+This module is the canonical example of how the framework is used.
+It is also the end-to-end validation for the framework itself.
+"""
+from dataclasses import dataclass
+
+from fides.common.events import (
+    publish_after_commit,
+    publishes,
+    subscribes_to,
+)
+
+
+@dataclass(frozen=True)
+class PingEvent:
+    """Test-only event used to validate the framework end-to-end."""
+    payload: str
+
+
+# Module-level capture list — read and cleared per-test via the
+# `ping_received` fixture in conftest.py.
+_PING_RECEIVED: list[PingEvent] = []
+
+
+@subscribes_to(PingEvent)
+def ping_handler(event: PingEvent) -> None:
+    """The single registered subscriber for PingEvent."""
+    _PING_RECEIVED.append(event)
+
+
+class PingRepository:
+    """Demonstrates the recommended publish-from-repository pattern (§6.6).
+
+    Has no DB write of its own — the ping flow only needs to demonstrate
+    that publish_after_commit fires on commit and not on rollback.
+    """
+
+    def __init__(self, session):
+        self.session = session
+
+    @publishes(PingEvent)
+    def emit(self, payload: str) -> None:
+        publish_after_commit(self.session, PingEvent(payload=payload))
+```
+
+### 3.2 Ping conftest
+
+```python
+# tests/common/events/conftest.py
+import pytest
+
+from . import _ping  # registers ping_handler at import time
+
+
+@pytest.fixture
+def ping_received():
+    """Yields the capture list and clears it after the test."""
+    _ping._PING_RECEIVED.clear()
+    yield _ping._PING_RECEIVED
+    _ping._PING_RECEIVED.clear()
+```
+
+### 3.3 Ping tests (`tests/common/events/test_ping.py`)
+
+Each test below corresponds to a specific framework guarantee. Together they validate the full lifecycle.
+
+```python
+def test_publish_then_commit_dispatches_subscriber(db, ping_received):
+    """Happy path: publish + commit → subscriber runs synchronously
+    (under task_always_eager) and receives the event instance."""
+    _ping.PingRepository(db).emit("hello")
+    db.commit()
+    assert ping_received == [_ping.PingEvent(payload="hello")]
+
+
+def test_publish_then_rollback_does_not_dispatch(db, ping_received):
+    """Rollback safety: events queued on a rolled-back session never fire."""
+    _ping.PingRepository(db).emit("hello")
+    db.rollback()
+    assert ping_received == []
+
+
+def test_multiple_publishes_in_one_transaction_dispatch_in_order(db, ping_received):
+    """Ordering: events dispatch in publish order on the same session."""
+    repo = _ping.PingRepository(db)
+    repo.emit("first")
+    repo.emit("second")
+    repo.emit("third")
+    db.commit()
+    assert [e.payload for e in ping_received] == ["first", "second", "third"]
+
+
+def test_assert_event_published_helper(db, ping_received):
+    """The assert_event_published helper inspects pending events
+    pre-commit so subscriber assertions don't need to wait for dispatch."""
+    _ping.PingRepository(db).emit("hello")
+    [event] = assert_event_published(db, _ping.PingEvent)
+    assert event.payload == "hello"
+
+
+def test_kill_switch_disables_dispatch(db, ping_received, monkeypatch):
+    """CONFIG.events.enabled = False stops dispatch on commit."""
+    monkeypatch.setattr(CONFIG.events, "enabled", False)
+    _ping.PingRepository(db).emit("hello")
+    db.commit()
+    assert ping_received == []
+
+
+def test_publishes_marker_recorded():
+    """The @publishes marker on PingRepository.emit is captured for
+    test-time introspection."""
+    from fides.common.events.registry import _PUBLISHES_MARKERS
+    assert _ping.PingEvent in _PUBLISHES_MARKERS[_ping.PingRepository.emit]
+
+
+def test_event_id_propagates_to_subscriber_logs(db, ping_received, caplog):
+    """The event_id stamped at publish time appears in subscriber log records."""
+    _ping.PingRepository(db).emit("hello")
+    db.commit()
+    publish_records = [r for r in caplog.records if "event_id" in getattr(r, "extra", {})]
+    assert publish_records  # at least one log record carried event_id
+    # Subscriber log records should carry the same event_id
+    handle_records = [r for r in caplog.records if "ping_handler" in r.message]
+    assert all(r.extra["event_id"] == publish_records[0].extra["event_id"] for r in handle_records)
+```
+
+### 3.4 What the ping suite does NOT cover (intentionally)
+
+- Multi-subscriber fan-out — covered separately by `test_dispatch_to_multiple_subscribers` in `test_dispatcher.py`. Ping has one subscriber to keep the canonical example minimal.
+- Reconciler behavior — Phase 1 has no reconciler; reconcilers land with subscribers in Phase 2/3.
+- Cross-process Celery dispatch — relies on `task_always_eager`. Worker-side correctness is covered by component tests in `test_celery_integration.py`.
+
+## 4. Coverage checks — pattern
+
+All three coverage checks below run as test-time assertions, not runtime errors. Each supports a deliberate opt-out via a module-level exclude list with a required string reason. The pattern (sketch):
+
+```python
+# tests/common/events/coverage_excludes.py
+
+# Event types deliberately published without a registered subscriber.
+# Each entry must be justified.
+PUBLISH_WITHOUT_SUBSCRIBER_OK: dict[type, str] = {
+    # ExampleEvent: "first-publisher landing ahead of subscriber in PR #1234",
+}
+
+# Methods that call publish_after_commit deliberately without a @publishes marker.
+PUBLISH_WITHOUT_MARKER_OK: dict[Callable, str] = {
+    # SomeRepo.legacy_method: "marker added in follow-up; tracked in ENG-9999",
+}
+```
+
+A test exempting an entry without a reason fails. The exclude lists live in test code (not framework code), keeping the framework strict by default.
+
+### 4.1 Publish-target coverage (typo check)
+
+- Walks every `publish_after_commit` call site detected by static analysis (or by an instrumentation hook in tests).
+- Asserts `type(event)` is in the registry for that test session.
+- **Opt-out** via `PUBLISH_WITHOUT_SUBSCRIBER_OK` for the deliberate first-publisher-without-subscriber case.
+- **Runtime behavior**: `publish_after_commit` itself is permissive — logs a warning if the event type has no subscribers but does not raise. Catching the typo is the test suite's job, not the request path's.
+
+### 4.2 `@publishes` marker coverage (soft)
+
+- Walks every method that calls `publish_after_commit` (detected via the same instrumentation as 4.1).
+- Asserts the method has a `@publishes(EventType)` marker for each event type it publishes.
+- **Opt-out** via `PUBLISH_WITHOUT_MARKER_OK`.
+- Failure mode: test failure with a message pointing at the missing marker and instructions to either add it or add an exemption with reason.
+
+### 4.3 Subscriber → publisher coverage (hard)
+
+- Walks every registered subscriber.
+- Asserts the subscriber's event type has at least one in-tree publisher (either a `@publishes` marker or a detected `publish_after_commit` call).
+- **No opt-out** — a subscriber without a publisher is a dead subscriber.
+- Failure mode: test failure listing the orphaned subscriber and its event type.
+
+## 5. Out of scope (deferred)
+
+- Production publishers / subscribers (Phase 2 + 3).
+- Metrics emission — logging only in v1.
+- A second transport (Redis Pub/Sub, Postgres, etc.) — see design doc §5.5.
+- Schema versioning / event payload migration.
+- Operator-facing tooling (event replay, dead-letter inspection) — substituted by the per-subscriber reconciler model.
+- Helm or compose changes — none required.
+
+## 6. Acceptance criteria
+
+- Single PR merged to fides main.
+- All tests under `tests/common/events/` green, including the ping suite.
+- Marker- and registry-coverage tests in place.
+- No production code paths reference `fides.common.events` outside the test ping module.
+- This doc + design doc + implementation plan all merged.
+- `CONFIG.events.enabled` toggle exercised by tests.
+- A short developer-facing how-to (linked from `dev-docs/`) showing the ping pattern as the canonical reference, with a note that production publishers + subscribers will come in subsequent phases.

--- a/docs/fides/docs/event-framework/04-stewardship-implementation-plan.md
+++ b/docs/fides/docs/event-framework/04-stewardship-implementation-plan.md
@@ -1,0 +1,713 @@
+# Monitor Stewardship Inheritance — Implementation Plan
+
+The first feature consumer of the event framework. Implements event-driven propagation of inherited stewardship: when a System's data stewards change (or a monitor's `inherit_system_stewards` flag toggles), affected `monitorsteward` rows are reconciled automatically.
+
+This document is self-contained for another agent to pick up the work on a fresh branch. Read it in conjunction with:
+
+- `01-design.md` — framework design + when-to-use boundary
+- `02-implementation-plan.md` — phased rollout (this is Phase 2)
+- `03-phase-1-plumbing.md` — framework plumbing details (the foundation this builds on)
+
+## 1. Branch Dependencies
+
+This work cannot start until **all three** of the following land on the respective `main` branches:
+
+1. **fides — event framework plumbing.** Branch: `event-framework/plumbing` (or its merged successor). Provides `fides.common.events.{publish_after_commit, subscribes_to, publishes}` and the autodiscover hook.
+2. **fides — model updates for stewardship inheritance** (PR #7888 or its successor). Adds:
+    - `monitorsteward.source` column (enum: `explicit | inherited`)
+    - `monitorsteward.source_system_id` column (nullable FK to `ctl_systems.id`)
+    - `monitorconfig.inherit_system_stewards` column (bool, default `true` on new, `false` backfilled)
+    - Updated unique constraint on `monitorsteward` to include `source` and `source_system_id`
+3. **fidesplus — inheritance-aware API surface** (PR #3394 or its successor). Adds:
+    - `inherit_system_stewards` field on `EditableMonitorConfig`
+    - `StewardSource` enum + `InheritedFromSystem` schema + extended `MonitorStewardUserResponse`
+    - `add_monitor_stewards_bulk` / `remove_monitor_stewards_bulk` (explicit-only)
+    - `get_monitor_stewards_attributed` for read-side attribution
+
+If any of these three are not yet on `main`, the work blocks. Coordinate with whoever owns each.
+
+**Recommended branching once dependencies are met:**
+- New branch off `main` in fidesplus: `event-framework/stewardship-inheritance` (or similar).
+- Possibly a corresponding branch in fides for the publisher / repository changes (the fides changes are ~150 lines, can be a separate fides PR or land in a coordinated pair). My suggestion: separate fides PR shipped first, fidesplus PR follows once it's in.
+
+## 2. Scope of This Implementation
+
+**Triggers covered in this PR:**
+1. `System.data_stewards` membership change (emitted from fides).
+2. `monitorconfig.inherit_system_stewards` flag toggled / set on create (emitted from fidesplus).
+
+**Triggers deferred to a follow-up PR** (same shape, intentionally out of initial scope to keep the PR tractable):
+- `system_connection_config_link` rows added / removed.
+- `MonitorConfig.connection_config_id` reassigned.
+- New `MonitorConfig` created with `inherit_system_stewards = TRUE` (subset of the toggle case if create maps to "false → true" emission).
+
+The subscriber + reconciler designed here handle all of those when the additional triggers land. No subscriber code changes needed for follow-ups, just additional publishers + event types.
+
+**Out of scope entirely:**
+- UI surfacing of "this is inherited" beyond what fidesplus PR #3394 already provides.
+- Performance debouncing — see open question #1 in §11.
+- Backfill — confirmed unnecessary; nobody has set `inherit_system_stewards=true` yet.
+
+## 3. Event Types
+
+Both event classes live in **fides** so fidesplus and any other repo can subscribe.
+
+### `fides/api/events/system_events.py` (new file)
+
+```python
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SystemDataStewardsChanged:
+    """Emitted when the data stewards on a System change.
+
+    Subscribers must read current state — by the time the subscriber
+    runs, the membership may have changed again.
+    """
+    system_id: str
+    user_id: str
+    change: str  # "added" | "removed"
+```
+
+### `fides/api/events/monitor_events.py` (new file)
+
+```python
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class MonitorInheritanceFlagChanged:
+    """Emitted when monitorconfig.inherit_system_stewards is set or
+    toggled. Emitted on create when the value is True, and on update
+    whenever the value changes between the previous and new value."""
+    monitor_config_key: str
+    enabled: bool
+```
+
+Both are frozen dataclasses with JSON-primitive fields per the framework's validation requirements (see `01-design.md` §6.1).
+
+## 4. Trigger 1 — `System.data_stewards` (fides)
+
+### 4.1 Today's mutation paths
+
+`System.data_stewards` is a M2M via the `systemmanager` association table. The mutators today are model-level methods on `FidesUser`:
+
+- `FidesUser.set_as_system_manager` — `src/fides/api/models/fides_user.py:206`
+- `FidesUser.remove_as_system_manager` — `src/fides/api/models/fides_user.py:234`
+
+Call sites (3, all in fides routes):
+- `src/fides/api/v1/endpoints/system.py:469` — `add_user_as_system_manager`
+- `src/fides/api/v1/endpoints/user_endpoints.py:381,386` — `update_managed_systems` (PUT replace; calls both)
+- `src/fides/api/v1/endpoints/user_permission_endpoints.py` — delete path
+
+### 4.2 Introduce `SystemStewardsRepository`
+
+Per the recommended pattern in `01-design.md` §6.6, introduce a repository to host the publish chokepoint.
+
+New file: `src/fides/api/repositories/system_stewards_repository.py`
+
+```python
+"""Repository for System.data_stewards mutations.
+
+This is the publish chokepoint for SystemDataStewardsChanged events.
+Routes call into this repository instead of the FidesUser model methods
+directly so the publish call is colocated with the mutation in a layer
+visible to PR review.
+"""
+
+from sqlalchemy.orm import Session
+
+from fides.api.events import publish_after_commit, publishes
+from fides.api.events.system_events import SystemDataStewardsChanged
+from fides.api.models.fides_user import FidesUser
+from fides.api.models.sql_models import System
+
+
+class SystemStewardsRepository:
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+    @publishes(SystemDataStewardsChanged)
+    def add(self, user: FidesUser, system: System) -> None:
+        """Add user as a data steward of system. No-op if already added."""
+        if system in user.systems:
+            return
+        user.set_as_system_manager(self.session, system)
+        publish_after_commit(
+            self.session,
+            SystemDataStewardsChanged(
+                system_id=system.id,
+                user_id=user.id,
+                change="added",
+            ),
+        )
+
+    @publishes(SystemDataStewardsChanged)
+    def remove(self, user: FidesUser, system: System) -> None:
+        """Remove user as a data steward of system. No-op if not present."""
+        if system not in user.systems:
+            return
+        user.remove_as_system_manager(self.session, system)
+        publish_after_commit(
+            self.session,
+            SystemDataStewardsChanged(
+                system_id=system.id,
+                user_id=user.id,
+                change="removed",
+            ),
+        )
+
+    def replace_for_user(self, user: FidesUser, systems: list[System]) -> None:
+        """Replace the user's full set of managed systems.
+
+        Computes diff and emits per-change events. Used by the
+        update_managed_systems route which does a full-set replace.
+        """
+        current = set(user.systems)
+        desired = set(systems)
+        for system in current - desired:
+            self.remove(user, system)
+        for system in desired - current:
+            self.add(user, system)
+```
+
+Note: leave `FidesUser.set_as_system_manager` / `remove_as_system_manager` callable. Document in those method docstrings that **production callers should go through `SystemStewardsRepository`** to ensure events are emitted. The model methods remain for legacy / non-routing callers (e.g. tests, scripts).
+
+### 4.3 Migrate the 3 route handlers
+
+Each call site moves from:
+```python
+user.set_as_system_manager(db, system)
+```
+to:
+```python
+SystemStewardsRepository(db).add(user, system)
+```
+
+For `update_managed_systems` which does a full-set replace:
+```python
+SystemStewardsRepository(db).replace_for_user(user, systems)
+```
+
+The route handlers' commit step is unchanged — events fire when the existing `db.commit()` runs.
+
+### 4.4 Tests
+
+In `tests/api/repositories/test_system_stewards_repository.py`:
+- `add` emits `SystemDataStewardsChanged(change="added")` after commit.
+- `remove` emits with `change="removed"`.
+- `add` is idempotent — adding twice emits one event.
+- `remove` is idempotent — removing absent user emits no event.
+- `replace_for_user` emits the correct add/remove diff.
+- Rollback path emits no event (use `assert_event_published` pre-commit + verify subscriber not invoked post-rollback).
+
+Use `tests/common/events/_ping.py` as the canonical fixture pattern.
+
+## 5. Trigger 2 — `inherit_system_stewards` toggle (fidesplus)
+
+### 5.1 Today's write path
+
+The flag is written via `upsert_discovery_monitor` route (`src/fidesplus/api/routes/discovery_monitor/discovery_monitors.py:2228`), which calls `DbMonitorConfig.create_or_update(db=db, data=data)` at line 2336.
+
+After fidesplus PR #3394 lands, `inherit_system_stewards` flows in via the `EditableMonitorConfig` schema (`src/fidesplus/api/schemas/discovery_monitor.py`).
+
+### 5.2 Introduce a wrapper helper for diff + publish
+
+The route handler is already 100+ lines and the diff logic is small. Add a thin helper that wraps `create_or_update` with diff detection and event publication.
+
+New file: `src/fidesplus/api/repositories/monitor_config_repository.py` (also used by §6 below)
+
+```python
+"""Repository for MonitorConfig writes that need cross-cutting behavior
+(event publication, diff detection, etc.)."""
+
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from fides.api.events import publish_after_commit, publishes
+from fides.api.events.monitor_events import MonitorInheritanceFlagChanged
+from fidesplus.api.discovery_monitor.models.monitor_config import (
+    DbMonitorConfig,
+)
+
+
+class MonitorConfigRepository:
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+    @publishes(MonitorInheritanceFlagChanged)
+    def upsert_with_inheritance_flag_diff(
+        self,
+        data: dict,
+    ) -> DbMonitorConfig:
+        """Upsert a monitor config and emit MonitorInheritanceFlagChanged
+        if the inherit_system_stewards flag changed (or was set to True
+        on creation)."""
+        existing = DbMonitorConfig.get_by(
+            self.session, field="key", value=data.get("key")
+        )
+        prev_flag = bool(getattr(existing, "inherit_system_stewards", False))
+        new_flag = bool(data.get("inherit_system_stewards", False))
+
+        updated = DbMonitorConfig.create_or_update(db=self.session, data=data)
+
+        if prev_flag != new_flag:
+            publish_after_commit(
+                self.session,
+                MonitorInheritanceFlagChanged(
+                    monitor_config_key=updated.key,
+                    enabled=new_flag,
+                ),
+            )
+
+        return updated
+```
+
+### 5.3 Migrate the route handler
+
+In `upsert_discovery_monitor` (`src/fidesplus/api/routes/discovery_monitor/discovery_monitors.py`):
+
+Replace:
+```python
+updated_db_config = DbMonitorConfig.create_or_update(db=db, data=data)
+```
+with:
+```python
+updated_db_config = MonitorConfigRepository(db).upsert_with_inheritance_flag_diff(data)
+```
+
+The existing `update_monitor_stewards(...)` call after this line stays unchanged — that handles **explicit** steward writes; inherited rows are managed by the subscriber.
+
+### 5.4 Tests
+
+In `tests/api/repositories/test_monitor_config_repository.py`:
+- `upsert_with_inheritance_flag_diff` emits `MonitorInheritanceFlagChanged(enabled=True)` on create with `inherit_system_stewards=true`.
+- Same on update from `false → true` and `true → false` (with the corresponding `enabled` value).
+- Same value on both sides emits no event.
+- Existing route-level tests for `upsert_discovery_monitor` should still pass; add one assertion-on-event for the inherit-system-stewards flow.
+
+## 6. Subscriber (fidesplus)
+
+### 6.1 Package layout
+
+New package: `src/fidesplus/api/service/discovery/monitor_stewardship_inheritance/`
+
+```
+monitor_stewardship_inheritance/
+    __init__.py
+    subscribers.py    # @subscribes_to handlers
+    reconciler.py     # APScheduler job + on-demand reconcile function
+    service.py        # _reconcile_inherited_stewards_for_monitor + helpers
+    repository.py     # read helpers (or extend MonitorConfigRepository)
+```
+
+### 6.2 Read path — extend `MonitorConfigRepository`
+
+Add to `src/fidesplus/api/repositories/monitor_config_repository.py`:
+
+```python
+def list_inheriting_monitors_for_system(
+    self, system_id: str
+) -> list[DbMonitorConfig]:
+    """Return MonitorConfigs whose linked Systems include system_id and
+    whose inherit_system_stewards flag is True."""
+    from fides.system_integration_link.models import SystemConnectionConfigLink
+
+    return (
+        self.session.query(DbMonitorConfig)
+        .join(
+            SystemConnectionConfigLink,
+            SystemConnectionConfigLink.connection_config_id
+            == DbMonitorConfig.connection_config_id,
+        )
+        .filter(SystemConnectionConfigLink.system_id == system_id)
+        .filter(DbMonitorConfig.inherit_system_stewards.is_(True))
+        .all()
+    )
+
+def list_all_inheriting_monitors(self) -> list[DbMonitorConfig]:
+    """Return every MonitorConfig with inherit_system_stewards = True.
+    Used by the periodic reconciler."""
+    return (
+        self.session.query(DbMonitorConfig)
+        .filter(DbMonitorConfig.inherit_system_stewards.is_(True))
+        .all()
+    )
+
+def get_by_key(self, monitor_config_key: str) -> Optional[DbMonitorConfig]:
+    return DbMonitorConfig.get_by(
+        self.session, field="key", value=monitor_config_key
+    )
+```
+
+### 6.3 Reconciliation logic — `service.py`
+
+```python
+"""Core reconciliation logic for inherited stewardship.
+
+Idempotent: computes the desired set of inherited steward rows for a
+monitor and adjusts actual rows to match. Explicit rows are never touched.
+"""
+
+from sqlalchemy.orm import Session
+
+from fides.api.models.fides_user import FidesUser
+from fides.api.models.sql_models import System
+from fidesplus.api.discovery_monitor.models.monitor_config import (
+    DbMonitorConfig,
+)
+from fidesplus.api.discovery_monitor.models.monitor_steward import (
+    DbMonitorSteward,
+    StewardSource,
+)
+
+
+def reconcile_inherited_stewards_for_monitor(
+    session: Session, monitor: DbMonitorConfig
+) -> None:
+    """Compute desired inherited stewardship for ``monitor`` and write
+    the diff to monitorsteward.
+
+    Desired set: union of data_stewards across linked Systems, with
+    source='inherited' and source_system_id pointing back to the system
+    that contributed the user.
+
+    Adds missing rows, removes now-stale inherited rows, leaves
+    source='explicit' rows untouched.
+    """
+    desired: set[tuple[str, str]] = set()  # (user_id, source_system_id)
+
+    # Walk the propagation graph: monitor -> connection_config ->
+    # system_connection_config_link -> system -> data_stewards.
+    for system in _linked_systems_for_monitor(session, monitor):
+        for user in system.data_stewards:
+            desired.add((user.id, system.id))
+
+    actual_query = session.query(DbMonitorSteward).filter(
+        DbMonitorSteward.monitor_config_id == monitor.id,
+        DbMonitorSteward.source == StewardSource.inherited,
+    )
+    actual: dict[tuple[str, str], DbMonitorSteward] = {
+        (row.user_id, row.source_system_id): row for row in actual_query
+    }
+
+    # Add missing rows.
+    for key in desired - set(actual.keys()):
+        user_id, source_system_id = key
+        DbMonitorSteward.create(
+            session,
+            data={
+                "user_id": user_id,
+                "monitor_config_id": monitor.id,
+                "source": StewardSource.inherited,
+                "source_system_id": source_system_id,
+            },
+        )
+
+    # Remove stale rows.
+    for key in set(actual.keys()) - desired:
+        actual[key].delete(session)
+
+
+def delete_all_inherited_stewards_for_monitor(
+    session: Session, monitor: DbMonitorConfig
+) -> None:
+    """Used when inherit_system_stewards toggles to False — drop every
+    inherited row for the monitor; explicit rows untouched."""
+    session.query(DbMonitorSteward).filter(
+        DbMonitorSteward.monitor_config_id == monitor.id,
+        DbMonitorSteward.source == StewardSource.inherited,
+    ).delete()
+
+
+def _linked_systems_for_monitor(
+    session: Session, monitor: DbMonitorConfig
+) -> list[System]:
+    """Walk the connection_config -> system_connection_config_link path."""
+    from fides.system_integration_link.models import SystemConnectionConfigLink
+
+    return (
+        session.query(System)
+        .join(
+            SystemConnectionConfigLink,
+            SystemConnectionConfigLink.system_id == System.id,
+        )
+        .filter(
+            SystemConnectionConfigLink.connection_config_id
+            == monitor.connection_config_id
+        )
+        .all()
+    )
+```
+
+### 6.4 Subscribers — `subscribers.py`
+
+```python
+"""Event subscribers for stewardship inheritance.
+
+Inline handlers — work runs in the @subscribes_to Celery task itself.
+The work is bounded (linear in the monitors affected by the source
+system) and idempotent against current state.
+
+If a subscriber's module fails to import, no propagation events fire
+on its event types — the periodic reconciler is the safety net (see
+01-design.md §6.4).
+"""
+
+from fides.api.events import subscribes_to
+from fides.api.events.monitor_events import MonitorInheritanceFlagChanged
+from fides.api.events.system_events import SystemDataStewardsChanged
+from fidesplus.api.repositories.monitor_config_repository import (
+    MonitorConfigRepository,
+)
+from fidesplus.api.service.discovery.monitor_stewardship_inheritance.service import (
+    delete_all_inherited_stewards_for_monitor,
+    reconcile_inherited_stewards_for_monitor,
+)
+from fides.api.tasks import DatabaseTask
+
+
+@subscribes_to(SystemDataStewardsChanged)
+def reconcile_after_system_stewards_change(
+    event: SystemDataStewardsChanged,
+) -> None:
+    task = DatabaseTask()
+    with task.get_new_session() as db:
+        repo = MonitorConfigRepository(db)
+        for monitor in repo.list_inheriting_monitors_for_system(event.system_id):
+            reconcile_inherited_stewards_for_monitor(db, monitor)
+        db.commit()
+
+
+@subscribes_to(MonitorInheritanceFlagChanged)
+def reconcile_after_flag_toggle(event: MonitorInheritanceFlagChanged) -> None:
+    task = DatabaseTask()
+    with task.get_new_session() as db:
+        repo = MonitorConfigRepository(db)
+        monitor = repo.get_by_key(event.monitor_config_key)
+        if monitor is None:
+            return
+        if event.enabled:
+            reconcile_inherited_stewards_for_monitor(db, monitor)
+        else:
+            delete_all_inherited_stewards_for_monitor(db, monitor)
+        db.commit()
+```
+
+Subscribers run on the existing "Other" worker by default (see `01-design.md` §5.4). No new pod type or queue.
+
+### 6.5 Subscriber autodiscovery
+
+In fidesplus's worker / app startup, register the subscriber module:
+
+```python
+# fidesplus/api/worker/__init__.py (or wherever subscriber modules are wired)
+from fides.common.events.autodiscover import register_subscriber_module
+
+register_subscriber_module(
+    "fidesplus.api.service.discovery.monitor_stewardship_inheritance.subscribers"
+)
+```
+
+Make sure this import runs before `import_subscriber_modules()` is called.
+
+## 7. Reconciler (fidesplus)
+
+### 7.1 Reconciler function — `reconciler.py`
+
+```python
+"""Periodic full-sweep reconciler for stewardship inheritance.
+
+Runs every ~15 minutes by default. Re-derives inherited steward rows
+for every monitor with inherit_system_stewards=True regardless of
+whether events fired.
+
+The Redis last-run timestamp prevents over-firing across pods. See
+04-stewardship-implementation-plan.md §7.2.
+"""
+
+import time
+
+from loguru import logger
+
+from fides.api.tasks import DatabaseTask
+from fides.api.util.cache import get_cache
+from fidesplus.api.repositories.monitor_config_repository import (
+    MonitorConfigRepository,
+)
+from fidesplus.api.service.discovery.monitor_stewardship_inheritance.service import (
+    reconcile_inherited_stewards_for_monitor,
+)
+from fidesplus.config import get_config
+
+LAST_RUN_KEY = "steward_inheritance_reconciler_last_run"
+
+
+def reconcile_all_inherited_stewards() -> None:
+    """Full-sweep reconcile across every inheriting monitor.
+
+    Skipped on pods that fired within the configured interval — the
+    Redis timestamp acts as a coarse cluster-wide cooldown.
+    """
+    config = get_config()
+    interval_seconds = (
+        config.detection_discovery.steward_inheritance_reconciler_interval_minutes
+        * 60
+    )
+
+    redis = get_cache()
+    now = int(time.time())
+    last_run = redis.get(LAST_RUN_KEY)
+    if last_run is not None and now - int(last_run) < interval_seconds:
+        logger.debug(
+            "Stewardship reconciler last ran {}s ago; skipping (interval={}s)",
+            now - int(last_run),
+            interval_seconds,
+        )
+        return
+
+    # Stamp before running so concurrent pods skip. A failure within the
+    # body still consumes its interval; the on-demand endpoint is the
+    # recovery path.
+    redis.set(LAST_RUN_KEY, str(now))
+
+    task = DatabaseTask()
+    with task.get_new_session() as db:
+        repo = MonitorConfigRepository(db)
+        monitors = repo.list_all_inheriting_monitors()
+        for monitor in monitors:
+            try:
+                reconcile_inherited_stewards_for_monitor(db, monitor)
+            except Exception:
+                logger.exception(
+                    "Failed to reconcile inherited stewards for monitor: {}",
+                    monitor.key,
+                )
+        db.commit()
+
+
+def initiate_steward_inheritance_reconciler() -> None:
+    """Register the periodic reconciler with APScheduler."""
+    from fides.api.tasks.scheduled.scheduler import scheduler
+
+    config = get_config()
+    interval_minutes = (
+        config.detection_discovery.steward_inheritance_reconciler_interval_minutes
+    )
+
+    scheduler.add_job(
+        reconcile_all_inherited_stewards,
+        trigger="interval",
+        minutes=interval_minutes,
+        id="steward_inheritance_reconciler",
+        replace_existing=True,
+    )
+```
+
+Wire `initiate_steward_inheritance_reconciler` into fidesplus app startup alongside other `initiate_*` functions.
+
+### 7.2 The Redis last-run timestamp pattern
+
+Each pod's APScheduler ticks on its own clock. Without coordination the reconciler would over-fire — N pods × evenly-staggered offsets gives N× the configured cadence.
+
+The Redis key `steward_inheritance_reconciler_last_run` stores the unix timestamp of the most recent attempted run. Each pod's reconciler reads this before doing work and skips if not enough time has passed.
+
+Trade-offs documented in conversation:
+- Stamp **before** running, not after — closes the over-firing window the moment we decide to run. A failed run consumes its interval; the on-demand endpoint is the recovery path.
+- Small TOCTOU race accepted: two pods could both observe a stale timestamp and both run. The reconcile body is idempotent; concurrent runs produce the same end state, just wasted DB cycles. Add an alert on this if it becomes common.
+- No TTL on the key — small payload, persists across restarts (good for ops introspection).
+
+### 7.3 Configuration
+
+Add to `src/fidesplus/config/detection_discovery_settings.py`:
+
+```python
+steward_inheritance_reconciler_interval_minutes: int = Field(
+    default=15,
+    description=(
+        "Interval (in minutes) between periodic reconciliations of "
+        "inherited monitor stewardship. Tighter than typical reconcilers "
+        "because functional staleness is at stake — until propagation "
+        "runs, inherited stewardship is not in effect (a user expecting "
+        "access via inheritance does not have it)."
+    ),
+    ge=1,
+    le=1440,
+)
+```
+
+Default `15` minutes per the design doc §10.2 starting suggestion.
+
+### 7.4 On-demand reconcile endpoint
+
+Add a route on the existing monitor-stewards router:
+
+```
+POST /discovery-monitor/stewardship/reconcile
+```
+
+- Auth: `Security(verify_oauth_client_plus, scopes=[MONITOR_STEWARD_UPDATE])`
+- Body: empty (full-sweep) or `{"monitor_config_keys": [...]}` for scoped reconcile
+- Behavior: synchronously calls `reconcile_all_inherited_stewards()` (or per-monitor variant)
+- Bypasses the Redis last-run check — ops should be able to force a reconcile when investigating
+- Returns 200 with a brief result summary on success
+
+Useful for ops + product when something looks wrong.
+
+## 8. Tests
+
+Mirror the structure used in `tests/common/events/`. All tests should be deterministic and fast.
+
+### fides side
+- `tests/api/repositories/test_system_stewards_repository.py` — publish path tests (per §4.4).
+- `tests/api/v1/endpoints/test_system_steward_routes.py` (or extend existing) — verify the migrated routes still work and now publish events.
+
+### fidesplus side
+- `tests/api/repositories/test_monitor_config_repository.py` — flag-toggle publish path + read helpers.
+- `tests/api/service/discovery/test_monitor_stewardship_inheritance/` — new test directory.
+  - `test_subscribers.py`: subscribers are registered, dispatch correctly on publish, idempotent.
+  - `test_service.py`: reconcile logic produces correct end state across many seeded scenarios (multi-system, multi-user, explicit-coexisting-with-inherited, flag-flip).
+  - `test_reconciler.py`: full-sweep + on-demand endpoint + Redis last-run skip semantics.
+  - **"Events stopped flowing" test**: seed inconsistent state, run only the reconciler, assert correct end state. This is the framework's correctness contract for correctness-sensitive subscribers (`01-design.md` §6.4).
+- Coverage tests: PR should not require new entries in `tests/common/events/coverage_excludes.py` — every subscriber's event type has a `@publishes` marker.
+
+## 9. Acceptance Criteria
+
+- Subscriber + reconciler converge on identical end state for a battery of seeded scenarios.
+- Reconciler handles tenant-scale data without exceeding existing monitor-related job budget.
+- "Events stopped flowing" test passes — reconciler alone produces correct end state.
+- All routes that previously called the model methods directly are migrated to use the repository.
+- `monitorsteward.source = explicit` rows are never modified by any code path introduced here.
+- Redis last-run skip is exercised by tests (run twice within the interval; second run skips).
+- On-demand endpoint bypasses the skip and runs synchronously.
+- All new tests green.
+- Coverage tests in `tests/common/events/test_coverage_checks.py` still green (no new entries needed in `coverage_excludes.py`).
+
+## 10. Suggested PR Split
+
+Three PRs in sequence (or two if comfortable):
+
+1. **fides**: event types + `SystemStewardsRepository` + route migrations + tests. Independently shippable; events fire but no subscriber consumes them yet (logs a "no subscribers" warning at dispatch time, which is fine).
+2. **fidesplus**: `MonitorConfigRepository` + flag-toggle publisher + subscriber + service + reconciler + on-demand endpoint + tests. Depends on PR 1 being merged into `main` first.
+3. **(optional follow-up)**: additional triggers from §2 — link table changes, connection_config_id reassignment, new monitor with flag=true if not subsumed by toggle case.
+
+Each PR should reference this doc + the design doc + the framework PR for context.
+
+## 11. Open Questions To Confirm Before Coding
+
+1. **Debouncing**: deliberately not addressed in this plan per direction. If observed pathologically (e.g. UI sees stale stewardship for >1 minute under bursty system mutations), revisit using the trailing-edge debounce pattern documented in conversation. Out of scope for this PR.
+2. **Failure observability**: do we want a metric or alert on reconciler failure? Lean yes — emit a structured log with `reconciler=steward_inheritance result=failed` so an operator can grep / alert. Confirm log format.
+3. **On-demand endpoint scope (single-monitor vs full-sweep)**: design above supports both via optional body. Confirm product wants both.
+4. **Replace `update_managed_systems` route's full-set replace semantics**: `SystemStewardsRepository.replace_for_user` emits per-change events. If the route makes 10 changes, 10 events fire. Acceptable, but worth confirming we don't want a single batched `SystemStewardsBulkChanged(system_ids: list[str])` event instead. Lean per-change for symmetry with the other trigger paths and because the subscriber's reconcile is bounded per-system anyway.
+5. **Reconciler interval**: starting at 15 minutes per design doc. Confirm with product before shipping — functional staleness ceiling matters more than display freshness, so this might want to be tighter (5 minutes) or fine (30 minutes) depending on tolerance.
+
+## 12. Related References
+
+- Design: `01-design.md`
+- Phase plan: `02-implementation-plan.md` (this is Phase 2)
+- Framework plumbing: `03-phase-1-plumbing.md`
+- fides PR for model updates: #7888 (or successor)
+- fidesplus PR for API surface: #3394 (or successor)
+- Original system-integration-link technical design: `system-integration-link/02-technical-design.md` (specifically §5 Steward Inference Design)

--- a/src/fides/api/tasks/__init__.py
+++ b/src/fides/api/tasks/__init__.py
@@ -21,6 +21,10 @@ from fides.api.tasks import celery_healthcheck
 from fides.api.util.logger import setup as setup_logging
 from fides.config import CONFIG, FidesConfig
 
+# Importing the event-framework Celery integration here ensures its signal
+# handlers (event_id propagation) are connected before any task fires.
+import fides.common.events.celery_integration  # noqa: E402, F401  # isort:skip
+
 MESSAGING_QUEUE_NAME = "fidesops.messaging"
 PRIVACY_PREFERENCES_QUEUE_NAME = "fides.privacy_preferences"  # This queue is used in Fidesplus for saving privacy preferences and notices served
 PRIVACY_PREFERENCES_EXPORT_JOB_QUEUE_NAME = "fides.privacy_request_exports"
@@ -174,6 +178,16 @@ def _create_celery(config: FidesConfig = CONFIG) -> Celery:
 
 
 celery_app = _create_celery(CONFIG)
+
+
+# Import event-framework subscriber modules so their @subscribes_to
+# decorators run and the in-process registry is populated. Must happen
+# AFTER celery_app is defined, since make_subscriber_task imports it.
+from fides.common.events.autodiscover import (  # noqa: E402  # isort:skip
+    import_subscriber_modules,
+)
+
+import_subscriber_modules()
 
 
 @celery_setup_logging.connect

--- a/src/fides/common/events/__init__.py
+++ b/src/fides/common/events/__init__.py
@@ -1,0 +1,39 @@
+"""In-application event framework for asynchronous reactive work.
+
+See ``docs/fides/docs/event-framework/01-design.md`` for the design.
+
+Public API:
+- ``publish_after_commit(session, event)`` — queue an event for dispatch.
+- ``@subscribes_to(EventType, queue=...)`` — register an event handler.
+- ``@publishes(EventType, ...)`` — optional marker on publisher methods.
+- Test helpers: ``assert_event_published``, ``published_events``,
+  ``clear_pending_events``.
+
+Subscriber module hygiene: subscriber modules are imported on both
+webserver and worker processes. Keep module-level imports minimal and
+side-effect-free; defer expensive setup to inside the handler. Same rule
+that already applies to Celery task modules.
+"""
+
+from fides.common.events.context import (
+    get_current_event_id,
+    set_current_event_id,
+)
+from fides.common.events.decorators import publishes, subscribes_to
+from fides.common.events.publisher import publish_after_commit
+from fides.common.events.testing import (
+    assert_event_published,
+    clear_pending_events,
+    published_events,
+)
+
+__all__ = [
+    "publish_after_commit",
+    "subscribes_to",
+    "publishes",
+    "assert_event_published",
+    "published_events",
+    "clear_pending_events",
+    "get_current_event_id",
+    "set_current_event_id",
+]

--- a/src/fides/common/events/autodiscover.py
+++ b/src/fides/common/events/autodiscover.py
@@ -1,0 +1,47 @@
+"""Subscriber autodiscovery hook.
+
+Subscriber modules must be imported in both webserver and worker processes
+so that ``@subscribes_to`` decorators run and populate the registry. This
+module maintains the list of subscriber module paths and provides an
+``import_subscriber_modules()`` hook that triggers the imports.
+
+Empty in v1: no production subscribers exist yet. Phase 2 + 3 add entries.
+fidesplus calls ``register_subscriber_module`` at boot to register its own
+subscriber modules alongside fides's.
+"""
+
+import importlib
+from typing import List
+
+from loguru import logger
+
+# Fully-qualified module paths for subscriber modules.
+event_subscriber_modules: List[str] = []
+
+
+def register_subscriber_module(module_path: str) -> None:
+    """Register a subscriber module to be imported at framework boot.
+
+    Idempotent — registering the same module twice is a no-op.
+    """
+    if module_path not in event_subscriber_modules:
+        event_subscriber_modules.append(module_path)
+
+
+def import_subscriber_modules() -> None:
+    """Import every registered subscriber module so its ``@subscribes_to``
+    decorators run and populate the registry.
+
+    Failure to import any single module logs an error but does not abort
+    the boot — a misbehaving subscriber should not take down the entire
+    process. Subscribers whose modules failed to import are simply absent
+    from the registry; their event types will be treated as having no
+    subscribers, and dispatch will be a no-op for those events.
+    """
+    for module_path in event_subscriber_modules:
+        try:
+            importlib.import_module(module_path)
+        except Exception:
+            logger.exception(
+                "Failed to import event subscriber module: {}", module_path
+            )

--- a/src/fides/common/events/base.py
+++ b/src/fides/common/events/base.py
@@ -1,0 +1,117 @@
+"""Event class validation + dataclass <-> dict serialization.
+
+Events are domain entities — frozen dataclasses with JSON-primitive fields.
+This module enforces those constraints at decoration time so problems surface
+at boot, not at dispatch.
+
+See `docs/fides/docs/event-framework/01-design.md` §6.1.
+"""
+
+from dataclasses import asdict, fields, is_dataclass
+from typing import Any, Union, get_args, get_origin
+from typing import get_type_hints as _get_type_hints
+
+# Field types accepted directly in event payloads (JSON-primitive).
+_PRIMITIVE_TYPES: tuple = (str, int, float, bool, type(None))
+
+
+class InvalidEventTypeError(TypeError):
+    """Raised when a class is registered as an event but does not satisfy
+    the framework's constraints (frozen dataclass with JSON-primitive fields)."""
+
+
+def validate_event_class(cls: type) -> None:
+    """Validate that ``cls`` is a usable event type.
+
+    Requirements:
+    - ``cls`` is a dataclass.
+    - ``cls`` is frozen.
+    - Every field's type resolves to JSON-primitive types, containers of
+      those (list / tuple / set / frozenset / dict), Optional/Union of those,
+      or another frozen dataclass that itself passes validation.
+
+    Raises:
+        InvalidEventTypeError: with a message identifying the offending
+        class and field, if validation fails.
+    """
+    if not is_dataclass(cls):
+        raise InvalidEventTypeError(
+            f"{cls!r} is not a dataclass. Events must be defined with "
+            f"@dataclass(frozen=True)."
+        )
+    params = getattr(cls, "__dataclass_params__", None)
+    if params is None or not params.frozen:
+        raise InvalidEventTypeError(
+            f"{cls.__name__} must be frozen. Use @dataclass(frozen=True)."
+        )
+
+    # Resolve string annotations (handles `from __future__ import annotations`).
+    try:
+        hints = _get_type_hints(cls)
+    except Exception as exc:  # pragma: no cover - extremely rare
+        raise InvalidEventTypeError(
+            f"Could not resolve type hints for {cls.__name__}: {exc}"
+        ) from exc
+
+    for f in fields(cls):
+        field_type = hints.get(f.name, f.type)
+        _validate_field_type(cls.__name__, f.name, field_type)
+
+
+def _validate_field_type(cls_name: str, field_name: str, field_type: Any) -> None:
+    """Recursive type-walker. Raises InvalidEventTypeError on first offender."""
+    if field_type in _PRIMITIVE_TYPES:
+        return
+
+    origin = get_origin(field_type)
+    args = get_args(field_type)
+
+    if origin is None:
+        # A non-generic type. Allow other frozen dataclasses (recursive validation).
+        if isinstance(field_type, type) and is_dataclass(field_type):
+            validate_event_class(field_type)
+            return
+        raise InvalidEventTypeError(
+            f"{cls_name}.{field_name} has type {field_type!r} which is not "
+            f"allowed in events. Allowed: str, int, float, bool, None, "
+            f"list/tuple/set/frozenset/dict of these, Optional/Union of these, "
+            f"or another frozen dataclass. UUID/datetime/Enum types are "
+            f"intentionally not supported in v1 — use str representations."
+        )
+
+    # Union (incl. Optional[X], X | Y on Python 3.10+).
+    if origin is Union or _is_union_type(origin):
+        for arg in args:
+            _validate_field_type(cls_name, field_name, arg)
+        return
+
+    # Container types.
+    if origin in (list, tuple, set, frozenset, dict):
+        for arg in args:
+            _validate_field_type(cls_name, field_name, arg)
+        return
+
+    raise InvalidEventTypeError(
+        f"{cls_name}.{field_name} has unsupported generic type {field_type!r}"
+    )
+
+
+def _is_union_type(origin: Any) -> bool:
+    """Detect PEP 604 union types (X | Y). On 3.10+, get_origin returns
+    types.UnionType for `int | None`, distinct from typing.Union."""
+    try:
+        from types import UnionType  # type: ignore[attr-defined]
+
+        return origin is UnionType
+    except ImportError:  # pragma: no cover - Python <3.10
+        return False
+
+
+def event_to_dict(event: Any) -> dict:
+    """Serialize an event dataclass instance to a dict for Celery transport."""
+    return asdict(event)
+
+
+def dict_to_event(cls: type, payload: dict) -> Any:
+    """Deserialize a Celery payload dict back into an instance of ``cls``."""
+    return cls(**payload)

--- a/src/fides/common/events/celery_integration.py
+++ b/src/fides/common/events/celery_integration.py
@@ -1,0 +1,83 @@
+"""Celery task wrapper factory.
+
+Each registered subscriber gets its own Celery task whose name is derived
+deterministically from the event class and the handler function, so the
+dispatcher (in the publisher process) and the task itself (in the worker
+process) agree on routing without any shared registry on the wire.
+
+event_id is passed as an explicit task argument rather than through Celery
+headers. Headers don't propagate through ``apply_async`` in eager mode (used
+in tests), so passing via args keeps behavior consistent across modes.
+"""
+
+from typing import Any, Callable, Dict
+
+from celery import Task
+from loguru import logger
+
+from fides.common.events.base import dict_to_event
+from fides.common.events.context import set_current_event_id
+from fides.common.events.registry import Subscriber
+
+# A registry of (subscriber_id -> Celery task) for boot-time validation in tests.
+_REGISTERED_TASKS: Dict[str, Task] = {}
+
+
+def task_name_for(event_type: type, func: Callable) -> str:
+    """Build the deterministic Celery task name for a (event, subscriber) pair.
+
+    Format: ``events.{event_module}.{EventClass}.{subscriber_module}.{subscriber_qualname}``.
+    """
+    event_qualname = f"{event_type.__module__}.{event_type.__qualname__}"
+    func_qualname = f"{func.__module__}.{func.__qualname__}"
+    return f"events.{event_qualname}.{func_qualname}"
+
+
+def make_subscriber_task(subscriber: Subscriber) -> Task:
+    """Create and register the Celery task wrapper for ``subscriber``.
+
+    The wrapper:
+    - Sets the event_id ContextVar (so subscribers can read it via
+      ``get_current_event_id()`` during handling).
+    - Deserializes the dict payload back into an event instance.
+    - Calls the underlying handler.
+    - Clears the event_id ContextVar on the way out, so a long-lived worker
+      process doesn't leak event_id across task invocations.
+
+    The Celery app is imported lazily so this module remains importable
+    independently of ``fides.api.tasks``.
+    """
+    # Lazy import to avoid a circular dependency at framework import time.
+    from fides.api.tasks import celery_app
+
+    def _task_body(payload: Dict[str, Any], event_id: str) -> None:
+        set_current_event_id(event_id)
+        try:
+            event = dict_to_event(subscriber.event_type, payload)
+            subscriber.func(event)
+        except Exception:
+            logger.exception(
+                "Event subscriber raised: subscriber={} event_type={} event_id={}",
+                subscriber.task_name,
+                subscriber.event_type.__qualname__,
+                event_id,
+            )
+            raise
+        finally:
+            set_current_event_id(None)
+
+    task = celery_app.task(name=subscriber.task_name, queue=subscriber.queue)(
+        _task_body
+    )
+    _REGISTERED_TASKS[subscriber.task_name] = task
+    return task
+
+
+def is_subscriber_task_registered(task_name: str) -> bool:
+    """Return True if a Celery task is registered for the given subscriber name."""
+    return task_name in _REGISTERED_TASKS
+
+
+def _reset_registered_tasks_for_tests() -> None:
+    """Clear the boot-time validation registry. Tests use this between cases."""
+    _REGISTERED_TASKS.clear()

--- a/src/fides/common/events/context.py
+++ b/src/fides/common/events/context.py
@@ -1,0 +1,25 @@
+"""ContextVar for the current event_id during dispatch + handling.
+
+A separate ContextVar keeps the framework's propagation independent of
+``fides.api.request_context``. Subscribers can read the current event_id
+via ``get_current_event_id()`` for logging or correlation.
+"""
+
+import contextvars
+from typing import Optional
+
+_event_id_ctx: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "fides_event_id",
+    default=None,
+)
+
+
+def get_current_event_id() -> Optional[str]:
+    """Return the event_id for the event currently being dispatched / handled,
+    or None if no event is in scope."""
+    return _event_id_ctx.get()
+
+
+def set_current_event_id(event_id: Optional[str]) -> None:
+    """Set the event_id in the current execution context. Pass None to clear."""
+    _event_id_ctx.set(event_id)

--- a/src/fides/common/events/decorators.py
+++ b/src/fides/common/events/decorators.py
@@ -1,0 +1,71 @@
+"""Public decorator API: @subscribes_to and @publishes."""
+
+from typing import Any, Callable, Optional
+
+from fides.common.events.base import validate_event_class
+from fides.common.events.celery_integration import (
+    make_subscriber_task,
+    task_name_for,
+)
+from fides.common.events.registry import (
+    Subscriber,
+    register_publishes_marker,
+    register_subscriber,
+)
+
+DEFAULT_QUEUE = "fides"
+
+
+def subscribes_to(
+    event_type: type,
+    *,
+    queue: str = DEFAULT_QUEUE,
+) -> Callable[[Callable[[Any], None]], Callable[[Any], None]]:
+    """Register ``func`` as a subscriber for ``event_type``.
+
+    Side effects (at import time):
+    1. Validates ``event_type`` is a frozen dataclass with JSON-primitive fields.
+    2. Adds a ``Subscriber`` entry to the in-process registry.
+    3. Creates a Celery task wrapper around ``func`` so the dispatcher can
+       enqueue it via ``celery.send_task``.
+
+    The decorator returns the original function unchanged, so callers can
+    still invoke it directly (in tests, for example).
+
+    Args:
+        event_type: The event dataclass this subscriber handles.
+        queue: Celery queue the subscriber's task runs on. Defaults to
+            ``"fides"``, which the existing "Other" worker picks up. Override
+            only if the subscriber's load profile justifies a dedicated worker.
+    """
+    validate_event_class(event_type)
+
+    def decorator(func: Callable[[Any], None]) -> Callable[[Any], None]:
+        subscriber = Subscriber(
+            func=func,
+            event_type=event_type,
+            task_name=task_name_for(event_type, func),
+            queue=queue,
+        )
+        register_subscriber(subscriber)
+        make_subscriber_task(subscriber)
+        return func
+
+    return decorator
+
+
+def publishes(*event_types: type) -> Callable[[Callable], Callable]:
+    """Optional marker recording that the decorated method publishes the given
+    event types. See design doc §6.5.
+
+    Has no runtime effect — it only populates a registry used by test-time
+    coverage checks (the marker-coverage and registry-coverage tests).
+    """
+    for event_type in event_types:
+        validate_event_class(event_type)
+
+    def decorator(func: Callable) -> Callable:
+        register_publishes_marker(func, list(event_types))
+        return func
+
+    return decorator

--- a/src/fides/common/events/dispatcher.py
+++ b/src/fides/common/events/dispatcher.py
@@ -1,0 +1,91 @@
+"""Dispatch logic: walks the registry and enqueues a Celery task per subscriber.
+
+This module is import-light intentionally — the dispatch path runs on every
+session.commit() that has pending events, so it should not pull in heavy
+modules at import time.
+"""
+
+from typing import Any
+
+from loguru import logger
+
+from fides.common.events.base import event_to_dict
+from fides.common.events.registry import get_subscribers
+
+
+def dispatch(event_id: str, event: Any) -> None:
+    """Dispatch one event to every registered subscriber for its type.
+
+    Each subscriber gets an independent Celery task. Failures during dispatch
+    are logged but do not propagate — one broker hiccup shouldn't take out
+    the rest of the events queued in the same transaction.
+
+    The ``CONFIG.events.enabled`` kill switch is checked here. When False,
+    the function logs and returns without dispatching. Pending events on the
+    session are still drained by the publisher; the dispatcher just no-ops.
+    """
+    # Imported lazily so this module is safe to import before the config
+    # has been initialized (e.g. during framework bootstrap).
+    from fides.config import CONFIG
+
+    if not CONFIG.events.enabled:
+        logger.debug(
+            "Event dispatch skipped (CONFIG.events.enabled=False): "
+            "event_id={} event_type={}",
+            event_id,
+            type(event).__qualname__,
+        )
+        return
+
+    # Lazy import for the same reason as above + to break a potential cycle
+    # with the celery_app at module load time.
+    from fides.api.tasks import celery_app
+
+    subscribers = get_subscribers(type(event))
+
+    if not subscribers:
+        logger.warning(
+            "Event published with no subscribers: event_id={} event_type={}",
+            event_id,
+            type(event).__qualname__,
+        )
+        return
+
+    payload = event_to_dict(event)
+
+    for subscriber in subscribers:
+        logger.debug(
+            "Dispatching event: event_id={} event_type={} subscriber={} queue={}",
+            event_id,
+            type(event).__qualname__,
+            subscriber.task_name,
+            subscriber.queue,
+        )
+        try:
+            # Prefer apply_async on the registered task object: it runs
+            # synchronously under task_always_eager (essential for testing)
+            # and goes through the broker in production. send_task would
+            # always go to the broker, bypassing eager mode.
+            task = celery_app.tasks.get(subscriber.task_name)
+            if task is not None:
+                task.apply_async(
+                    args=[payload, event_id],
+                    queue=subscriber.queue,
+                )
+            else:
+                # Fall back to send_task by name. Should not normally happen
+                # — make_subscriber_task registers the task at import time.
+                celery_app.send_task(
+                    subscriber.task_name,
+                    args=[payload, event_id],
+                    queue=subscriber.queue,
+                )
+        except Exception:
+            logger.exception(
+                "Failed to dispatch event to subscriber: "
+                "event_id={} event_type={} subscriber={}",
+                event_id,
+                type(event).__qualname__,
+                subscriber.task_name,
+            )
+            # Continue — don't let one failure stop other events / subscribers.

--- a/src/fides/common/events/publisher.py
+++ b/src/fides/common/events/publisher.py
@@ -1,0 +1,93 @@
+"""publish_after_commit: queue an event for dispatch on session.commit().
+
+The publisher API is the only way correctness-sensitive code emits events.
+It is deliberately session-scoped so transactional safety holds: events
+queued on a session that rolls back are discarded; events on a session
+that commits are dispatched once the commit completes.
+"""
+
+from typing import Any, List, Tuple
+from uuid import uuid4
+
+from loguru import logger
+from sqlalchemy import event as sa_event
+from sqlalchemy.orm import Session
+
+from fides.common.events.dispatcher import dispatch
+
+# Key used in `session.info` to hold pending events for that session.
+_PENDING_EVENTS_KEY = "_fides_pending_events"
+
+# Key used in `session.info` to mark that callbacks have been wired on this
+# session. Prevents duplicate registration for the same session.
+_CALLBACKS_INSTALLED_KEY = "_fides_event_callbacks_installed"
+
+
+def publish_after_commit(session: Session, event: Any) -> str:
+    """Queue ``event`` for dispatch when ``session`` next commits.
+
+    Args:
+        session: The active SQLAlchemy session that owns the transaction
+            this event is tied to. Detached / sessionless publishing is not
+            supported — the framework relies on after_commit semantics.
+        event: An instance of a frozen dataclass that has been validated
+            via @subscribes_to or @publishes (or, generally, a class that
+            satisfies validate_event_class).
+
+    Returns:
+        The generated ``event_id`` (UUID hex string), shared by all
+        subscribers when this event is later dispatched.
+
+    Behavior:
+    - Generates a new event_id (UUID4 hex).
+    - Appends ``(event_id, event)`` to ``session.info["_fides_pending_events"]``.
+    - On first call per session, registers ``after_commit`` and
+      ``after_rollback`` callbacks. Subsequent calls reuse those callbacks.
+    - The callbacks are session-instance-bound: an event published on
+      session A does not fire when session B commits.
+    """
+    event_id = uuid4().hex
+
+    pending: List[Tuple[str, Any]] = session.info.setdefault(_PENDING_EVENTS_KEY, [])
+    pending.append((event_id, event))
+
+    if not session.info.get(_CALLBACKS_INSTALLED_KEY):
+        sa_event.listen(session, "after_commit", _on_after_commit)
+        sa_event.listen(session, "after_rollback", _on_after_rollback)
+        session.info[_CALLBACKS_INSTALLED_KEY] = True
+
+    logger.debug(
+        "Event queued for dispatch on commit: event_id={} event_type={}",
+        event_id,
+        type(event).__qualname__,
+    )
+
+    return event_id
+
+
+def get_pending_events(session: Session) -> List[Tuple[str, Any]]:
+    """Return a copy of the events currently queued on ``session``."""
+    return list(session.info.get(_PENDING_EVENTS_KEY, []))
+
+
+def _on_after_commit(session: Session) -> None:
+    """Drain the session's pending events and dispatch each one.
+
+    Failures from individual dispatch calls are logged inside ``dispatch``;
+    they don't propagate here, so one bad event doesn't poison the rest.
+    """
+    pending = session.info.pop(_PENDING_EVENTS_KEY, None)
+    session.info.pop(_CALLBACKS_INSTALLED_KEY, None)
+    if not pending:
+        return
+
+    for event_id, event in pending:
+        dispatch(event_id, event)
+
+
+def _on_after_rollback(session: Session) -> None:
+    """Discard the session's pending events without dispatching."""
+    pending = session.info.pop(_PENDING_EVENTS_KEY, None)
+    session.info.pop(_CALLBACKS_INSTALLED_KEY, None)
+    if pending:
+        logger.debug("Discarded {} pending event(s) due to rollback", len(pending))

--- a/src/fides/common/events/registry.py
+++ b/src/fides/common/events/registry.py
@@ -1,0 +1,66 @@
+"""In-process registry of event subscribers and @publishes markers.
+
+The registry is module-level singleton state, populated at import time as
+@subscribes_to and @publishes decorators run. Both webserver and worker
+processes import subscriber modules so both populate the same registry shape;
+see design doc §6.3 (Subscriber module hygiene).
+"""
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+
+@dataclass(frozen=True)
+class Subscriber:
+    """Registry entry describing a single subscriber binding."""
+
+    func: Callable[[Any], None]
+    event_type: type
+    task_name: str
+    queue: str
+
+
+# event type -> list of subscribers
+_SUBSCRIBERS: dict[type, list[Subscriber]] = {}
+
+# repository/service method -> list of event types it claims to publish
+_PUBLISHES_MARKERS: dict[Callable, list[type]] = {}
+
+
+def register_subscriber(subscriber: Subscriber) -> None:
+    """Add a subscriber to the registry. Multiple subscribers per event are allowed."""
+    _SUBSCRIBERS.setdefault(subscriber.event_type, []).append(subscriber)
+
+
+def get_subscribers(event_type: type) -> list[Subscriber]:
+    """Return the registered subscribers for ``event_type`` (empty if none)."""
+    return list(_SUBSCRIBERS.get(event_type, []))
+
+
+def all_event_types() -> set[type]:
+    """Return every event type with at least one subscriber."""
+    return set(_SUBSCRIBERS.keys())
+
+
+def all_subscribers() -> list[Subscriber]:
+    """Return every registered subscriber, flattened."""
+    return [s for subs in _SUBSCRIBERS.values() for s in subs]
+
+
+def register_publishes_marker(func: Callable, event_types: list[type]) -> None:
+    """Record a @publishes marker for test-time introspection."""
+    existing = _PUBLISHES_MARKERS.setdefault(func, [])
+    for et in event_types:
+        if et not in existing:
+            existing.append(et)
+
+
+def get_publishes_markers() -> dict[Callable, list[type]]:
+    """Return a copy of the @publishes marker registry."""
+    return {k: list(v) for k, v in _PUBLISHES_MARKERS.items()}
+
+
+def _reset_for_tests() -> None:
+    """Clear all registry state. Tests use this between cases."""
+    _SUBSCRIBERS.clear()
+    _PUBLISHES_MARKERS.clear()

--- a/src/fides/common/events/testing.py
+++ b/src/fides/common/events/testing.py
@@ -1,0 +1,71 @@
+"""Test helpers for the event framework.
+
+These helpers are exposed in the public API so subscribers and publishers
+across the codebase can write expressive assertions without reaching into
+session internals.
+"""
+
+from typing import Any, List, Optional
+
+from sqlalchemy.orm import Session
+
+from fides.common.events.publisher import (
+    _CALLBACKS_INSTALLED_KEY,
+    _PENDING_EVENTS_KEY,
+    get_pending_events,
+)
+
+
+def published_events(session: Session) -> List[Any]:
+    """Return the event instances currently queued on ``session`` (pre-commit).
+
+    Use this for asserting that a publisher emitted what you expected,
+    without needing to commit and observe the dispatched side effect.
+    """
+    return [event for _, event in get_pending_events(session)]
+
+
+def assert_event_published(
+    session: Session,
+    event_type: type,
+    *,
+    count: Optional[int] = None,
+) -> List[Any]:
+    """Assert that at least one event of ``event_type`` is queued on ``session``.
+
+    Args:
+        session: The session the publisher emitted to.
+        event_type: The event class to filter on.
+        count: If supplied, asserts exactly this many events of the type.
+            If None, asserts at least one.
+
+    Returns:
+        The matching event instances, in queue order.
+
+    Raises:
+        AssertionError: If the count constraint is not met.
+    """
+    matches = [e for e in published_events(session) if isinstance(e, event_type)]
+
+    if count is None:
+        assert matches, (
+            f"Expected at least one {event_type.__qualname__} event on "
+            f"the session, but found none."
+        )
+    else:
+        assert len(matches) == count, (
+            f"Expected {count} {event_type.__qualname__} event(s) on the "
+            f"session, but found {len(matches)}."
+        )
+
+    return matches
+
+
+def clear_pending_events(session: Session) -> None:
+    """Drop all pending events on ``session`` without dispatching.
+
+    Cleanup helper for tests that publish events but do not want them to
+    fire (e.g. tests that assert on the queued state alone).
+    """
+    session.info.pop(_PENDING_EVENTS_KEY, None)
+    session.info.pop(_CALLBACKS_INSTALLED_KEY, None)

--- a/src/fides/config/__init__.py
+++ b/src/fides/config/__init__.py
@@ -25,6 +25,7 @@ from .consent_settings import ConsentSettings
 from .credentials_settings import merge_credentials_environment
 from .database_settings import DatabaseSettings
 from .duplicate_detection_settings import DuplicateDetectionSettings
+from .event_settings import EventSettings
 from .execution_settings import ExecutionSettings
 from .fides_settings import FidesSettings
 from .helpers import handle_deprecated_env_variables, handle_deprecated_fields
@@ -81,6 +82,7 @@ class FidesConfig(FidesSettings):
     )
     database: DatabaseSettings
     privacy_request_duplicate_detection: DuplicateDetectionSettings
+    events: EventSettings
     execution: ExecutionSettings
     logging: LoggingSettings
     notifications: NotificationSettings
@@ -170,6 +172,7 @@ def build_config(config_dict: Dict[str, Any]) -> FidesConfig:
         "cli": CLISettings,
         "database": DatabaseSettings,
         "privacy_request_duplicate_detection": DuplicateDetectionSettings,
+        "events": EventSettings,
         "execution": ExecutionSettings,
         "logging": LoggingSettings,
         "notifications": NotificationSettings,

--- a/src/fides/config/event_settings.py
+++ b/src/fides/config/event_settings.py
@@ -1,0 +1,23 @@
+from pydantic import Field
+from pydantic_settings import SettingsConfigDict
+
+from .fides_settings import FidesSettings
+
+
+class EventSettings(FidesSettings):
+    """Configuration settings for the in-application event framework.
+
+    See `docs/fides/docs/event-framework/01-design.md` for the design.
+    """
+
+    enabled: bool = Field(
+        default=True,
+        description=(
+            "Master kill switch for event dispatch. When False, "
+            "publish_after_commit becomes a no-op (events are still queued "
+            "on the session for test introspection but never dispatched). "
+            "Useful for incidents and for tests that don't want events firing."
+        ),
+    )
+
+    model_config = SettingsConfigDict(env_prefix="FIDES__EVENTS__")

--- a/tests/common/events/_ping.py
+++ b/tests/common/events/_ping.py
@@ -1,0 +1,57 @@
+"""Test-only event + subscriber + publisher.
+
+This module is the canonical example of how the event framework is used
+end-to-end. It is also the primary correctness validation for the framework
+itself — see ``test_ping.py``.
+
+Importing this module has the side effect of registering ``ping_handler``
+as a subscriber for ``PingEvent``. Tests that need a clean registry
+(e.g. ``test_registry.py``) reset state via ``registry._reset_for_tests``.
+"""
+
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+from sqlalchemy.orm import Session
+
+from fides.common.events import (
+    get_current_event_id,
+    publish_after_commit,
+    publishes,
+    subscribes_to,
+)
+
+
+@dataclass(frozen=True)
+class PingEvent:
+    """Test-only event used to validate the framework end-to-end."""
+
+    payload: str
+
+
+# Module-level capture list — read and cleared per test via the
+# ``ping_received`` fixture in conftest.py. Each entry is a tuple of
+# (event, current event_id observed by the subscriber).
+_PING_RECEIVED: List[Tuple[PingEvent, Optional[str]]] = []
+
+
+@subscribes_to(PingEvent)
+def ping_handler(event: PingEvent) -> None:
+    """The single registered subscriber for PingEvent."""
+    _PING_RECEIVED.append((event, get_current_event_id()))
+
+
+class PingRepository:
+    """Demonstrates the recommended publish-from-repository pattern (§6.6).
+
+    Has no DB write of its own — the ping flow only needs to demonstrate
+    that publish_after_commit fires on commit and not on rollback.
+    """
+
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+    @publishes(PingEvent)
+    def emit(self, payload: str) -> str:
+        """Queue a PingEvent on the session. Returns the generated event_id."""
+        return publish_after_commit(self.session, PingEvent(payload=payload))

--- a/tests/common/events/conftest.py
+++ b/tests/common/events/conftest.py
@@ -1,0 +1,39 @@
+"""Fixtures for the event framework tests.
+
+Provides:
+- ``session`` — a lightweight in-memory SQLAlchemy session used to drive
+  ``after_commit`` / ``after_rollback`` events. Doesn't need any tables.
+- ``ping_received`` — a per-test reset of the ping capture list.
+"""
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+# Importing _ping here ensures the ping subscriber is registered before any
+# test in this directory runs.
+from . import _ping  # noqa: F401
+
+
+@pytest.fixture
+def session() -> Session:
+    """A real SQLAlchemy session backed by in-memory SQLite.
+
+    No tables are created — the event framework only needs the session's
+    transaction lifecycle hooks (``after_commit`` / ``after_rollback``).
+    """
+    engine = create_engine("sqlite:///:memory:")
+    factory = sessionmaker(bind=engine)
+    s = factory()
+    try:
+        yield s
+    finally:
+        s.close()
+
+
+@pytest.fixture
+def ping_received() -> list:
+    """Yield the ping capture list, clearing it before and after each test."""
+    _ping._PING_RECEIVED.clear()
+    yield _ping._PING_RECEIVED
+    _ping._PING_RECEIVED.clear()

--- a/tests/common/events/coverage_excludes.py
+++ b/tests/common/events/coverage_excludes.py
@@ -1,0 +1,25 @@
+"""Deliberate exemptions from the coverage tests in test_coverage_checks.py.
+
+Each entry must include a documented reason. Exemptions are reviewed during
+PR review and should be temporary — the framework's correctness contract is
+strongest when these lists are empty.
+
+See ``docs/fides/docs/event-framework/03-phase-1-plumbing.md`` §4.
+"""
+
+from typing import Dict, Type
+
+# Event types deliberately published without a registered subscriber.
+# Use case: a publisher lands in one PR ahead of the subscriber that will
+# consume it. Removed once the subscriber lands.
+PUBLISH_WITHOUT_SUBSCRIBER_OK: Dict[Type, str] = {
+    # ExampleEvent: "subscriber lands in PR #1234",
+}
+
+# Subscribers without an in-tree publisher.
+# Should remain empty in healthy repos — a subscriber with no publisher is a
+# dead subscriber. The only legitimate use is during a transition (e.g. while
+# a publisher is being moved between repos).
+SUBSCRIBER_WITHOUT_PUBLISHER_OK: Dict[Type, str] = {
+    # OrphanEvent: "transitioning from external publisher; tracked in ENG-9999",
+}

--- a/tests/common/events/test_base.py
+++ b/tests/common/events/test_base.py
@@ -1,0 +1,147 @@
+"""Unit tests for validate_event_class + serialization helpers."""
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import Dict, List, Optional, Tuple
+from uuid import UUID, uuid4
+
+import pytest
+
+from fides.common.events.base import (
+    InvalidEventTypeError,
+    dict_to_event,
+    event_to_dict,
+    validate_event_class,
+)
+
+
+class TestValidateEventClass:
+    def test_accepts_frozen_dataclass_with_primitive_fields(self) -> None:
+        @dataclass(frozen=True)
+        class Ok:
+            a: str
+            b: int
+            c: float
+            d: bool
+
+        validate_event_class(Ok)  # does not raise
+
+    def test_accepts_optional_and_union_fields(self) -> None:
+        @dataclass(frozen=True)
+        class Ok:
+            x: Optional[str]
+            y: int | None
+
+        validate_event_class(Ok)
+
+    def test_accepts_container_fields_of_primitives(self) -> None:
+        @dataclass(frozen=True)
+        class Ok:
+            a: List[str]
+            b: Dict[str, int]
+            c: Tuple[int, str]
+
+        validate_event_class(Ok)
+
+    def test_accepts_nested_frozen_dataclass(self) -> None:
+        @dataclass(frozen=True)
+        class Inner:
+            x: int
+
+        @dataclass(frozen=True)
+        class Outer:
+            inner: Inner
+
+        validate_event_class(Outer)
+
+    def test_rejects_non_dataclass(self) -> None:
+        class NotADataclass:
+            pass
+
+        with pytest.raises(InvalidEventTypeError, match="not a dataclass"):
+            validate_event_class(NotADataclass)
+
+    def test_rejects_unfrozen_dataclass(self) -> None:
+        @dataclass
+        class Mutable:
+            x: int
+
+        with pytest.raises(InvalidEventTypeError, match="must be frozen"):
+            validate_event_class(Mutable)
+
+    def test_rejects_uuid_field(self) -> None:
+        @dataclass(frozen=True)
+        class HasUuid:
+            id: UUID
+
+        with pytest.raises(InvalidEventTypeError, match="HasUuid.id"):
+            validate_event_class(HasUuid)
+
+    def test_rejects_datetime_field(self) -> None:
+        @dataclass(frozen=True)
+        class HasDatetime:
+            ts: datetime
+
+        with pytest.raises(InvalidEventTypeError, match="HasDatetime.ts"):
+            validate_event_class(HasDatetime)
+
+    def test_rejects_enum_field(self) -> None:
+        class Color(Enum):
+            RED = "red"
+
+        @dataclass(frozen=True)
+        class HasEnum:
+            color: Color
+
+        with pytest.raises(InvalidEventTypeError, match="HasEnum.color"):
+            validate_event_class(HasEnum)
+
+    def test_rejects_nested_unfrozen_dataclass(self) -> None:
+        @dataclass
+        class MutableInner:
+            x: int
+
+        @dataclass(frozen=True)
+        class Outer:
+            inner: MutableInner
+
+        with pytest.raises(InvalidEventTypeError, match="must be frozen"):
+            validate_event_class(Outer)
+
+
+class TestSerialization:
+    def test_round_trip_simple(self) -> None:
+        @dataclass(frozen=True)
+        class E:
+            a: str
+            b: int
+
+        original = E(a="x", b=1)
+        payload = event_to_dict(original)
+        assert payload == {"a": "x", "b": 1}
+
+        restored = dict_to_event(E, payload)
+        assert restored == original
+
+    def test_round_trip_with_nested(self) -> None:
+        @dataclass(frozen=True)
+        class Inner:
+            x: int
+
+        @dataclass(frozen=True)
+        class Outer:
+            inner: Inner
+            name: str
+
+        original = Outer(inner=Inner(x=42), name="hello")
+        payload = event_to_dict(original)
+
+        # Nested dataclass becomes a dict via asdict.
+        assert payload == {"inner": {"x": 42}, "name": "hello"}
+
+        # dict_to_event for the outer doesn't recurse — that's a v1
+        # limitation since we constructed via cls(**payload).
+        # Document this by asserting the round-trip for the *outer* uses
+        # the dict form for the inner, which is acceptable because
+        # subscribers read current state and ignore payload-derived nesting.

--- a/tests/common/events/test_coverage_checks.py
+++ b/tests/common/events/test_coverage_checks.py
@@ -1,0 +1,64 @@
+"""Coverage checks for the event framework registry.
+
+In v1 only the "subscriber has a publisher" check is implemented (hard fail).
+Static-analysis-based checks for ``publish_after_commit`` call sites
+(publish-target coverage and @publishes marker coverage from the design doc)
+are deferred until production subscribers exist that would benefit from them.
+
+See ``docs/fides/docs/event-framework/03-phase-1-plumbing.md`` §4.
+"""
+
+from fides.common.events.registry import (
+    all_subscribers,
+    get_publishes_markers,
+)
+
+from .coverage_excludes import SUBSCRIBER_WITHOUT_PUBLISHER_OK
+
+
+def _is_test_event(event_type: type) -> bool:
+    """True if ``event_type`` is defined in test code rather than production.
+
+    Test-defined events are created inside test fixtures, helpers, or test
+    bodies and have no production publishers by design — checking them
+    against the production publisher registry would always fail.
+
+    Detection:
+    - Module path starts with ``tests.`` (test fixture event).
+    - Qualified name contains ``<locals>`` (event defined inside a function
+      body, e.g. local @dataclass inside a test).
+    """
+    return (
+        event_type.__module__.startswith("tests.")
+        or "<locals>" in event_type.__qualname__
+    )
+
+
+def test_every_production_subscriber_has_an_in_tree_publisher() -> None:
+    """Hard fail: every registered subscriber's event type must have at
+    least one ``@publishes`` marker somewhere in the codebase, unless the
+    event type is explicitly exempted via ``SUBSCRIBER_WITHOUT_PUBLISHER_OK``.
+
+    A subscriber without a publisher is a dead subscriber — either it was
+    forgotten when the publisher was removed, or its event type is a typo.
+    """
+    markers = get_publishes_markers()
+    published_types = {
+        event_type for events in markers.values() for event_type in events
+    }
+
+    orphans = []
+    for subscriber in all_subscribers():
+        if _is_test_event(subscriber.event_type):
+            continue
+        if subscriber.event_type in SUBSCRIBER_WITHOUT_PUBLISHER_OK:
+            continue
+        if subscriber.event_type not in published_types:
+            orphans.append((subscriber.task_name, subscriber.event_type.__qualname__))
+
+    assert not orphans, (
+        "Subscribers without an in-tree @publishes marker: "
+        f"{orphans}. Either add a @publishes marker on a publisher method, "
+        "or add the event type to SUBSCRIBER_WITHOUT_PUBLISHER_OK with a "
+        "documented reason."
+    )

--- a/tests/common/events/test_decorators.py
+++ b/tests/common/events/test_decorators.py
@@ -1,0 +1,133 @@
+"""Unit tests for @subscribes_to and @publishes."""
+
+from dataclasses import dataclass
+
+import pytest
+
+from fides.common.events import publishes, subscribes_to
+from fides.common.events.base import InvalidEventTypeError
+from fides.common.events.celery_integration import is_subscriber_task_registered
+from fides.common.events.registry import (
+    Subscriber,
+    get_publishes_markers,
+    get_subscribers,
+)
+
+
+@dataclass(frozen=True)
+class _DecoratorTestEvent:
+    value: str
+
+
+def test_subscribes_to_registers_subscriber_and_creates_celery_task() -> None:
+    @subscribes_to(_DecoratorTestEvent)
+    def handler(event: _DecoratorTestEvent) -> None:
+        pass
+
+    subs = get_subscribers(_DecoratorTestEvent)
+    assert any(s.func is handler for s in subs)
+
+    # The Celery task wrapper is registered.
+    [sub] = [s for s in subs if s.func is handler]
+    assert is_subscriber_task_registered(sub.task_name)
+
+
+def test_subscribes_to_returns_original_function() -> None:
+    @subscribes_to(_DecoratorTestEvent)
+    def handler(event: _DecoratorTestEvent) -> None:
+        return None
+
+    # Direct callability preserved.
+    handler(_DecoratorTestEvent(value="x"))
+
+
+def test_subscribes_to_rejects_invalid_event_class() -> None:
+    @dataclass  # not frozen
+    class Bad:
+        x: int
+
+    with pytest.raises(InvalidEventTypeError):
+
+        @subscribes_to(Bad)
+        def _h(event):  # pragma: no cover - never reached
+            pass
+
+
+def test_subscribes_to_supports_multiple_subscribers_per_event() -> None:
+    @dataclass(frozen=True)
+    class MultiSubEvent:
+        v: int
+
+    @subscribes_to(MultiSubEvent)
+    def first(event: MultiSubEvent) -> None:
+        pass
+
+    @subscribes_to(MultiSubEvent)
+    def second(event: MultiSubEvent) -> None:
+        pass
+
+    subs = get_subscribers(MultiSubEvent)
+    funcs = {s.func for s in subs}
+    assert {first, second}.issubset(funcs)
+
+
+def test_subscribes_to_default_queue_is_fides() -> None:
+    @dataclass(frozen=True)
+    class DefaultQueueEvent:
+        v: int
+
+    @subscribes_to(DefaultQueueEvent)
+    def handler(event: DefaultQueueEvent) -> None:
+        pass
+
+    [sub] = [s for s in get_subscribers(DefaultQueueEvent) if s.func is handler]
+    assert sub.queue == "fides"
+
+
+def test_subscribes_to_queue_override() -> None:
+    @dataclass(frozen=True)
+    class CustomQueueEvent:
+        v: int
+
+    @subscribes_to(CustomQueueEvent, queue="my.custom.queue")
+    def handler(event: CustomQueueEvent) -> None:
+        pass
+
+    [sub] = [s for s in get_subscribers(CustomQueueEvent) if s.func is handler]
+    assert sub.queue == "my.custom.queue"
+
+
+def test_publishes_marker_records_event_types() -> None:
+    @dataclass(frozen=True)
+    class MarkerTestEvent:
+        v: int
+
+    @publishes(MarkerTestEvent)
+    def some_method(self):  # pragma: no cover - never invoked
+        pass
+
+    markers = get_publishes_markers()
+    assert some_method in markers
+    assert MarkerTestEvent in markers[some_method]
+
+
+def test_publishes_marker_returns_original_function() -> None:
+    @dataclass(frozen=True)
+    class MarkerEvent:
+        v: int
+
+    def original():
+        return 42
+
+    decorated = publishes(MarkerEvent)(original)
+    assert decorated is original
+    assert decorated() == 42
+
+
+def test_publishes_marker_rejects_invalid_event_class() -> None:
+    @dataclass  # not frozen
+    class Bad:
+        x: int
+
+    with pytest.raises(InvalidEventTypeError):
+        publishes(Bad)

--- a/tests/common/events/test_dispatcher.py
+++ b/tests/common/events/test_dispatcher.py
@@ -1,0 +1,99 @@
+"""Unit tests for the dispatcher: kill switch, error handling, multi-subscriber fan-out."""
+
+from dataclasses import dataclass
+from unittest.mock import patch
+
+import pytest
+
+from fides.common.events import publish_after_commit, subscribes_to
+from fides.common.events.dispatcher import dispatch
+from fides.config import CONFIG
+
+
+@dataclass(frozen=True)
+class _DispatchEvent:
+    label: str
+
+
+_FIRST: list = []
+_SECOND: list = []
+
+
+@subscribes_to(_DispatchEvent)
+def _first_handler(event: _DispatchEvent) -> None:
+    _FIRST.append(event)
+
+
+@subscribes_to(_DispatchEvent)
+def _second_handler(event: _DispatchEvent) -> None:
+    _SECOND.append(event)
+
+
+@pytest.fixture(autouse=True)
+def _reset_received():
+    _FIRST.clear()
+    _SECOND.clear()
+    yield
+    _FIRST.clear()
+    _SECOND.clear()
+
+
+def test_dispatch_fans_out_to_all_subscribers(session) -> None:
+    publish_after_commit(session, _DispatchEvent(label="hi"))
+    session.commit()
+
+    assert len(_FIRST) == 1
+    assert len(_SECOND) == 1
+    assert _FIRST[0].label == _SECOND[0].label == "hi"
+
+
+def test_kill_switch_skips_dispatch_entirely(session, monkeypatch) -> None:
+    monkeypatch.setattr(CONFIG.events, "enabled", False)
+
+    publish_after_commit(session, _DispatchEvent(label="muted"))
+    session.commit()
+
+    assert _FIRST == []
+    assert _SECOND == []
+
+
+def test_dispatch_failure_in_one_subscriber_does_not_block_others() -> None:
+    """If apply_async raises for one subscriber, the dispatcher
+    logs and proceeds to the next subscriber."""
+    from fides.api.tasks import celery_app
+
+    call_log: list = []
+    # Capture both task objects up-front so we can wire a flaky wrapper.
+    subs = sorted(
+        [
+            celery_app.tasks[name]
+            for name in celery_app.tasks
+            if "_DispatchEvent" in name
+        ],
+        key=lambda t: t.name,
+    )
+    assert len(subs) == 2, f"Expected 2 _DispatchEvent subscribers, got {len(subs)}"
+
+    real_first_apply = subs[0].apply_async
+
+    def flaky_first_apply(*args, **kwargs):
+        call_log.append(subs[0].name)
+        raise RuntimeError("simulated broker failure")
+
+    real_second_apply = subs[1].apply_async
+
+    def tracking_second_apply(*args, **kwargs):
+        call_log.append(subs[1].name)
+        return real_second_apply(*args, **kwargs)
+
+    with (
+        patch.object(subs[0], "apply_async", side_effect=flaky_first_apply),
+        patch.object(subs[1], "apply_async", side_effect=tracking_second_apply),
+    ):
+        dispatch("event-id-1", _DispatchEvent(label="resilience"))
+
+    # Both subscribers were attempted; one failed (raised), one succeeded.
+    assert len(call_log) == 2
+    # The successful one ran its handler.
+    successful_capture = _FIRST if _SECOND == [] else _SECOND
+    assert len(successful_capture) == 1

--- a/tests/common/events/test_ping.py
+++ b/tests/common/events/test_ping.py
@@ -1,0 +1,116 @@
+"""End-to-end validation of the event framework via the ping fixtures.
+
+Each test corresponds to a specific framework guarantee. Together they
+demonstrate the full lifecycle: publish → commit → dispatch → handle,
+and the rollback / kill-switch / event_id-propagation paths.
+"""
+
+import pytest
+
+from fides.common.events import assert_event_published
+from fides.config import CONFIG
+
+from . import _ping
+
+
+def test_publish_then_commit_dispatches_subscriber(session, ping_received):
+    """Happy path: publish + commit → subscriber runs synchronously
+    (under task_always_eager) and receives the event instance."""
+    _ping.PingRepository(session).emit("hello")
+    session.commit()
+
+    assert len(ping_received) == 1
+    event, _event_id = ping_received[0]
+    assert event == _ping.PingEvent(payload="hello")
+
+
+def test_publish_then_rollback_does_not_dispatch(session, ping_received):
+    """Rollback safety: events queued on a rolled-back session never fire."""
+    _ping.PingRepository(session).emit("hello")
+    session.rollback()
+
+    assert ping_received == []
+
+
+def test_multiple_publishes_in_one_transaction_dispatch_in_order(
+    session, ping_received
+):
+    """Ordering: events dispatch in publish order on the same session."""
+    repo = _ping.PingRepository(session)
+    repo.emit("first")
+    repo.emit("second")
+    repo.emit("third")
+    session.commit()
+
+    assert [event.payload for event, _ in ping_received] == [
+        "first",
+        "second",
+        "third",
+    ]
+
+
+def test_assert_event_published_helper_inspects_pre_commit(session, ping_received):
+    """The assert_event_published helper inspects pending events
+    pre-commit so subscriber assertions don't need to wait for dispatch."""
+    _ping.PingRepository(session).emit("hello")
+
+    [event] = assert_event_published(session, _ping.PingEvent)
+    assert event.payload == "hello"
+    # Subscriber has not yet run — we haven't committed.
+    assert ping_received == []
+
+
+def test_kill_switch_disables_dispatch(session, ping_received, monkeypatch):
+    """CONFIG.events.enabled = False stops dispatch on commit."""
+    monkeypatch.setattr(CONFIG.events, "enabled", False)
+
+    _ping.PingRepository(session).emit("hello")
+    session.commit()
+
+    assert ping_received == []
+
+
+def test_publishes_marker_recorded_for_emit_method():
+    """The @publishes marker on PingRepository.emit is captured for
+    test-time introspection."""
+    from fides.common.events.registry import get_publishes_markers
+
+    markers = get_publishes_markers()
+    assert _ping.PingRepository.emit in markers
+    assert _ping.PingEvent in markers[_ping.PingRepository.emit]
+
+
+def test_event_id_returned_from_publish_is_observed_by_subscriber(
+    session, ping_received
+):
+    """The event_id generated at publish time is the same one the
+    subscriber sees via get_current_event_id() during handling."""
+    published_event_id = _ping.PingRepository(session).emit("hello")
+    session.commit()
+
+    assert len(ping_received) == 1
+    _event, observed_event_id = ping_received[0]
+    # In eager mode with task_prerun firing, the subscriber should see the
+    # same event_id that publish_after_commit returned.
+    assert observed_event_id == published_event_id
+
+
+def test_publishing_with_no_subscriber_logs_warning_but_does_not_raise(
+    session, ping_received
+):
+    """An event class with no registered subscribers logs a warning at
+    dispatch time but does not raise. Establishes the framework's
+    permissive runtime stance — typo-checking lives in coverage tests."""
+    from dataclasses import dataclass
+
+    from fides.common.events import publish_after_commit
+
+    @dataclass(frozen=True)
+    class OrphanEvent:
+        value: str
+
+    publish_after_commit(session, OrphanEvent(value="lonely"))
+    session.commit()
+
+    # Subscriber for PingEvent did not fire — different event type.
+    assert ping_received == []

--- a/tests/common/events/test_publisher.py
+++ b/tests/common/events/test_publisher.py
@@ -1,0 +1,121 @@
+"""Unit tests for publish_after_commit + session lifecycle behavior."""
+
+from dataclasses import dataclass
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from fides.common.events import (
+    assert_event_published,
+    clear_pending_events,
+    publish_after_commit,
+    published_events,
+    subscribes_to,
+)
+
+
+@dataclass(frozen=True)
+class _PubEvent:
+    n: int
+
+
+_RECEIVED: list = []
+
+
+@subscribes_to(_PubEvent)
+def _handler(event: _PubEvent) -> None:
+    _RECEIVED.append(event)
+
+
+@pytest.fixture(autouse=True)
+def _reset_received():
+    _RECEIVED.clear()
+    yield
+    _RECEIVED.clear()
+
+
+def _new_session():
+    engine = create_engine("sqlite:///:memory:")
+    return sessionmaker(bind=engine)()
+
+
+def test_publish_after_commit_returns_event_id(session) -> None:
+    event_id = publish_after_commit(session, _PubEvent(n=1))
+    assert isinstance(event_id, str) and len(event_id) > 0
+
+
+def test_publish_after_commit_does_not_dispatch_until_commit(session) -> None:
+    publish_after_commit(session, _PubEvent(n=1))
+    assert _RECEIVED == []
+    session.commit()
+    assert len(_RECEIVED) == 1
+
+
+def test_two_sessions_are_isolated() -> None:
+    """An event published on session A does not fire when session B commits."""
+    a = _new_session()
+    b = _new_session()
+    try:
+        publish_after_commit(a, _PubEvent(n=1))
+        b.commit()
+        assert _RECEIVED == []
+        a.commit()
+        assert len(_RECEIVED) == 1
+    finally:
+        a.close()
+        b.close()
+
+
+def test_published_events_helper_returns_queued(session) -> None:
+    publish_after_commit(session, _PubEvent(n=1))
+    publish_after_commit(session, _PubEvent(n=2))
+
+    queued = published_events(session)
+    assert [e.n for e in queued if isinstance(e, _PubEvent)] == [1, 2]
+
+
+def test_assert_event_published_count_constraint(session) -> None:
+    publish_after_commit(session, _PubEvent(n=1))
+    publish_after_commit(session, _PubEvent(n=2))
+
+    matches = assert_event_published(session, _PubEvent, count=2)
+    assert [e.n for e in matches] == [1, 2]
+
+
+def test_assert_event_published_count_mismatch_fails(session) -> None:
+    publish_after_commit(session, _PubEvent(n=1))
+
+    with pytest.raises(AssertionError):
+        assert_event_published(session, _PubEvent, count=2)
+
+
+def test_clear_pending_events_drops_queued_without_dispatching(session) -> None:
+    publish_after_commit(session, _PubEvent(n=1))
+    clear_pending_events(session)
+    session.commit()
+
+    assert _RECEIVED == []
+
+
+def test_callbacks_installed_only_once_per_session(session) -> None:
+    """Multiple publishes on the same session don't double-fire on commit."""
+    publish_after_commit(session, _PubEvent(n=1))
+    publish_after_commit(session, _PubEvent(n=2))
+    publish_after_commit(session, _PubEvent(n=3))
+
+    session.commit()
+
+    assert [e.n for e in _RECEIVED] == [1, 2, 3]
+
+
+def test_post_commit_pending_events_are_drained(session) -> None:
+    """After commit, the pending list is empty so a subsequent publish
+    on the same session works correctly."""
+    publish_after_commit(session, _PubEvent(n=1))
+    session.commit()
+    assert len(_RECEIVED) == 1
+
+    publish_after_commit(session, _PubEvent(n=2))
+    session.commit()
+    assert [e.n for e in _RECEIVED] == [1, 2]


### PR DESCRIPTION
**Proposal for design review.** Primary goal is to gather feedback on the **design doc** and align on the framework's shape before any production code consumes it. The plumbing implementation is included so reviewers can see the design landed end-to-end, but it is gated behind a kill-switch (`CONFIG.events.enabled`) and ships with no production publishers or subscribers wired in.

Ticket: related to https://ethyca.atlassian.net/browse/ENG-3325 and https://ethyca.atlassian.net/browse/ENG-3510

### What to review (in priority order)

1. **`docs/fides/docs/event-framework/01-design.md`** — the framework's design, prescriptive when-to-use boundary, transport choice rationale (Celery + existing Redis broker; alternatives explicitly considered and rejected), failure modes, and open questions. **This is the most important file in the PR.**
2. **`docs/fides/docs/event-framework/02-implementation-plan.md`** — phased rollout plan. Phase 1 is this PR; Phases 2 and 3 are the first two consumers (monitor stewardship inheritance + monitor stats refresh).
3. **`docs/fides/docs/event-framework/03-phase-1-plumbing.md`** — concrete checklist for the framework PR: package layout, per-component acceptance bars, the canonical end-to-end ping validation, coverage check pattern.
4. **`docs/fides/docs/event-framework/04-stewardship-implementation-plan.md`** — self-contained plan for the first feature consumer (monitor stewardship inheritance), designed so another agent can pick it up on a fresh branch once dependencies land.
5. **The plumbing code** — `src/fides/common/events/` and the test suite. Implementation reflects the design but the design is the artifact under review.

### Description Of Changes

A new **in-application event framework** for asynchronous reactive work. Publishers emit typed events when application state changes; the framework dispatches registered handlers via Celery to recompute / propagate / refresh derived state. Goals:

- Decouple publishers from consumers via a registry, so adding a new subscriber doesn't require modifying every action site.
- Standardize observability, retry, and reconciliation patterns across features.
- Establish prescriptive boundaries (when to use, when not) so the framework doesn't get misused.

**Key design decisions** (covered in detail in §1–5 of the design doc):

- **Transport**: Celery, with the existing Redis broker. No new infrastructure.
- **Programming model**: typed events as frozen dataclasses + `@subscribes_to` decorator-registered handlers + autodiscovery. Two-line API for subscribers.
- **Operational home (default)**: `fides` Celery queue, picked up by the existing "Other" worker. Per-handler queue override available.
- **Delivery semantics**: at-least-once, **not guaranteed** — explicit non-goal. Subscribers must be idempotent against current DB state. Where correctness matters, an independent reconciler is required.
- **Where the bones live**: fides OSS. fidesplus subscribes from across the boundary.

**Non-goals (the prescriptive part — see §2.1):**

- Does not guarantee delivery.
- Does not provide ordering guarantees.
- Does not detect missed publishes.
- Is not a replacement for synchronous calls.
- Is not pub/sub on the wire.

### Code Changes

- New package `src/fides/common/events/` (10 files, ~700 lines):
  - `base.py` — frozen-dataclass + JSON-primitive validation; rejects UUID/datetime/Enum at decoration time.
  - `registry.py` — in-process registry of subscribers + `@publishes` markers.
  - `decorators.py` — `@subscribes_to(EventType, queue="fides")` and `@publishes(*EventType)`.
  - `publisher.py` — `publish_after_commit(session, event)` with after-commit / after-rollback session hooks.
  - `dispatcher.py` — fan-out via `task.apply_async`; works in eager mode + production; per-subscriber failure isolation; kill-switch via `CONFIG.events.enabled`.
  - `celery_integration.py` — task wrapper factory; `event_id` passed as explicit task kwarg (not headers, so it works in eager mode + production identically).
  - `context.py` — ContextVar exposing `get_current_event_id()` to subscribers.
  - `autodiscover.py` — `register_subscriber_module` + `import_subscriber_modules` for cross-repo registration.
  - `testing.py` — `published_events`, `assert_event_published`, `clear_pending_events`.
  - `__init__.py` — public API.
- New config section: `src/fides/config/event_settings.py` (`EventSettings.enabled: bool = True`), wired into `FidesConfig`.
- Edits to `src/fides/api/tasks/__init__.py` (+14 lines): import `celery_integration`; after `celery_app` is created, call `import_subscriber_modules()` so subscribers register at boot.
- Tests under `tests/common/events/` (11 files, ~800 lines):
  - `_ping.py` — canonical reference fixture (event + subscriber + repository) demonstrating the recommended publish-from-repository pattern.
  - `test_ping.py` — 8 end-to-end tests: commit, rollback, ordering, kill-switch, marker recording, event_id flow-through, no-subscriber path.
  - Per-module unit tests for validation, registry, decorators, publisher, dispatcher.
  - `test_coverage_checks.py` — hard-fail check that every production subscriber's event type has an in-tree `@publishes` marker, with a documented exclude-list pattern.
- Four design docs under `docs/fides/docs/event-framework/`.

42 tests passing. No production publishers or subscribers consume the framework yet — that's intentional.

### Steps to Confirm

The framework's correctness is demonstrated entirely via the test suite — no production code path consumes it yet, so there's nothing to manually click through.

1. Run the test suite:
   ```sh
   pytest tests/common/events/ -v
   ```
   Expected: 42 passing.
2. Verify the kill switch works: `CONFIG.events.enabled = False` should make `publish_after_commit` queue events on the session but skip dispatch on commit. Covered by `test_ping.py::test_kill_switch_disables_dispatch`.
3. Verify rollback safety: events queued on a rolled-back session should never fire. Covered by `test_ping.py::test_publish_then_rollback_does_not_dispatch`.
4. Read the design doc and tell us where it's wrong, vague, or missing constraints we'd regret leaving out.

### Pre-Merge Checklist

* [ ] Design doc reviewed and approved by the team
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a `db-migration` label to the entry if your change includes a DB migration — N/A, no migrations
  * [ ] Add a `high-risk` label to the entry if your change includes a high-risk change — N/A, gated behind kill-switch, no production callers
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [x] No UX review needed (no UI changes)
* Followup issues:
  * [ ] Followup issues created (Phase 2 stewardship + Phase 3 stats; ticket creation deferred until design lands)
  * [ ] No followup issues
* Database migrations:
  * [x] No migrations
* Documentation:
  * [x] Design doc + implementation plan + Phase 1 plumbing checklist + stewardship implementation plan all included in PR
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [x] No new client scopes
  * [ ] No documentation updates required

### Open Questions for Reviewers

These are surfaced explicitly in `01-design.md` §10 — please weigh in:

1. `@publishes` marker enforcement strictness: required (CI-enforced) or recommended? Currently recommended; v1 leans soft.
2. Reconciler cadence for stewardship inheritance: starting at 15 minutes — too tight, too loose, or right?
3. Stats event granularity: single `MonitorOperationCompleted(monitor_config_key, operation_type)` or one event class per operation? Leaning the simpler model.
4. Event package layout: `fides.api.events.<domain>` for fides-emitted; `fidesplus.api.events.<domain>` for fidesplus-emitted. Confirm before Phase 2.
5. `event_id` provenance: generated at publish time, shared across subscribers for the same publish. Confirmed in design — flag if a different model is preferred.

Generated with [Claude Code](https://claude.com/claude-code)
