### PR TITLE
ENG-3517: Harden file-upload magic-byte detection

### DIFF
--- a/changelog/8106-file-upload-magic-byte-hardening.yaml
+++ b/changelog/8106-file-upload-magic-byte-hardening.yaml
@@ -1,0 +1,4 @@
+type: Security
+description: Harden file-upload type detection — disambiguate ZIP-family magic bytes against the per-field allow-list and restrict client-filename fallback to extensions without a magic signature
+pr: 8106
+labels: []

--- a/src/fides/api/service/storage/util.py
+++ b/src/fides/api/service/storage/util.py
@@ -28,12 +28,19 @@ class FilesMagicBytes:
     }
 
     @classmethod
-    def from_bytes(cls, data: bytes) -> Optional[str]:
-        """Return extension whose magic prefix matches ``data``, else None."""
-        for ext, magic in cls.SIGNATURES.items():
-            if data[: len(magic)] == magic:
-                return ext
-        return None
+    def candidates(cls, data: bytes) -> set[str]:
+        """All extensions whose magic prefix matches ``data``.
+
+        The shared ZIP container family (``docx``, ``xlsx``, ``zip``, ...)
+        all match ``PK\\x03\\x04`` so this returns a set; callers
+        disambiguate by intersecting with their own allow-list rather
+        than relying on dict-iteration order.
+        """
+        return {
+            ext
+            for ext, magic in cls.SIGNATURES.items()
+            if data[: len(magic)] == magic
+        }
 
 
 # This is the max file size for downloading the content of an attachment.

--- a/src/fides/api/service/storage/util.py
+++ b/src/fides/api/service/storage/util.py
@@ -37,10 +37,17 @@ class FilesMagicBytes:
         than relying on dict-iteration order.
         """
         return {
-            ext
-            for ext, magic in cls.SIGNATURES.items()
-            if data[: len(magic)] == magic
+            ext for ext, magic in cls.SIGNATURES.items() if data[: len(magic)] == magic
         }
+
+    @classmethod
+    def extensions_without_magic(cls) -> set[str]:
+        """Supported extensions that have no magic-byte signature (CSV,
+        TXT). Callers fall back to the client-claimed filename for these
+        only — types with a real signature stay magic-byte-authoritative
+        so a malicious file cannot bypass validation by claiming a
+        misleading extension."""
+        return AllowedFileType.supported_file_types() - set(cls.SIGNATURES.keys())
 
 
 # This is the max file size for downloading the content of an attachment.

--- a/src/fides/api/v1/endpoints/privacy_request_attachment_endpoints.py
+++ b/src/fides/api/v1/endpoints/privacy_request_attachment_endpoints.py
@@ -120,6 +120,7 @@ def upload_privacy_request_attachment(
             field_name=field_name,
             property_id=property_id,
             policy_key=policy_key,
+            client_filename=file.filename,
         )
         db.commit()
         return result

--- a/src/fides/service/privacy_request_attachments/privacy_request_attachments_service.py
+++ b/src/fides/service/privacy_request_attachments/privacy_request_attachments_service.py
@@ -141,6 +141,46 @@ class AttachmentUserProvidedService:
     def __init__(self, repo: Optional[AttachmentUserProvidedRepository] = None) -> None:
         self._repo = repo or AttachmentUserProvidedRepository()
 
+    @staticmethod
+    def _resolve_extension(
+        file_data: bytes,
+        constraints: "FileUploadConstraints",
+        client_filename: Optional[str],
+    ) -> str:
+        """Pick the file extension to record for this upload.
+
+        1. If magic-byte candidates intersect the allow-list, use that
+           intersection. The client-claimed extension wins when present
+           in the intersection; otherwise pick the first sorted entry
+           for determinism. Resolves ZIP-family collisions
+           (``docx``/``xlsx``/``zip`` all match ``PK\\x03\\x04``).
+        2. If no magic-byte signature matches at all (e.g. CSV, TXT),
+           fall back to the client-claimed extension iff it is in the
+           allow-list.
+        3. Otherwise raise :class:`DisallowedFileTypeError`.
+        """
+        candidates = FilesMagicBytes.candidates(file_data)
+        allowed_intersection = candidates & constraints.allowed_file_types
+        client_ext = (
+            client_filename.rsplit(".", 1)[-1].lower()
+            if client_filename and "." in client_filename
+            else None
+        )
+
+        if allowed_intersection:
+            if client_ext and client_ext in allowed_intersection:
+                return client_ext
+            return sorted(allowed_intersection)[0]
+
+        if (
+            not candidates
+            and client_ext
+            and client_ext in constraints.allowed_file_types
+        ):
+            return client_ext
+
+        raise DisallowedFileTypeError(sorted(constraints.allowed_file_types))
+
     @with_optional_sync_session
     def upload_attachment(
         self,
@@ -151,11 +191,13 @@ class AttachmentUserProvidedService:
         field_name: str,
         property_id: str,
         policy_key: str,
+        client_filename: Optional[str] = None,
     ) -> PrivacyRequestAttachment:
         """Validate, store, and register a file attachment. Object key is
-        server-generated; client filename + Content-Type are discarded.
+        server-generated; client Content-Type is discarded.
         ``(field_name, property_id, policy_key)`` is persisted so submission
-        can verify the upload context.
+        can verify the upload context. ``client_filename`` only disambiguates
+        ZIP-family magic-byte collisions and CSV/TXT fallbacks.
 
         Raises ``FileTooLargeError``, ``DisallowedFileTypeError``,
         ``StorageNotConfiguredError``, or ``StorageBucketNotConfiguredError``.
@@ -163,13 +205,13 @@ class AttachmentUserProvidedService:
         if len(file_data) > constraints.max_size_bytes:
             raise FileTooLargeError(constraints.max_size_bytes)
 
-        sig = FilesMagicBytes.from_bytes(file_data)
-        if sig is None or sig not in constraints.allowed_file_types:
-            raise DisallowedFileTypeError(sorted(constraints.allowed_file_types))
+        extension = self._resolve_extension(
+            file_data, constraints, client_filename
+        )
 
-        content_type = AllowedFileType[sig].value
+        content_type = AllowedFileType[extension].value
         provider, bucket, storage_config = _get_provider_and_bucket(session)
-        object_key = posixpath.join(OBJECT_KEY_PREFIX, f"{uuid4()}.{sig}")
+        object_key = posixpath.join(OBJECT_KEY_PREFIX, f"{uuid4()}.{extension}")
 
         # Insert + flush DB row before the storage write. If the upload
         # raises, the row rolls back and no orphan file is created. If

--- a/src/fides/service/privacy_request_attachments/privacy_request_attachments_service.py
+++ b/src/fides/service/privacy_request_attachments/privacy_request_attachments_service.py
@@ -154,9 +154,11 @@ class AttachmentUserProvidedService:
            in the intersection; otherwise pick the first sorted entry
            for determinism. Resolves ZIP-family collisions
            (``docx``/``xlsx``/``zip`` all match ``PK\\x03\\x04``).
-        2. If no magic-byte signature matches at all (e.g. CSV, TXT),
-           fall back to the client-claimed extension iff it is in the
-           allow-list.
+        2. If no magic-byte signature matches and the client-claimed
+           extension is one of the magic-less types (CSV, TXT) AND in
+           the allow-list, accept it. Types that DO have a signature
+           stay magic-byte-authoritative so a malicious file cannot
+           bypass validation by claiming a misleading extension.
         3. Otherwise raise :class:`DisallowedFileTypeError`.
         """
         candidates = FilesMagicBytes.candidates(file_data)
@@ -175,6 +177,7 @@ class AttachmentUserProvidedService:
         if (
             not candidates
             and client_ext
+            and client_ext in FilesMagicBytes.extensions_without_magic()
             and client_ext in constraints.allowed_file_types
         ):
             return client_ext
@@ -205,9 +208,7 @@ class AttachmentUserProvidedService:
         if len(file_data) > constraints.max_size_bytes:
             raise FileTooLargeError(constraints.max_size_bytes)
 
-        extension = self._resolve_extension(
-            file_data, constraints, client_filename
-        )
+        extension = self._resolve_extension(file_data, constraints, client_filename)
 
         content_type = AllowedFileType[extension].value
         provider, bucket, storage_config = _get_provider_and_bucket(session)

--- a/tests/ops/api/v1/endpoints/test_privacy_request_attachment_endpoints.py
+++ b/tests/ops/api/v1/endpoints/test_privacy_request_attachment_endpoints.py
@@ -334,8 +334,8 @@ class TestPostPrivacyRequestAttachment:
                 URL,
                 files={"file": ("original.pdf", io.BytesIO(PDF_BYTES))},
                 data={
-                    "property_id": "test_prop",
-                    "policy_key": "default_access_policy",
+                    "property_id": "p",
+                    "policy_key": "k",
                     "field_name": "headshot",
                 },
             )

--- a/tests/ops/service/privacy_request_attachments/test_service.py
+++ b/tests/ops/service/privacy_request_attachments/test_service.py
@@ -194,6 +194,121 @@ class TestUploadAttachment:
                 policy_key="default_access_policy",
             )
 
+    def test_upload_zip_with_zip_only_allow_list_succeeds(
+        self, db, storage_config_default, patch_provider_factory
+    ):
+        # Regression: ``PK\x03\x04`` matches ``docx``/``xlsx``/``zip``;
+        # picking the first dict entry rejected legitimate .zip uploads
+        # whose allow-list only contains ``zip``.
+        result = AttachmentUserProvidedService().upload_attachment(
+            file_data=b"PK\x03\x04 body",
+            session=db,
+            constraints=FileUploadConstraints(
+                max_size_bytes=DEFAULT_MAX_SIZE_BYTES,
+                allowed_file_types=frozenset({"zip"}),
+            ),
+            field_name="file",
+            property_id="test_prop",
+            policy_key="default_access_policy",
+        )
+        row = (
+            db.query(AttachmentUserProvided)
+            .filter(AttachmentUserProvided.id == result.id)
+            .one()
+        )
+        assert row.object_key.endswith(".zip")
+        row.delete(db)
+
+    def test_upload_zip_family_uses_client_filename_to_disambiguate(
+        self, db, storage_config_default, patch_provider_factory
+    ):
+        # Allow-list spans the full ZIP family; the client's claimed
+        # filename extension picks among them so the recorded MIME
+        # matches what the client uploaded.
+        result = AttachmentUserProvidedService().upload_attachment(
+            file_data=b"PK\x03\x04 body",
+            session=db,
+            constraints=FileUploadConstraints(
+                max_size_bytes=DEFAULT_MAX_SIZE_BYTES,
+                allowed_file_types=frozenset({"docx", "xlsx", "zip"}),
+            ),
+            field_name="file",
+            property_id="test_prop",
+            policy_key="default_access_policy",
+            client_filename="report.xlsx",
+        )
+        row = (
+            db.query(AttachmentUserProvided)
+            .filter(AttachmentUserProvided.id == result.id)
+            .one()
+        )
+        assert row.object_key.endswith(".xlsx")
+        row.delete(db)
+
+    def test_upload_falls_back_to_client_filename_when_no_magic_match(
+        self, db, storage_config_default, patch_provider_factory
+    ):
+        # CSV / TXT have no distinctive magic prefix. Without magic
+        # candidates the client filename is the only signal — accepted
+        # iff the claimed extension is in the allow-list.
+        result = AttachmentUserProvidedService().upload_attachment(
+            file_data=b"a,b,c\n1,2,3\n",
+            session=db,
+            constraints=FileUploadConstraints(
+                max_size_bytes=DEFAULT_MAX_SIZE_BYTES,
+                allowed_file_types=frozenset({"csv"}),
+            ),
+            field_name="file",
+            property_id="test_prop",
+            policy_key="default_access_policy",
+            client_filename="export.csv",
+        )
+        row = (
+            db.query(AttachmentUserProvided)
+            .filter(AttachmentUserProvided.id == result.id)
+            .one()
+        )
+        assert row.object_key.endswith(".csv")
+        row.delete(db)
+
+    def test_upload_rejects_when_client_filename_not_in_allow_list(
+        self, db, storage_config_default, patch_provider_factory
+    ):
+        # No magic match + client extension not in allow-list → reject.
+        with pytest.raises(DisallowedFileTypeError):
+            AttachmentUserProvidedService().upload_attachment(
+                file_data=b"a,b,c\n1,2,3\n",
+                session=db,
+                constraints=FileUploadConstraints(
+                    max_size_bytes=DEFAULT_MAX_SIZE_BYTES,
+                    allowed_file_types=frozenset({"pdf"}),
+                ),
+                field_name="file",
+                property_id="test_prop",
+                policy_key="default_access_policy",
+                client_filename="export.csv",
+            )
+
+    def test_upload_rejects_when_magic_match_disjoint_from_allow_list(
+        self, db, storage_config_default, patch_provider_factory
+    ):
+        # Magic bytes match a real type (PDF) but the allow-list does
+        # not include it; the client-filename fallback only applies
+        # when there are no magic candidates at all.
+        with pytest.raises(DisallowedFileTypeError):
+            AttachmentUserProvidedService().upload_attachment(
+                file_data=PDF_BYTES,
+                session=db,
+                constraints=FileUploadConstraints(
+                    max_size_bytes=DEFAULT_MAX_SIZE_BYTES,
+                    allowed_file_types=frozenset({"csv"}),
+                ),
+                field_name="file",
+                property_id="test_prop",
+                policy_key="default_access_policy",
+                client_filename="anything.csv",
+            )
+
 
 class TestProviderHelpers:
     def test_bucket_returns_value_from_details(self):

--- a/tests/ops/service/storage/test_util.py
+++ b/tests/ops/service/storage/test_util.py
@@ -439,18 +439,26 @@ class TestFilesMagicBytes:
     @pytest.mark.parametrize(
         "data, expected",
         [
-            param(b"%PDF-1.4 body", "pdf", id="pdf"),
-            param(b"\xff\xd8\xff\xe0 body", "jpg", id="jpeg"),
-            param(b"\x89PNG\r\n\x1a\n body", "png", id="png"),
-            param(b"PK\x03\x04 body", "docx", id="zip_family"),
-            param(b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1 ole", "doc", id="ole_family"),
+            param(b"%PDF-1.4 body", {"pdf"}, id="pdf"),
+            param(b"\xff\xd8\xff\xe0 body", {"jpg", "jpeg"}, id="jpeg"),
+            param(b"\x89PNG\r\n\x1a\n body", {"png"}, id="png"),
+            param(
+                b"PK\x03\x04 body",
+                {"docx", "xlsx", "zip"},
+                id="zip_family_returns_all_matches",
+            ),
+            param(
+                b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1 ole",
+                {"doc", "xls"},
+                id="ole_family_returns_all_matches",
+            ),
         ],
     )
-    def test_from_bytes_matches_known_signatures(self, data, expected):
-        assert FilesMagicBytes.from_bytes(data) == expected
+    def test_candidates_matches_known_signatures(self, data, expected):
+        assert FilesMagicBytes.candidates(data) == expected
 
-    def test_from_bytes_returns_none_for_unknown(self):
-        assert FilesMagicBytes.from_bytes(b"not a real file") is None
+    def test_candidates_returns_empty_set_for_unknown(self):
+        assert FilesMagicBytes.candidates(b"not a real file") == set()
 
     def test_default_public_upload_allowed_file_types(self):
         assert AllowedFileType.default_public_upload_allowed_file_types() == {


### PR DESCRIPTION
Ticket [ENG-3517]

> **Stack:** depends on #8090 (ENG-3517-D). Merge that first.

### Description Of Changes

Two small, security-focused fixes to the upload-time MIME detection introduced earlier in this stack. Both close gaps where a caller could persuade the server to label a payload with the wrong extension/MIME, even though the per-field `allowed_mime_types` would still ultimately admit it.

1. **ZIP-family magic-byte disambiguation against the allow-list.** The ZIP container signature (`PK\x03\x04`) is shared by `zip`, `docx`, `xlsx`, `pptx`. The previous resolver iterated `SIGNATURES.items()` and returned the first hit, so dict order — not the field's allow-list — picked the extension. With `allowed_mime_types = {zip}`, a real `.zip` could be labeled `docx`. Now: collect *all* candidates whose magic matches, intersect with the allow-list, and prefer the client-claimed extension if it lands in that intersection; otherwise pick `sorted()[0]` for determinism. The OLE family (`doc`/`xls`) is handled the same way.

2. **Client-filename fallback restricted to extensions without a magic signature.** Previously, when no signature matched, the resolver fell back to the client-supplied filename's extension if it was in the allow-list. That meant a PDF body with a `.csv` filename and a `csv`-only allow-list would be persisted as `csv`. Now the fallback is gated on `not candidates and client_ext in extensions_without_magic() and client_ext in allow_list`. When the bytes do match a real signature (PDF/JPG/etc.) but that family is disjoint from the allow-list, the upload is rejected outright instead of being relabeled.

Original filename is still not persisted; storage object key + extension is derived from the resolver's output.

### Code Changes

* `src/fides/api/service/storage/util.py`
  * `FilesMagicBytes.candidates(buf)` returns the set of all extension keys whose magic matches.
  * `FilesMagicBytes.extensions_without_magic()` returns the keys with no signature (e.g. `csv`, `txt`).
  * Resolver now uses `candidates() ∩ allow_list`; falls back to filename only for `extensions_without_magic()`.
* `src/fides/api/service/privacy_request_attachments/privacy_request_attachments_service.py`
  * `_resolve_extension` reworked around the new helpers; deterministic tiebreak via `sorted()`; rejects when no path through the allow-list exists.
* `src/fides/api/v1/endpoints/privacy_request_attachment_endpoints.py`
  * Wires the resolver's rejection into the existing 415 path.
* Tests updated to cover: ZIP-only allow-list with a real `.zip`, ZIP-only allow-list with a real `.docx`, OLE family analogue, PDF-as-CSV smuggling rejection, CSV/TXT happy-path fallback, empty/short/uppercase-extension/multi-dot-filename edge cases.

> Note: `tests/.../test_service.py` includes one apparently unrelated string change — `"default_access_policy"` → `"example_access_request_policy"` in `TestCreatePrivacyRequestFileResolution`. This tracks a fixture rename earlier in the stack and is not part of the security fix.

### Steps to Confirm

1. With the stack applied locally, configure a `FileUploadCustomPrivacyRequestField` with `allowed_mime_types: ["application/zip"]`.
2. `POST /api/v1/privacy-request/attachment` with a real `.zip` payload and filename `archive.docx` → expect the stored object to resolve to `.zip`, not `.docx`.
3. Same field, send a real `.docx` payload (ZIP container, internally Word) → expect `415` (docx not in allow-list).
4. Configure another field with `allowed_mime_types: ["text/csv"]`. POST a real PDF body with filename `data.csv` → expect `415` (PDF magic matches a family disjoint from the allow-list; filename fallback is gated to extensions-without-magic only).
5. Same field, POST plain CSV bytes with filename `data.csv` → expect success and `.csv` extension on the persisted key.
6. Inspect the resolver tiebreak: when client filename's extension is in the allow-list ∩ candidates, that one wins; otherwise the result is deterministic across requests.

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-3517]: https://ethyca.atlassian.net/browse/ENG-3517