### PR TITLE
ENG-3666 Parallelize warm_async_pool connections with asyncio.gather

### DIFF
--- a/changelog/8097-parallelize-pool-warmup.yaml
+++ b/changelog/8097-parallelize-pool-warmup.yaml
@@ -1,0 +1,4 @@
+type: Changed
+description: Parallelized async pool warm-up to reduce startup time for large pools
+pr: 8097
+labels: []

--- a/src/fides/api/db/ctl_session.py
+++ b/src/fides/api/db/ctl_session.py
@@ -1,6 +1,5 @@
-import asyncio
 import ssl
-from asyncio import Lock
+from asyncio import Lock, gather
 from contextlib import _AsyncGeneratorContextManager, asynccontextmanager
 from typing import Any, AsyncGenerator, Callable, Dict
 
@@ -171,7 +170,7 @@ async def warm_async_pool(pool_id: str, pool_size: int, engine: AsyncEngine) -> 
     connections = []
     try:
         # Open all connections concurrently to avoid paying N * RTT sequentially
-        results = await asyncio.gather(
+        results = await gather(
             *(engine.connect() for _ in range(pool_size)),
             return_exceptions=True,
         )
@@ -185,11 +184,9 @@ async def warm_async_pool(pool_id: str, pool_size: int, engine: AsyncEngine) -> 
         logger.info(
             f"Pool {pool_id} warmed up with {len(connections)}/{pool_size} connections. Releasing connections..."
         )
-    except Exception as e:
-        logger.error(f"An error occurred during warming of {pool_id}: {e}")
     finally:
         # Release all connections back to the pool
-        await asyncio.gather(*(conn.close() for conn in connections))
+        await gather(*(conn.close() for conn in connections))
         logger.info(f"Connections released back to the pool for {pool_id}.")
 
 

--- a/src/fides/api/db/ctl_session.py
+++ b/src/fides/api/db/ctl_session.py
@@ -1,3 +1,4 @@
+import asyncio
 import ssl
 from asyncio import Lock
 from contextlib import _AsyncGeneratorContextManager, asynccontextmanager
@@ -169,18 +170,26 @@ async def warm_async_pool(pool_id: str, pool_size: int, engine: AsyncEngine) -> 
     logger.info(f"Warming up {pool_id} connection pool with {pool_size} connections...")
     connections = []
     try:
-        # Check out connections
-        for _ in range(pool_size):
-            # This is actually async, even though the type checker may not think so
-            conn = await engine.connect()
-            connections.append(conn)
-        logger.info(f"Pool {pool_id} warmed up. Releasing connections...")
+        # Open all connections concurrently to avoid paying N * RTT sequentially
+        results = await asyncio.gather(
+            *(engine.connect() for _ in range(pool_size)),
+            return_exceptions=True,
+        )
+        for result in results:
+            if isinstance(result, BaseException):
+                logger.error(
+                    f"A connection failed during warming of {pool_id}: {result}"
+                )
+            else:
+                connections.append(result)
+        logger.info(
+            f"Pool {pool_id} warmed up with {len(connections)}/{pool_size} connections. Releasing connections..."
+        )
     except Exception as e:
         logger.error(f"An error occurred during warming of {pool_id}: {e}")
     finally:
         # Release all connections back to the pool
-        for conn in connections:
-            await conn.close()
+        await asyncio.gather(*(conn.close() for conn in connections))
         logger.info(f"Connections released back to the pool for {pool_id}.")
 
 

--- a/tests/lib/test_ctl_session.py
+++ b/tests/lib/test_ctl_session.py
@@ -1,0 +1,58 @@
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from fides.api.db.ctl_session import warm_async_pool
+from fides.config import CONFIG
+
+
+class TestWarmAsyncPool:
+    async def test_opens_and_closes_all_connections(self) -> None:
+        """All connections are opened concurrently and then closed."""
+        pool_size = 5
+        mock_conns = [AsyncMock() for _ in range(pool_size)]
+        engine = AsyncMock()
+        engine.connect = AsyncMock(side_effect=mock_conns)
+
+        await warm_async_pool("test-pool", pool_size, engine)
+
+        assert engine.connect.call_count == pool_size
+        for conn in mock_conns:
+            conn.close.assert_awaited_once()
+
+    async def test_partial_failure_closes_successful_connections(self) -> None:
+        """If some connections fail, the successful ones are still closed."""
+        good_conn_1 = AsyncMock()
+        good_conn_2 = AsyncMock()
+        engine = AsyncMock()
+        engine.connect = AsyncMock(
+            side_effect=[good_conn_1, ConnectionError("refused"), good_conn_2]
+        )
+
+        await warm_async_pool("test-pool", 3, engine)
+
+        assert engine.connect.call_count == 3
+        good_conn_1.close.assert_awaited_once()
+        good_conn_2.close.assert_awaited_once()
+
+    async def test_all_connections_fail(self) -> None:
+        """If every connection fails, no close calls are made and no exception propagates."""
+        engine = AsyncMock()
+        engine.connect = AsyncMock(side_effect=ConnectionError("refused"))
+
+        await warm_async_pool("test-pool", 3, engine)
+
+        assert engine.connect.call_count == 3
+
+    async def test_warms_real_engine(self) -> None:
+        """Warming a real async engine fills the connection pool."""
+        pool_size = 3
+        engine = create_async_engine(
+            CONFIG.database.async_database_uri, pool_size=pool_size, max_overflow=0
+        )
+        try:
+            await warm_async_pool("test-pool", pool_size, engine)
+            assert engine.pool.checkedin() == pool_size
+        finally:
+            await engine.dispose()

--- a/tests/lib/test_ctl_session.py
+++ b/tests/lib/test_ctl_session.py
@@ -1,6 +1,5 @@
 from unittest.mock import AsyncMock
 
-import pytest
 from sqlalchemy.ext.asyncio import create_async_engine
 
 from fides.api.db.ctl_session import warm_async_pool


### PR DESCRIPTION
Ticket [ENG-3666]

### Description Of Changes

Parallelizes the `warm_async_pool` function to open all database connections concurrently using `asyncio.gather` instead of sequentially. This reduces pool warm-up time from `N * RTT` to ~1 RTT, which significantly improves startup time for deployments with large pool sizes and/or high-latency database connections.

Partial connection failures are handled gracefully via `return_exceptions=True` — successful connections are still tracked and cleaned up properly.

### Code Changes

* `src/fides/api/db/ctl_session.py`: Replace sequential `for` loop with `asyncio.gather` for concurrent connection opening; also parallelize `close()` calls in the `finally` block
* `tests/lib/test_ctl_session.py`: New test file with unit tests (mocked engine) and an integration test (real async engine against Postgres)

### Steps to Confirm

1. Run `tests/lib/test_ctl_session.py` — all 4 tests should pass
2. Verify pool warm-up logs show `N/N connections` on startup with a readonly pool configured

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [x] No UX review needed
* Followup issues:
  * [x] No followup issues
* Database migrations:
  * [x] No migrations
* Documentation:
  * [x] No documentation updates required

[ENG-3666]: https://ethyca.atlassian.net/browse/ENG-3666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ