### PR TITLE
ENG-3518: Orphan-sweep cleanup for stale uploaded attachments

### DIFF
--- a/changelog/8107-attachment-orphan-sweep.yaml
+++ b/changelog/8107-attachment-orphan-sweep.yaml
@@ -1,0 +1,4 @@
+type: Added
+description: Periodic orphan-sweep task that deletes stale uploaded AttachmentUserProvided rows and their temp storage objects an hour after upload if the row was never claimed by a privacy-request submission
+pr: 8107
+labels: []

--- a/src/fides/api/main.py
+++ b/src/fides/api/main.py
@@ -63,6 +63,9 @@ from fides.api.util.rate_limit import safe_rate_limit_key
 from fides.cli.utils import FIDES_ASCII_ART
 from fides.config import CONFIG, check_required_webserver_config_values
 from fides.service.jira.polling_task import initiate_jira_ticket_polling
+from fides.service.privacy_request_attachments.privacy_request_attachments_service import (
+    initiate_scheduled_attachment_cleanup,
+)
 
 NEXT_JS_CATCH_ALL_SEGMENTS_RE = r"^\[{1,2}\.\.\.\w+\]{1,2}"  # https://nextjs.org/docs/pages/building-your-application/routing/dynamic-routes#catch-all-segments
 # Turbopack (Next.js 16+) chunk filenames can embed ".." anywhere, e.g.
@@ -104,6 +107,7 @@ async def lifespan(wrapped_app: FastAPI) -> AsyncGenerator[None, None]:
     initiate_scheduled_batch_email_send()
     initiate_poll_for_exited_privacy_request_tasks()
     initiate_scheduled_dsr_data_removal()
+    initiate_scheduled_attachment_cleanup()
     initiate_interrupted_task_requeue_poll()
     initiate_polling_task_requeue()
     initiate_jira_ticket_polling()

--- a/src/fides/service/privacy_request_attachments/privacy_request_attachments_repository.py
+++ b/src/fides/service/privacy_request_attachments/privacy_request_attachments_repository.py
@@ -93,3 +93,38 @@ class AttachmentUserProvidedRepository:
             raise InvalidAttachmentStateError(row.object_key, row.status)
         row.status = AttachmentUserProvidedStatus.promoted
         row.promoted_at = promoted_at or datetime.now(timezone.utc)
+
+    @with_optional_sync_session
+    def list_uploaded_older_than(
+        self,
+        cutoff: datetime,
+        *,
+        session: Session,
+    ) -> list[AttachmentUserProvided]:
+        """Return ``uploaded`` rows whose ``created_at`` is strictly before
+        ``cutoff``. Used by the orphan-sweep task to find rows whose temp
+        storage object was never claimed by a privacy-request submission."""
+        return (
+            session.query(AttachmentUserProvided)
+            .filter(
+                AttachmentUserProvided.status == AttachmentUserProvidedStatus.uploaded
+            )
+            .filter(AttachmentUserProvided.created_at < cutoff)
+            .all()
+        )
+
+    @with_optional_sync_session
+    def mark_deleted(
+        self,
+        row: AttachmentUserProvided,
+        *,
+        session: Session,  # pylint: disable=unused-argument
+    ) -> None:
+        """Flip a single row from ``uploaded`` to ``deleted`` (orphan sweep).
+
+        Raises :class:`InvalidAttachmentStateError` if the row is not in
+        ``uploaded`` so a concurrent promotion is never overwritten.
+        """
+        if row.status != AttachmentUserProvidedStatus.uploaded:
+            raise InvalidAttachmentStateError(row.object_key, row.status)
+        row.status = AttachmentUserProvidedStatus.deleted

--- a/src/fides/service/privacy_request_attachments/privacy_request_attachments_service.py
+++ b/src/fides/service/privacy_request_attachments/privacy_request_attachments_service.py
@@ -2,6 +2,7 @@
 
 import os
 import posixpath
+from datetime import datetime, timedelta, timezone
 from io import BytesIO
 from typing import Any, Optional
 from uuid import uuid4
@@ -37,6 +38,8 @@ from fides.api.service.storage.util import (
     FilesMagicBytes,
     FileUploadConstraints,
 )
+from fides.api.tasks import DatabaseTask, celery_app
+from fides.api.tasks.scheduled.scheduler import scheduler
 from fides.common.session_management import with_optional_sync_session
 from fides.config import CONFIG
 from fides.service.attachment_service import AttachmentService
@@ -57,6 +60,10 @@ DEFAULT_MAX_SIZE_BYTES = DEFAULT_FILE_MAX_SIZE_BYTES
 UPLOAD_READ_CHUNK_BYTES = 64 * 1024
 
 OBJECT_KEY_PREFIX = "privacy_request_attachments"
+
+ORPHAN_MIN_AGE_SECONDS = 3600  # uploaded rows younger than this are skipped
+ORPHAN_CLEANUP_INTERVAL_HOURS = 1
+ORPHAN_CLEANUP_JOB_ID = "attachment_user_provided_orphan_cleanup"
 
 
 def _bucket(storage_config: StorageConfig) -> str:
@@ -399,3 +406,101 @@ class AttachmentUserProvidedService:
                     row.object_key,
                     exc_info=True,
                 )
+
+
+def _cleanup_orphaned_attachments(db: Session) -> None:
+    """Sweep ``uploaded`` rows older than ``ORPHAN_MIN_AGE_SECONDS``.
+
+    For each row: delete the temp storage object, then CAS the row from
+    ``uploaded`` to ``deleted``. The ``InvalidAttachmentStateError`` raised
+    by :meth:`AttachmentUserProvidedRepository.mark_deleted` if the row has
+    already been promoted by a concurrent submission is logged and skipped
+    so the sweep is idempotent. The storage delete runs first because the
+    row in ``uploaded`` is the index that lets us find the object again on
+    the next sweep — leaving a row in ``deleted`` with the object still
+    present would orphan the bytes.
+
+    Inner function (no Celery context) so tests can drive it directly.
+    """
+    try:
+        provider, bucket, _ = _get_provider_and_bucket(db)
+    except (StorageNotConfiguredError, StorageBucketNotConfiguredError) as exc:
+        logger.info("Skipping attachment orphan cleanup: {}", exc)
+        return
+
+    cutoff = datetime.now(timezone.utc) - timedelta(seconds=ORPHAN_MIN_AGE_SECONDS)
+    repo = AttachmentUserProvidedRepository()
+    orphans = repo.list_uploaded_older_than(cutoff, session=db)
+
+    deleted = 0
+    skipped = 0
+    for row in orphans:
+        try:
+            provider.delete(bucket, row.object_key)
+        except Exception:
+            logger.warning(
+                "Failed to delete orphan storage object {}",
+                row.object_key,
+                exc_info=True,
+            )
+            skipped += 1
+            continue
+        try:
+            repo.mark_deleted(row, session=db)
+        except Exception:
+            # Storage object is already gone but the row could not be
+            # transitioned (concurrent promotion or unexpected state).
+            # Log and continue so one bad row does not abort the batch.
+            logger.warning(
+                "Failed to mark orphan row {} as deleted",
+                row.id,
+                exc_info=True,
+            )
+            skipped += 1
+            continue
+        deleted += 1
+
+    db.commit()
+    logger.info(
+        "Attachment orphan cleanup complete: deleted={} skipped={} cutoff={}",
+        deleted,
+        skipped,
+        cutoff.isoformat(),
+    )
+
+
+@celery_app.task(base=DatabaseTask, bind=True, ignore_result=True)
+def cleanup_orphaned_attachments(self: DatabaseTask) -> None:
+    """Celery wrapper that opens a fresh session and delegates to the
+    inner :func:`_cleanup_orphaned_attachments`. Scheduled via
+    :func:`initiate_scheduled_attachment_cleanup`."""
+    with self.get_new_session() as db:
+        _cleanup_orphaned_attachments(db)
+
+
+def initiate_scheduled_attachment_cleanup() -> None:
+    """Register the orphan-sweep task on the APScheduler.
+
+    Called from the FastAPI lifespan alongside the other periodic-task
+    initiators.
+    """
+    if CONFIG.test_mode:
+        return
+
+    assert scheduler.running, (
+        "Scheduler is not running! Cannot add attachment orphan cleanup job."
+    )
+
+    logger.info(
+        "Initiating scheduler for attachment orphan cleanup (every {} h)",
+        ORPHAN_CLEANUP_INTERVAL_HOURS,
+    )
+    scheduler.add_job(
+        func=cleanup_orphaned_attachments.delay,
+        kwargs={},
+        id=ORPHAN_CLEANUP_JOB_ID,
+        coalesce=True,
+        replace_existing=True,
+        trigger="interval",
+        hours=ORPHAN_CLEANUP_INTERVAL_HOURS,
+    )

--- a/tests/ops/service/privacy_request_attachments/test_repository.py
+++ b/tests/ops/service/privacy_request_attachments/test_repository.py
@@ -1,24 +1,35 @@
-"""Tests for AttachmentUserProvidedRepository.create_uploaded."""
+"""Tests for AttachmentUserProvidedRepository."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
 
 from fides.api.models.attachment import (
     AttachmentUserProvided,
     AttachmentUserProvidedStatus,
+)
+from fides.service.privacy_request_attachments.privacy_request_attachments_exceptions import (
+    InvalidAttachmentStateError,
 )
 from fides.service.privacy_request_attachments.privacy_request_attachments_repository import (
     AttachmentUserProvidedRepository,
 )
 
 
+def _create(db, storage_config, *, suffix: str = "flush"):
+    return AttachmentUserProvidedRepository().create_uploaded(
+        object_key=f"privacy_request_attachments/{suffix}.pdf",
+        storage_key=storage_config.key,
+        field_name="passport",
+        property_id="prop_xyz",
+        policy_key="default_access_policy",
+        session=db,
+    )
+
+
 class TestAttachmentUserProvidedRepository:
     def test_create_uploaded_persists_row(self, db, storage_config_default):
-        record = AttachmentUserProvidedRepository().create_uploaded(
-            object_key="privacy_request_attachments/flush.pdf",
-            storage_key=storage_config_default.key,
-            field_name="passport",
-            property_id="prop_xyz",
-            policy_key="default_access_policy",
-            session=db,
-        )
+        record = _create(db, storage_config_default)
         assert record.id is not None
         assert record.status == AttachmentUserProvidedStatus.uploaded
         assert record.storage_key == storage_config_default.key
@@ -32,4 +43,88 @@ class TestAttachmentUserProvidedRepository:
             .filter(AttachmentUserProvided.id == record.id)
             .one()
         )
+        row.delete(db)
+
+    def test_list_uploaded_older_than_returns_only_old_uploaded(
+        self, db, storage_config_default
+    ):
+        repo = AttachmentUserProvidedRepository()
+        old_record = _create(db, storage_config_default, suffix="old")
+        new_record = _create(db, storage_config_default, suffix="new")
+        old_row = (
+            db.query(AttachmentUserProvided)
+            .filter(AttachmentUserProvided.id == old_record.id)
+            .one()
+        )
+        new_row = (
+            db.query(AttachmentUserProvided)
+            .filter(AttachmentUserProvided.id == new_record.id)
+            .one()
+        )
+        old_row.created_at = datetime.now(timezone.utc) - timedelta(hours=2)
+        db.commit()
+
+        cutoff = datetime.now(timezone.utc) - timedelta(hours=1)
+        rows = repo.list_uploaded_older_than(cutoff, session=db)
+        ids = {r.id for r in rows}
+        assert old_row.id in ids
+        assert new_row.id not in ids
+
+        old_row.delete(db)
+        new_row.delete(db)
+
+    def test_list_uploaded_older_than_excludes_non_uploaded(
+        self, db, storage_config_default
+    ):
+        # Promoted/deleted rows must never come back from this query — they
+        # are out of scope for the orphan sweep.
+        repo = AttachmentUserProvidedRepository()
+        promoted_record = _create(db, storage_config_default, suffix="promoted")
+        promoted_row = (
+            db.query(AttachmentUserProvided)
+            .filter(AttachmentUserProvided.id == promoted_record.id)
+            .one()
+        )
+        promoted_row.status = AttachmentUserProvidedStatus.promoted
+        promoted_row.created_at = datetime.now(timezone.utc) - timedelta(hours=2)
+        db.commit()
+
+        cutoff = datetime.now(timezone.utc) - timedelta(hours=1)
+        rows = repo.list_uploaded_older_than(cutoff, session=db)
+        assert promoted_row.id not in {r.id for r in rows}
+
+        promoted_row.delete(db)
+
+    def test_mark_deleted_transitions_uploaded_row(self, db, storage_config_default):
+        repo = AttachmentUserProvidedRepository()
+        record = _create(db, storage_config_default, suffix="del")
+        row = (
+            db.query(AttachmentUserProvided)
+            .filter(AttachmentUserProvided.id == record.id)
+            .one()
+        )
+
+        repo.mark_deleted(row, session=db)
+        db.commit()
+
+        db.refresh(row)
+        assert row.status == AttachmentUserProvidedStatus.deleted
+
+        row.delete(db)
+
+    def test_mark_deleted_rejects_non_uploaded_row(self, db, storage_config_default):
+        # Concurrent promotion guard — never overwrite a ``promoted`` row.
+        repo = AttachmentUserProvidedRepository()
+        record = _create(db, storage_config_default, suffix="claimed")
+        row = (
+            db.query(AttachmentUserProvided)
+            .filter(AttachmentUserProvided.id == record.id)
+            .one()
+        )
+        row.status = AttachmentUserProvidedStatus.promoted
+        db.commit()
+
+        with pytest.raises(InvalidAttachmentStateError):
+            repo.mark_deleted(row, session=db)
+
         row.delete(db)

--- a/tests/ops/service/privacy_request_attachments/test_service.py
+++ b/tests/ops/service/privacy_request_attachments/test_service.py
@@ -2,6 +2,7 @@
 
 import io
 from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -27,9 +28,11 @@ from fides.service.privacy_request_attachments.privacy_request_attachments_repos
 )
 from fides.service.privacy_request_attachments.privacy_request_attachments_service import (
     DEFAULT_MAX_SIZE_BYTES,
+    ORPHAN_MIN_AGE_SECONDS,
     AttachmentUserProvidedService,
     FileUploadConstraints,
     _bucket,
+    _cleanup_orphaned_attachments,
     _get_provider_and_bucket,
 )
 
@@ -1177,3 +1180,191 @@ class TestFileUploadConstraintsValidation:
         c = FileUploadConstraints.defaults()
         assert c.max_size_bytes > 0
         assert c.allowed_file_types
+
+
+def _make_uploaded_row(db, storage_config, *, age_seconds: int, suffix: str):
+    """Insert an ``uploaded`` row and back-date its ``created_at``."""
+    record = AttachmentUserProvidedRepository().create_uploaded(
+        object_key=f"privacy_request_attachments/{suffix}.pdf",
+        storage_key=storage_config.key,
+        field_name="file",
+        property_id="test_prop",
+        policy_key="example_access_request_policy",
+        session=db,
+    )
+    row = (
+        db.query(AttachmentUserProvided)
+        .filter(AttachmentUserProvided.id == record.id)
+        .one()
+    )
+    row.created_at = datetime.now(timezone.utc) - timedelta(seconds=age_seconds)
+    db.commit()
+    return row
+
+
+class TestCleanupOrphanedAttachments:
+    """Cover ``_cleanup_orphaned_attachments`` orphan-sweep semantics."""
+
+    def test_deletes_uploaded_rows_older_than_cutoff(
+        self,
+        db,
+        storage_config_default,
+        patch_provider_factory,
+        mock_provider,
+    ):
+        # Storage object deleted, row CAS'd uploaded → deleted.
+        old = _make_uploaded_row(
+            db,
+            storage_config_default,
+            age_seconds=ORPHAN_MIN_AGE_SECONDS + 60,
+            suffix="orphan",
+        )
+
+        _cleanup_orphaned_attachments(db)
+
+        db.refresh(old)
+        assert old.status == AttachmentUserProvidedStatus.deleted
+        mock_provider.delete.assert_called_once_with(
+            "test_bucket", "privacy_request_attachments/orphan.pdf"
+        )
+
+        old.delete(db)
+
+    def test_skips_rows_younger_than_cutoff(
+        self,
+        db,
+        storage_config_default,
+        patch_provider_factory,
+        mock_provider,
+    ):
+        young = _make_uploaded_row(
+            db,
+            storage_config_default,
+            age_seconds=ORPHAN_MIN_AGE_SECONDS - 60,
+            suffix="fresh",
+        )
+
+        _cleanup_orphaned_attachments(db)
+
+        db.refresh(young)
+        assert young.status == AttachmentUserProvidedStatus.uploaded
+        mock_provider.delete.assert_not_called()
+
+        young.delete(db)
+
+    def test_skips_already_promoted_rows(
+        self,
+        db,
+        storage_config_default,
+        patch_provider_factory,
+        mock_provider,
+    ):
+        # Promoted rows must not be touched even if older than the cutoff.
+        promoted = _make_uploaded_row(
+            db,
+            storage_config_default,
+            age_seconds=ORPHAN_MIN_AGE_SECONDS + 60,
+            suffix="claimed",
+        )
+        promoted.status = AttachmentUserProvidedStatus.promoted
+        db.commit()
+
+        _cleanup_orphaned_attachments(db)
+
+        db.refresh(promoted)
+        assert promoted.status == AttachmentUserProvidedStatus.promoted
+        mock_provider.delete.assert_not_called()
+
+        promoted.delete(db)
+
+    def test_keeps_row_in_uploaded_when_storage_delete_fails(
+        self,
+        db,
+        storage_config_default,
+        patch_provider_factory,
+        mock_provider,
+    ):
+        # If we cannot delete the bytes, leave the row in ``uploaded`` so
+        # the next sweep retries — never advance to ``deleted`` while the
+        # object is still live.
+        mock_provider.delete.side_effect = RuntimeError("s3 down")
+        old = _make_uploaded_row(
+            db,
+            storage_config_default,
+            age_seconds=ORPHAN_MIN_AGE_SECONDS + 60,
+            suffix="stuck",
+        )
+
+        _cleanup_orphaned_attachments(db)
+
+        db.refresh(old)
+        assert old.status == AttachmentUserProvidedStatus.uploaded
+
+        old.delete(db)
+
+    def test_short_circuits_when_no_storage_config(self, db, storage_config_default):
+        # Function returns cleanly without iterating rows when storage is
+        # not configured — re-running once configured does the work.
+        old = _make_uploaded_row(
+            db,
+            storage_config_default,
+            age_seconds=ORPHAN_MIN_AGE_SECONDS + 60,
+            suffix="no_storage",
+        )
+
+        with patch(
+            "fides.service.privacy_request_attachments."
+            "privacy_request_attachments_service.get_active_default_storage_config",
+            return_value=None,
+        ):
+            _cleanup_orphaned_attachments(db)
+
+        db.refresh(old)
+        assert old.status == AttachmentUserProvidedStatus.uploaded
+
+        old.delete(db)
+
+    def test_one_failure_does_not_abort_batch(
+        self,
+        db,
+        storage_config_default,
+        patch_provider_factory,
+        mock_provider,
+    ):
+        # First delete raises, second succeeds — second row must still be
+        # transitioned to ``deleted``.
+        first = _make_uploaded_row(
+            db,
+            storage_config_default,
+            age_seconds=ORPHAN_MIN_AGE_SECONDS + 120,
+            suffix="bad",
+        )
+        second = _make_uploaded_row(
+            db,
+            storage_config_default,
+            age_seconds=ORPHAN_MIN_AGE_SECONDS + 60,
+            suffix="good",
+        )
+
+        deleted_keys: list[str] = []
+
+        def _maybe_fail(_bucket: str, key: str) -> None:
+            deleted_keys.append(key)
+            if key.endswith("bad.pdf"):
+                raise RuntimeError("s3 transient")
+
+        mock_provider.delete.side_effect = _maybe_fail
+
+        _cleanup_orphaned_attachments(db)
+
+        db.refresh(first)
+        db.refresh(second)
+        assert first.status == AttachmentUserProvidedStatus.uploaded
+        assert second.status == AttachmentUserProvidedStatus.deleted
+        assert sorted(deleted_keys) == [
+            "privacy_request_attachments/bad.pdf",
+            "privacy_request_attachments/good.pdf",
+        ]
+
+        first.delete(db)
+        second.delete(db)


### PR DESCRIPTION
Ticket [ENG-3518]

> **Stack:** depends on #8106 (ENG-3517-E). Merge that first.

### Description Of Changes

Adds a periodic Celery task that sweeps stale `uploaded` rows on `attachment_user_provided` — i.e. uploads that the data subject made but never attached to a privacy-request submission. Without this, the table accumulates rows whose temp storage objects are still live in the bucket, paid for indefinitely.

The sweep runs every hour, finds rows where `status='uploaded' AND created_at < now() - ORPHAN_MIN_AGE_SECONDS` (default 3600 s = 1 h), deletes the storage object first, then CAS-transitions the row to `deleted`. Rows that have already been claimed (`promoted`) or swept (`deleted`) are not touched. Order is deliberate — leaving a row in `deleted` while the bytes still exist would orphan the object beyond the index, so the storage delete must succeed before the row advances. If a single delete fails, the row stays in `uploaded` and the next sweep retries.

The 1-hour minimum age is a deliberate floor: a privacy-request submission can post the upload `id` long after the bytes hit storage (the privacy center holds it across navigation, etc.). Sweeping too eagerly would race ongoing user flows; an hour is well outside any realistic interactive submission window.

### Code Changes

* `src/fides/service/privacy_request_attachments/privacy_request_attachments_repository.py`:
  * `list_uploaded_older_than(cutoff, *, session)` — `uploaded` rows with `created_at < cutoff`.
  * `mark_deleted(row, *, session)` — CAS `uploaded → deleted`; raises `InvalidAttachmentStateError` on any other status so a concurrent promotion is never overwritten.
* `src/fides/service/privacy_request_attachments/privacy_request_attachments_service.py`:
  * `_cleanup_orphaned_attachments(db)` — testable inner (loops orphans, storage-delete first, then CAS, single commit at the end, one bad row never aborts the batch).
  * `@celery_app.task cleanup_orphaned_attachments(self)` — Celery wrapper; opens a fresh session via `self.get_new_session()` and delegates.
  * `initiate_scheduled_attachment_cleanup()` — registers `cleanup_orphaned_attachments.delay` on the APScheduler at a 1-hour interval, `coalesce=True`, `replace_existing=True`.
  * Constants: `ORPHAN_MIN_AGE_SECONDS = 3600`, `ORPHAN_CLEANUP_INTERVAL_HOURS = 1`, `ORPHAN_CLEANUP_JOB_ID`.
* `src/fides/api/main.py`: wires `initiate_scheduled_attachment_cleanup()` into the FastAPI lifespan, alongside the existing scheduled-task initiators.

### Steps to Confirm

1. Local stack up. Boot the API and confirm the scheduler log line: `Initiating scheduler for attachment orphan cleanup (every 1 h)`.
2. Upload a file via `POST /api/v1/privacy-request/attachment` but do **not** submit a privacy request that references it. Confirm a row is in `attachment_user_provided` with `status='uploaded'` and the storage object exists.
3. Backdate the row: `UPDATE attachment_user_provided SET created_at = now() - interval '2 hours' WHERE id = '<id>';`.
4. Either wait for the next interval tick or invoke the inner directly from a Python shell:
   ```python
   from fides.service.privacy_request_attachments.privacy_request_attachments_service import _cleanup_orphaned_attachments
   from fides.api.db.session import get_db_session
   with next(get_db_session()) as db:
       _cleanup_orphaned_attachments(db)
   ```
5. Confirm: row's `status` is now `deleted`; storage object is gone (`aws s3 ls` / local-storage path empty for that key).
6. Repeat with a row whose `created_at` is recent (< 1 h) — it must remain `uploaded` and the object must remain present.
7. Repeat with a row in `promoted` state and old `created_at` — must remain `promoted`.

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-3518]: https://ethyca.atlassian.net/browse/ENG-3518