### PR TITLE
Improve update polling for assessments

### DIFF
--- a/changelog/8102-fix-assessment-list-polling.yaml
+++ b/changelog/8102-fix-assessment-list-polling.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Fixed privacy assessment list to refresh while generation is in progress
+pr: 8102
+labels: []

--- a/clients/admin-ui/src/features/privacy-assessments/AssessmentTaskStatusIndicator.tsx
+++ b/clients/admin-ui/src/features/privacy-assessments/AssessmentTaskStatusIndicator.tsx
@@ -8,6 +8,7 @@ import { AssessmentTaskPopoverContent } from "./AssessmentTaskPopoverContent";
 import {
   useGetAssessmentTasksQuery,
   useGetAssessmentTemplatesQuery,
+  useGetPrivacyAssessmentsQuery,
 } from "./privacy-assessments.slice";
 import { TaskStatus } from "./types";
 
@@ -44,6 +45,17 @@ export const AssessmentTaskStatusIndicator = ({
     { page: 1, size: 10 },
     { pollingInterval: ACTIVE_POLL_INTERVAL, skip: !activeTask },
   );
+
+  // Mirror the task poll on the assessments list while a task is active so
+  // freshly-materialized `generating` rows and per-row status flips appear in
+  // the page list within ~15s, instead of waiting for the first LLM call to
+  // finish (which can be minutes for large prompts). Shares the cache key
+  // with the page's `useGetPrivacyAssessmentsQuery()`, so the page list
+  // re-renders automatically when this polling fills the cache.
+  useGetPrivacyAssessmentsQuery(undefined, {
+    pollingInterval: ACTIVE_POLL_INTERVAL,
+    skip: !activeTask,
+  });
 
   const lastCompletedTask = useMemo(
     () =>
@@ -82,50 +94,11 @@ export const AssessmentTaskStatusIndicator = ({
     );
   }, [templatesData]);
 
-  const completedCount = activeTask?.completed_count ?? 0;
-
-  // A row just flipped from `generating` → `in_progress`; pull fresh list
-  // data so the card updates in place without requiring user interaction.
-  const prevCompletedCountRef = useRef<number | null>(null);
-  useEffect(() => {
-    if (!activeTask) {
-      prevCompletedCountRef.current = null;
-      return;
-    }
-    if (
-      prevCompletedCountRef.current !== null &&
-      completedCount > prevCompletedCountRef.current
-    ) {
-      onTaskFinish?.();
-    }
-    prevCompletedCountRef.current = completedCount;
-  }, [activeTask, completedCount, onTaskFinish]);
-
-  // Active task just appeared: Celery has picked up the task and materialized
-  // the `generating` rows. The mutation's tag invalidation fired before
-  // materialization, so refetch once here to surface those rows. Skip the
-  // very first observation so a page mount with an already-active task
-  // doesn't trigger a redundant refetch on top of the initial query.
-  const prevActiveTaskIdRef = useRef<string | null>(null);
-  const hasObservedActiveTaskRef = useRef(false);
-  useEffect(() => {
-    const currentId = activeTask?.id ?? null;
-    if (
-      hasObservedActiveTaskRef.current &&
-      currentId &&
-      currentId !== prevActiveTaskIdRef.current
-    ) {
-      onTaskFinish?.();
-    }
-    prevActiveTaskIdRef.current = currentId;
-    hasObservedActiveTaskRef.current = true;
-  }, [activeTask, onTaskFinish]);
-
   // Detect active → idle transition for the final completion or error.
-  // The completed-count effect above can't catch the last increment because
-  // `activeTask` flips to null on the same poll that delivers it (the task
-  // status moves to COMPLETE/ERROR and falls out of the active filter), so
-  // refetch once here to surface the final row update.
+  // The list-poll subscription above stops the moment `activeTask` becomes
+  // null, so the very last row flip (committed at the same time the task
+  // moves to COMPLETE) won't be picked up by polling. Fire one explicit
+  // refetch here to surface that final state.
   const hadActiveTaskRef = useRef(false);
   useEffect(() => {
     if (hadActiveTaskRef.current && !activeTask) {


### PR DESCRIPTION
Ticket [ENG-3531]

### Description Of Changes

Follow-up to #8041. With realistic LLM call durations (a few minutes per declaration), the privacy assessments list still didn't update until the first LLM call finished — so users could wait 3+ minutes after clicking "Generate" before any cards appeared, even though the materialized `generating` rows existed in the DB within ~2 seconds of trigger.

The original implementation looked for chang

This PR replaces both refetch triggers with a single polling subscription on the assessments list query, gated on the same `!activeTask` condition as the existing tasks polling. The page's `useGetPrivacyAssessmentsQuery()` shares the RTK cache key, so the list re-renders automatically when the indicator's polling fills the cache. Time-to-first-card drops from ~3 min to ~15s.

### Code Changes

* `clients/admin-ui/src/features/privacy-assessments/AssessmentTaskStatusIndicator.tsx`:
  * Added a `useGetPrivacyAssessmentsQuery(undefined, { pollingInterval: 15s, skip: !activeTask })` subscription that mirrors the existing tasks-polling cadence.
  * Removed the `prevCompletedCountRef` effect (count-delta refetch trigger).
  * Removed the `prevActiveTaskIdRef` / `hasObservedActiveTaskRef` effect (one-shot refetch on task start).
  * Removed the now-unused `completedCount` derivation.
  * Kept the `hadActiveTaskRef` (active → idle) effect with its `onTaskFinish?.()` call: the polling subscription stops the moment `activeTask` becomes null, and the task's transition to `complete` happens in the same Celery commit as the last row's status flip. Without an explicit final refetch, ~50% of runs would leave one card showing stale state. The active → idle effect plugs that hole.
* No changes to `pages/privacy-assessments/index.tsx`. Its `onTaskFinish={refetchAssessments}` wiring is what the active → idle effect calls — kept as-is.

### Steps to Confirm

1. Bring up the local stack: backend (fides + fidesplus) + admin-ui dev server.
2. Trigger generation for a system that produces multiple declarations. Use a slow LLM (or stub `time.sleep(30)` in the LLM path) so each declaration takes well over 15s.
3. **Materialization gap**: within ~15s of clicking "Generate assessments", confirm the `Generating...` cards appear in the list (no manual refresh needed).
4. **Per-row flips**: as each LLM finishes, confirm the corresponding card flips to "Completeness X% / Resume" within ~15s, again without user interaction.
5. **Final state**: when the task finishes, confirm the last card's state is correct (not stuck mid-flip) and the success toast fires.
6. **Failure path**: trigger generation with an invalid LLM model. Confirm the error toast fires and any orphan `generating` rows are cleared (handled by the fidesplus side from #8041).
7. **Idle state**: with no active task, navigate to `/privacy-assessments`. Network tab should show the initial list fetch only — no further polling while idle (`skip: !activeTask` keeps the subscription dormant).
8. **Mid-task page mount**: refresh the page while a task is in flight. Cards should appear on the initial load and continue updating every ~15s until the task finishes.

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [x] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-3531]: https://ethyca.atlassian.net/browse/ENG-3531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ