### PR TITLE
Fix default tag color

### DIFF
--- a/clients/fidesui/src/ant-theme/default-theme.ts
+++ b/clients/fidesui/src/ant-theme/default-theme.ts
@@ -37,6 +37,7 @@ const brandTokens = {
   brandBgWarning: palette.FIDESUI_BG_WARNING,
   brandBgSuccess: palette.FIDESUI_BG_SUCCESS,
   brandBgInfo: palette.FIDESUI_BG_INFO,
+  brandBgDefault: palette.FIDESUI_BG_DEFAULT,
   brandErrorText: palette.FIDESUI_ERROR_TEXT,
   brandSuccessText: palette.FIDESUI_SUCCESS_TEXT,
 };

--- a/clients/fidesui/src/ant-theme/tokens.d.ts
+++ b/clients/fidesui/src/ant-theme/tokens.d.ts
@@ -27,6 +27,7 @@ declare module "antd/es/theme/interface/alias" {
     brandBgWarning: string;
     brandBgSuccess: string;
     brandBgInfo: string;
+    brandBgDefault: string;
     brandErrorText: string;
     brandSuccessText: string;
 


### PR DESCRIPTION
### Description Of Changes
Adds missing default color for tags after the css var changes.

### Code Changes

* <!-- list your code changes -->

### Steps to Confirm

1. Go to Privacy Request > DSR Policies
2. Confirm the policies tag next to the title "consent" "access" "erasure" have a gray background

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [x] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required
