### PR TITLE
Make database healthcheck timeout configurable

### DIFF
--- a/changelog/8100-configurable-healthcheck-timeout.yaml
+++ b/changelog/8100-configurable-healthcheck-timeout.yaml
@@ -1,0 +1,4 @@
+type: Added
+description: Added configurable timeout for database healthcheck queries
+pr: 8100
+labels: []

--- a/src/fides/api/v1/endpoints/health.py
+++ b/src/fides/api/v1/endpoints/health.py
@@ -33,13 +33,16 @@ PoolHealth = Literal["healthy", "unhealthy", "skipped"]
 DatabaseResponseHealth = Literal["healthy", "unhealthy", "needs migration"]
 HEALTH_ROUTER = APIRouter(tags=["Health"])
 
+
 # Per-pool ping: cap how long the health endpoint can block on each async check, and bound
 # statement runtime on PostgreSQL (SET LOCAL is a no-op on other dialects we skip).
-DATABASE_HEALTHCHECK_QUERY_TIMEOUT_SECONDS = 1.0
+def _healthcheck_timeout_seconds() -> float:
+    """Configurable timeout for healthcheck queries (default 1.0s)."""
+    return CONFIG.database.healthcheck_query_timeout
 
 
 def _healthcheck_statement_timeout_ms() -> int:
-    return max(1, int(DATABASE_HEALTHCHECK_QUERY_TIMEOUT_SECONDS * 1000))
+    return max(1, int(_healthcheck_timeout_seconds() * 1000))
 
 
 def _bind_dialect_name(bind: Any) -> str:
@@ -249,13 +252,13 @@ async def _check_async_session(
     try:
         await asyncio.wait_for(
             _ping_with_session(),
-            timeout=DATABASE_HEALTHCHECK_QUERY_TIMEOUT_SECONDS,
+            timeout=_healthcheck_timeout_seconds(),
         )
         return "healthy"
     except asyncio.TimeoutError:
         logger.error(
             "Async database healthcheck timed out after {}s",
-            DATABASE_HEALTHCHECK_QUERY_TIMEOUT_SECONDS,
+            _healthcheck_timeout_seconds(),
         )
         return "unhealthy"
     except Exception as error:  # pylint: disable=broad-except

--- a/src/fides/config/database_settings.py
+++ b/src/fides/config/database_settings.py
@@ -144,6 +144,8 @@ class DatabaseSettings(FidesSettings):
     )
     healthcheck_query_timeout: float = Field(
         default=1.0,
+        ge=0.1,
+        le=10.0,
         description="Timeout in seconds for database healthcheck queries on the /health/database endpoint.",
     )
     test_db: str = Field(

--- a/src/fides/config/database_settings.py
+++ b/src/fides/config/database_settings.py
@@ -142,6 +142,10 @@ class DatabaseSettings(FidesSettings):
         default=True,
         description="If true, the engine will pre-ping connections to ensure they are still valid before using them.",
     )
+    healthcheck_query_timeout: float = Field(
+        default=1.0,
+        description="Timeout in seconds for database healthcheck queries on the /health/database endpoint.",
+    )
     test_db: str = Field(
         default="default_test_db",
         description="Used instead of the 'db' value when the FIDES_TEST_MODE environment variable is set to True. Avoids overwriting production data.",

--- a/tests/api/v1/endpoints/test_database_health_unit.py
+++ b/tests/api/v1/endpoints/test_database_health_unit.py
@@ -34,7 +34,7 @@ async def test_check_async_session_times_out(monkeypatch: pytest.MonkeyPatch) ->
         async def __aexit__(self, *_args: object) -> None:
             return None
 
-    monkeypatch.setattr(health, "DATABASE_HEALTHCHECK_QUERY_TIMEOUT_SECONDS", 0.15)
+    monkeypatch.setattr(health.CONFIG.database, "healthcheck_query_timeout", 0.15)
 
     def _factory() -> _SlowCM:
         return _SlowCM()

--- a/tests/ctl/core/test_api.py
+++ b/tests/ctl/core/test_api.py
@@ -3539,6 +3539,7 @@ class TestHealthchecks:
                     async_readonly_database_pool_size=getattr(
                         test_config.database, "async_readonly_database_pool_size", 10
                     ),
+                    healthcheck_query_timeout=1.0,
                 )
             ),
         )


### PR DESCRIPTION
Ticket [ENG-3666]

### Description Of Changes

The `/health/database` endpoint uses a hardcoded 1-second timeout for pool health checks. For deployments with high-latency database connections, this can cause false-negative health checks. This PR makes the timeout configurable via `FIDES__DATABASE__HEALTHCHECK_QUERY_TIMEOUT`.

### Code Changes

* `src/fides/config/database_settings.py`: Added `healthcheck_query_timeout` field (default `1.0`)
* `src/fides/api/v1/endpoints/health.py`: Replaced hardcoded constant with config-backed `_healthcheck_timeout_seconds()`
* `tests/ctl/core/test_api.py`: Added missing config field to `SimpleNamespace` mock

### Steps to Confirm

1. Run `tests/ctl/core/test_api.py::TestHealthchecks` — all 9 tests should pass
2. Set `FIDES__DATABASE__HEALTHCHECK_QUERY_TIMEOUT=5.0` and verify the health endpoint respects the configured timeout

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [x] No UX review needed
* Followup issues:
  * [x] No followup issues
* Database migrations:
  * [x] No migrations
* Documentation:
  * [x] No documentation updates required

[ENG-3666]: https://ethyca.atlassian.net/browse/ENG-3666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ