### PR TITLE
ENG-3517: Foundation - attachment_user_provided model + repository

### DIFF
--- a/.fides/db_dataset.yml
+++ b/.fides/db_dataset.yml
@@ -97,6 +97,28 @@ dataset:
     - name: client_id
       data_categories:
         - system.operations
+  - name: attachment_user_provided
+    fields:
+    - name: created_at
+      data_categories: [system.operations]
+    - name: field_name
+      data_categories: [system.operations]
+    - name: id
+      data_categories: [system.operations]
+    - name: object_key
+      data_categories: [system.operations]
+    - name: policy_key
+      data_categories: [system.operations]
+    - name: promoted_at
+      data_categories: [system.operations]
+    - name: property_id
+      data_categories: [system.operations]
+    - name: status
+      data_categories: [system.operations]
+    - name: storage_key
+      data_categories: [system.operations]
+    - name: updated_at
+      data_categories: [system.operations]
   - name: answer_version
     description: 'Immutable history of assessment answer versions'
     fields:

--- a/changelog/8110-attachment-upload.yaml
+++ b/changelog/8110-attachment-upload.yaml
@@ -1,0 +1,4 @@
+type: Added
+description: ENG-3517 foundation - `attachment_user_provided` table (alembic 9b449105864d), model, repository (CRUD + state-machine + cleanup helpers), domain exceptions. Upload service + endpoint live in fidesplus.
+pr: 8110
+labels: []

--- a/changelog/8110-attachment-upload.yaml
+++ b/changelog/8110-attachment-upload.yaml
@@ -1,4 +1,4 @@
 type: Added
-description: ENG-3517 foundation - `attachment_user_provided` table (alembic 9b449105864d), model, repository (CRUD + state-machine + cleanup helpers), domain exceptions. Upload service + endpoint live in fidesplus.
+description: Added `attachment_user_provided` table, model, repository and, domain exceptions.
 pr: 8110
-labels: []
+labels: [db-migration]

--- a/src/fides/api/alembic/migrations/versions/xx_2026_05_05_1200_9b449105864d_add_attachment_user_provided.py
+++ b/src/fides/api/alembic/migrations/versions/xx_2026_05_05_1200_9b449105864d_add_attachment_user_provided.py
@@ -78,4 +78,4 @@ def downgrade() -> None:
         table_name="attachment_user_provided",
     )
     op.drop_table("attachment_user_provided")
-    op.execute("DROP TYPE attachmentuserprovidedstatus")
+    sa.Enum(name="attachmentuserprovidedstatus").drop(op.get_bind(), checkfirst=True)

--- a/src/fides/api/alembic/migrations/versions/xx_2026_05_05_1200_9b449105864d_add_attachment_user_provided.py
+++ b/src/fides/api/alembic/migrations/versions/xx_2026_05_05_1200_9b449105864d_add_attachment_user_provided.py
@@ -1,0 +1,81 @@
+"""add attachment_user_provided
+
+Revision ID: 9b449105864d
+Revises: e3f4a5b6c7d8
+Create Date: 2026-05-05 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "9b449105864d"
+down_revision = "e3f4a5b6c7d8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "attachment_user_provided",
+        sa.Column("id", sa.String(length=255), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("object_key", sa.String(), nullable=False),
+        sa.Column(
+            "status",
+            sa.Enum(
+                "uploaded",
+                "promoted",
+                "deleted",
+                name="attachmentuserprovidedstatus",
+            ),
+            server_default="uploaded",
+            nullable=False,
+        ),
+        sa.Column("storage_key", sa.String(), nullable=False),
+        sa.Column("promoted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("field_name", sa.String(), nullable=False),
+        sa.Column("property_id", sa.String(), nullable=False),
+        sa.Column("policy_key", sa.String(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "object_key", name="uq_attachment_user_provided_object_key"
+        ),
+    )
+    op.create_index(
+        op.f("ix_attachment_user_provided_id"),
+        "attachment_user_provided",
+        ["id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_attachment_user_provided_status_created_at",
+        "attachment_user_provided",
+        ["status", "created_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_attachment_user_provided_status_created_at",
+        table_name="attachment_user_provided",
+    )
+    op.drop_index(
+        op.f("ix_attachment_user_provided_id"),
+        table_name="attachment_user_provided",
+    )
+    op.drop_table("attachment_user_provided")
+    op.execute("DROP TYPE attachmentuserprovidedstatus")

--- a/src/fides/api/alembic/migrations/versions/xx_2026_05_05_1200_9b449105864d_add_attachment_user_provided.py
+++ b/src/fides/api/alembic/migrations/versions/xx_2026_05_05_1200_9b449105864d_add_attachment_user_provided.py
@@ -1,7 +1,7 @@
 """add attachment_user_provided
 
 Revision ID: 9b449105864d
-Revises: e3f4a5b6c7d8
+Revises: 6ebb8e54e130
 Create Date: 2026-05-05 12:00:00.000000
 
 """
@@ -11,7 +11,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "9b449105864d"
-down_revision = "e3f4a5b6c7d8"
+down_revision = "6ebb8e54e130"
 branch_labels = None
 depends_on = None
 

--- a/src/fides/api/alembic/migrations/versions/xx_2026_05_14_1000_9b449105864d_add_attachment_user_provided.py
+++ b/src/fides/api/alembic/migrations/versions/xx_2026_05_14_1000_9b449105864d_add_attachment_user_provided.py
@@ -2,7 +2,7 @@
 
 Revision ID: 9b449105864d
 Revises: 6ebb8e54e130
-Create Date: 2026-05-05 12:00:00.000000
+Create Date: 2026-05-14 10:00:00.000000
 
 """
 

--- a/src/fides/api/models/attachment.py
+++ b/src/fides/api/models/attachment.py
@@ -34,6 +34,7 @@ class AttachmentType(str, EnumType):
 
     internal_use_only = "internal_use_only"
     include_with_access_package = "include_with_access_package"
+    user_provided = "user_provided"
 
 
 class AttachmentReferenceType(str, EnumType):
@@ -47,6 +48,15 @@ class AttachmentReferenceType(str, EnumType):
     comment = "comment"
     manual_task_submission = "manual_task_submission"
     request_task = "request_task"
+
+
+class AttachmentUserProvidedStatus(str, EnumType):
+    """Lifecycle: ``uploaded`` → ``promoted`` (claimed by a submitted request)
+    or ``deleted`` (orphan-swept; row kept for audit)."""
+
+    uploaded = "uploaded"
+    promoted = "promoted"
+    deleted = "deleted"
 
 
 class AttachmentReference(Base):
@@ -186,3 +196,52 @@ class Attachment(Base):
     ) -> "Attachment":
         """Creates a new attachment record in the database."""
         return cls._create_record(db=db, data=data, check_name=check_name)
+
+
+class AttachmentUserProvided(Base):
+    """Lifecycle row for a data-subject-uploaded file. ``storage_key`` is a
+    plain reference (no FK) so rows survive storage-config churn for audit."""
+
+    @declared_attr
+    def __tablename__(cls) -> str:
+        return "attachment_user_provided"
+
+    # Tighten base columns to ``nullable=False`` (base declares them nullable).
+    created_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    object_key = Column(String, nullable=False, unique=True)
+
+    status = Column(
+        EnumColumn(AttachmentUserProvidedStatus, name="attachmentuserprovidedstatus"),
+        nullable=False,
+        server_default=AttachmentUserProvidedStatus.uploaded.value,
+    )
+
+    storage_key = Column(String, nullable=False)
+    promoted_at = Column(DateTime(timezone=True), nullable=True)
+
+    # ``field_name`` + ``property_id`` + ``policy_key`` bind the upload to the
+    # privacy-center config triple it was issued under; re-validated at
+    # promotion. Intentionally non-FK so audit rows survive config rename/delete
+    # between upload and submission.
+    field_name = Column(String, nullable=False)
+    property_id = Column(String, nullable=False)
+    policy_key = Column(String, nullable=False)
+
+    __table_args__ = (
+        # Speeds up the orphan-cleanup sweep:
+        #   WHERE status = 'uploaded' AND created_at < :cutoff
+        Index(
+            "ix_attachment_user_provided_status_created_at",
+            "status",
+            "created_at",
+        ),
+    )

--- a/src/fides/service/privacy_request_attachments/__init__.py
+++ b/src/fides/service/privacy_request_attachments/__init__.py
@@ -1,0 +1,1 @@
+"""Data-subject-uploaded attachment service package."""

--- a/src/fides/service/privacy_request_attachments/privacy_request_attachments_entities.py
+++ b/src/fides/service/privacy_request_attachments/privacy_request_attachments_entities.py
@@ -1,0 +1,39 @@
+"""Domain entities for data-subject-uploaded attachments."""
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from fides.api.models.attachment import (
+    AttachmentUserProvided,
+    AttachmentUserProvidedStatus,
+)
+
+
+@dataclass
+class AttachmentUserProvidedRecord:
+    """Detach-safe view of an ``attachment_user_provided`` row."""
+
+    id: str
+    object_key: str
+    storage_key: str
+    status: AttachmentUserProvidedStatus
+    created_at: datetime
+    field_name: str
+    property_id: str
+    policy_key: str
+
+    @classmethod
+    def from_orm(cls, obj: AttachmentUserProvided) -> "AttachmentUserProvidedRecord":
+        # SA Column descriptors don't narrow to the runtime types declared on
+        # this dataclass — ignore arg-type at the two columns that diverge:
+        # status (str vs enum) and created_at (Optional vs required).
+        return cls(
+            id=obj.id,
+            object_key=obj.object_key,
+            storage_key=obj.storage_key,
+            status=obj.status,  # type: ignore[arg-type]
+            created_at=obj.created_at,  # type: ignore[arg-type]
+            field_name=obj.field_name,
+            property_id=obj.property_id,
+            policy_key=obj.policy_key,
+        )

--- a/src/fides/service/privacy_request_attachments/privacy_request_attachments_exceptions.py
+++ b/src/fides/service/privacy_request_attachments/privacy_request_attachments_exceptions.py
@@ -1,0 +1,22 @@
+"""Domain exceptions for the attachments service.
+
+Routes catch these and translate to HTTP. Services and repositories must
+never raise ``HTTPException`` directly.
+"""
+
+
+class AttachmentsServiceError(Exception):
+    """Base class for attachments service domain errors."""
+
+
+class InvalidAttachmentStateError(AttachmentsServiceError):
+    """Raised when an attachment is not in the expected lifecycle state."""
+
+    def __init__(self, object_key: str, status: str, expected: str = "uploaded"):
+        self.object_key = object_key
+        self.status = status
+        self.expected = expected
+        super().__init__(
+            f"Attachment '{object_key}' is in state {status}, "
+            f"expected '{expected}'. Refusing to promote."
+        )

--- a/src/fides/service/privacy_request_attachments/privacy_request_attachments_repository.py
+++ b/src/fides/service/privacy_request_attachments/privacy_request_attachments_repository.py
@@ -3,6 +3,7 @@
 from datetime import datetime, timezone
 from typing import Optional
 
+from sqlalchemy.future import select
 from sqlalchemy.orm import Session
 
 from fides.api.models.attachment import (
@@ -61,13 +62,13 @@ class AttachmentUserProvidedRepository:
         """
         if not ids:
             return {}
-        rows = (
-            session.query(AttachmentUserProvided)
-            .filter(AttachmentUserProvided.id.in_(ids))
+        query = (
+            select(AttachmentUserProvided)
+            .where(AttachmentUserProvided.id.in_(ids))
             .order_by(AttachmentUserProvided.id)
             .with_for_update()
-            .all()
         )
+        rows = session.execute(query).scalars().all()
         return {row.id: row for row in rows}
 
     @staticmethod
@@ -102,11 +103,8 @@ class AttachmentUserProvidedRepository:
         session: Session,
     ) -> list[AttachmentUserProvided]:
         """Return every ``uploaded`` row created before ``cutoff`` (exclusive)."""
-        return (
-            session.query(AttachmentUserProvided)
-            .filter(
-                AttachmentUserProvided.status == AttachmentUserProvidedStatus.uploaded
-            )
-            .filter(AttachmentUserProvided.created_at < cutoff)
-            .all()
+        query = select(AttachmentUserProvided).where(
+            AttachmentUserProvided.status == AttachmentUserProvidedStatus.uploaded,
+            AttachmentUserProvided.created_at < cutoff,
         )
+        return list(session.execute(query).scalars().all())

--- a/src/fides/service/privacy_request_attachments/privacy_request_attachments_repository.py
+++ b/src/fides/service/privacy_request_attachments/privacy_request_attachments_repository.py
@@ -1,0 +1,112 @@
+"""Data-access layer for ``AttachmentUserProvided`` rows."""
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from fides.api.models.attachment import (
+    AttachmentUserProvided,
+    AttachmentUserProvidedStatus,
+)
+from fides.common.session_management import with_optional_sync_session
+from fides.service.privacy_request_attachments.privacy_request_attachments_entities import (
+    AttachmentUserProvidedRecord,
+)
+from fides.service.privacy_request_attachments.privacy_request_attachments_exceptions import (
+    InvalidAttachmentStateError,
+)
+
+
+class AttachmentUserProvidedRepository:
+    """DB reads/writes for ``attachment_user_provided``."""
+
+    @with_optional_sync_session
+    def create_uploaded(
+        self,
+        *,
+        object_key: str,
+        storage_key: str,
+        field_name: str,
+        property_id: str,
+        policy_key: str,
+        session: Session,
+    ) -> AttachmentUserProvidedRecord:
+        """Insert a new ``uploaded`` row; flush so ``id`` is populated."""
+        row = AttachmentUserProvided(
+            object_key=object_key,
+            status=AttachmentUserProvidedStatus.uploaded,
+            storage_key=storage_key,
+            field_name=field_name,
+            property_id=property_id,
+            policy_key=policy_key,
+        )
+        session.add(row)
+        session.flush()
+        session.refresh(row)
+        return AttachmentUserProvidedRecord.from_orm(row)
+
+    @staticmethod
+    def lock_by_ids(
+        ids: list[str], *, session: Session
+    ) -> dict[str, AttachmentUserProvided]:
+        """Lock matching rows under ``FOR UPDATE``, keyed by id.
+
+        ``session`` is required — the lock is only meaningful inside a
+        caller-owned transaction. Ordered by ``id`` to give all callers the
+        same lock-acquisition order (deadlock-safe across overlapping
+        batches). Returns rows in *any* state; missing ids are absent from
+        the dict. Pair with :meth:`assert_all_uploaded` to enforce the
+        lifecycle precondition.
+        """
+        if not ids:
+            return {}
+        rows = (
+            session.query(AttachmentUserProvided)
+            .filter(AttachmentUserProvided.id.in_(ids))
+            .order_by(AttachmentUserProvided.id)
+            .with_for_update()
+            .all()
+        )
+        return {row.id: row for row in rows}
+
+    @staticmethod
+    def assert_all_uploaded(rows: list[AttachmentUserProvided]) -> None:
+        """Raise :class:`InvalidAttachmentStateError` on first non-``uploaded`` row."""
+        for row in rows:
+            if row.status != AttachmentUserProvidedStatus.uploaded:
+                raise InvalidAttachmentStateError(row.object_key, row.status)
+
+    @staticmethod
+    def mark_promoted(
+        row: AttachmentUserProvided,
+        *,
+        promoted_at: Optional[datetime] = None,
+    ) -> None:
+        """Flip ``uploaded`` → ``promoted`` (in-session). Caller owns commit."""
+        if row.status != AttachmentUserProvidedStatus.uploaded:
+            raise InvalidAttachmentStateError(row.object_key, row.status)
+        row.status = AttachmentUserProvidedStatus.promoted
+        row.promoted_at = promoted_at or datetime.now(timezone.utc)
+
+    @staticmethod
+    def mark_deleted(row: AttachmentUserProvided) -> None:
+        """Transition a row to ``deleted`` (in-session, no commit)."""
+        row.status = AttachmentUserProvidedStatus.deleted
+
+    @with_optional_sync_session
+    def list_uploaded_older_than(
+        self,
+        cutoff: datetime,
+        *,
+        session: Session,
+    ) -> list[AttachmentUserProvided]:
+        """Return every ``uploaded`` row created before ``cutoff`` (exclusive)."""
+        return (
+            session.query(AttachmentUserProvided)
+            .filter(
+                AttachmentUserProvided.status == AttachmentUserProvidedStatus.uploaded
+            )
+            .filter(AttachmentUserProvided.created_at < cutoff)
+            .all()
+        )

--- a/tests/ops/service/privacy_request_attachments/test_repository.py
+++ b/tests/ops/service/privacy_request_attachments/test_repository.py
@@ -1,0 +1,160 @@
+"""Tests for AttachmentUserProvidedRepository."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from fides.api.models.attachment import (
+    AttachmentUserProvided,
+    AttachmentUserProvidedStatus,
+)
+from fides.service.privacy_request_attachments.privacy_request_attachments_exceptions import (
+    InvalidAttachmentStateError,
+)
+from fides.service.privacy_request_attachments.privacy_request_attachments_repository import (
+    AttachmentUserProvidedRepository,
+)
+
+UPLOADED = AttachmentUserProvidedStatus.uploaded
+PROMOTED = AttachmentUserProvidedStatus.promoted
+DELETED = AttachmentUserProvidedStatus.deleted
+
+
+@pytest.fixture
+def repo() -> AttachmentUserProvidedRepository:
+    return AttachmentUserProvidedRepository()
+
+
+@pytest.fixture
+def insert_row(db, storage_config_default):
+    """Insert rows; auto-clean on teardown. ``.track(id)`` registers a row
+    inserted via the repository for the same teardown sweep."""
+    created: list[str] = []
+
+    def _factory(
+        *,
+        object_key: str = "privacy_request_attachments/file.pdf",
+        status: AttachmentUserProvidedStatus = UPLOADED,
+        created_at: datetime | None = None,
+    ) -> AttachmentUserProvided:
+        row = AttachmentUserProvided(
+            object_key=object_key,
+            status=status,
+            storage_key=storage_config_default.key,
+            field_name="passport",
+            property_id="prop_xyz",
+            policy_key="default_access_policy",
+        )
+        if created_at is not None:
+            row.created_at = created_at
+        db.add(row)
+        db.flush()
+        db.refresh(row)
+        created.append(row.id)
+        return row
+
+    _factory.track = created.append  # type: ignore[attr-defined]
+    yield _factory
+    if created:
+        db.query(AttachmentUserProvided).filter(
+            AttachmentUserProvided.id.in_(created)
+        ).delete(synchronize_session=False)
+        db.commit()
+
+
+@pytest.fixture
+def uploaded_row(insert_row) -> AttachmentUserProvided:
+    return insert_row()
+
+
+def test_create_uploaded_persists_row(repo, db, storage_config_default, insert_row):
+    record = repo.create_uploaded(
+        object_key="privacy_request_attachments/flush.pdf",
+        storage_key=storage_config_default.key,
+        field_name="passport",
+        property_id="prop_xyz",
+        policy_key="default_access_policy",
+        session=db,
+    )
+    insert_row.track(record.id)
+    assert record.id and record.status == UPLOADED
+    assert record.object_key == "privacy_request_attachments/flush.pdf"
+    assert record.created_at is not None
+    assert (record.field_name, record.property_id, record.policy_key) == (
+        "passport",
+        "prop_xyz",
+        "default_access_policy",
+    )
+
+
+def test_lock_by_ids_keys_dict_and_returns_any_state(repo, db, insert_row):
+    a = insert_row(object_key="prefix/a.pdf")
+    b = insert_row(object_key="prefix/b.pdf", status=PROMOTED)
+    locked = repo.lock_by_ids([a.id, b.id, "att_missing"], session=db)
+    assert set(locked.keys()) == {a.id, b.id}
+    assert locked[a.id].status == UPLOADED
+    assert locked[b.id].status == PROMOTED
+
+
+def test_lock_by_ids_empty_list_short_circuits(repo, db):
+    assert repo.lock_by_ids([], session=db) == {}
+
+
+def test_assert_all_uploaded_passes(repo, uploaded_row):
+    repo.assert_all_uploaded([uploaded_row])
+
+
+def test_assert_all_uploaded_raises_on_non_uploaded(repo, insert_row):
+    with pytest.raises(InvalidAttachmentStateError):
+        repo.assert_all_uploaded([insert_row(status=PROMOTED)])
+
+
+class TestMarkPromoted:
+    @pytest.mark.parametrize(
+        "explicit_ts",
+        [None, datetime(2026, 1, 1, tzinfo=timezone.utc)],
+    )
+    def test_flips_status_and_sets_promoted_at(
+        self, repo, db, uploaded_row, explicit_ts
+    ):
+        repo.mark_promoted(uploaded_row, promoted_at=explicit_ts)
+        db.flush()
+        db.refresh(uploaded_row)
+        assert uploaded_row.status == PROMOTED
+        if explicit_ts is None:
+            assert uploaded_row.promoted_at is not None
+        else:
+            assert uploaded_row.promoted_at == explicit_ts
+
+    @pytest.mark.parametrize("prior_status", [PROMOTED, DELETED])
+    def test_raises_on_non_uploaded(self, repo, db, insert_row, prior_status):
+        row = insert_row(status=prior_status)
+        with pytest.raises(InvalidAttachmentStateError):
+            repo.mark_promoted(row)
+        db.refresh(row)
+        assert row.status == prior_status
+
+
+def test_mark_deleted_in_session_only(repo, db, uploaded_row):
+    repo.mark_deleted(uploaded_row)
+    assert uploaded_row.status == DELETED
+    db.flush()
+    db.refresh(uploaded_row)
+    assert uploaded_row.status == DELETED
+
+
+def test_list_uploaded_older_than(repo, db, insert_row):
+    old = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    cutoff = datetime(2021, 1, 1, tzinfo=timezone.utc)
+    future = datetime.now(timezone.utc) + timedelta(days=1)
+    old_uploaded = insert_row(object_key="prefix/old_uploaded.pdf", created_at=old)
+    new_uploaded = insert_row(object_key="prefix/new_uploaded.pdf", created_at=future)
+    old_promoted = insert_row(
+        object_key="prefix/old_promoted.pdf", status=PROMOTED, created_at=old
+    )
+    boundary = insert_row(object_key="prefix/boundary.pdf", created_at=cutoff)
+    ret_ids = {r.id for r in repo.list_uploaded_older_than(cutoff, session=db)}
+    assert old_uploaded.id in ret_ids
+    assert new_uploaded.id not in ret_ids  # too new
+    assert old_promoted.id not in ret_ids  # not uploaded
+    assert boundary.id not in ret_ids  # cutoff is exclusive


### PR DESCRIPTION
Ticket [ENG-3517]

### List of related changes

| # | Ticket | Repo | PR | Description | Approved |                                                                                                                                                                
  |---|---|---|---|---|---|                                                                                                                                                                                          
  | this PR | ENG-3517 | fides | [#8110](https://github.com/ethyca/fides/pull/8110) | Foundation — `attachment_user_provided` model + repository (lifecycle, locking, orphan-sweep query) | [] |                           
  | 2 | ENG-3517 | fides | [#8113](https://github.com/ethyca/fides/pull/8113) | `FileUploadCustomPrivacyRequestField` schema variant, storage util (magic bytes, allowed types), promotion hook, config flags | [] | 
  | 3 | ENG-3517 | fidesplus | [#3524](https://github.com/ethyca/fidesplus/pull/3524) | Attachment service + `PrivacyRequestService` promotion hook implementation | [] |                                            
  | 4 | ENG-3517 | fidesplus | [#3534](https://github.com/ethyca/fidesplus/pull/3534) | `POST /privacy-request/attachment` HTTP endpoint (multipart upload, per-field constraints, rate limit) | [x] |                
  | 5 | ENG-3518 | fidesplus | [#3526](https://github.com/ethyca/fidesplus/pull/3526) | Hourly Celery orphan-sweep: deletes temp storage objects + `uploaded` rows older than cutoff | [x] |                          
  | 6 | ENG-3519 | fidesplus | [#3543](https://github.com/ethyca/fidesplus/pull/3543) | Local-dev `clamav-icap` container (Ubuntu + c-icap + libclamav, profile-gated in compose) | [x] |                             
  | 7 | ENG-3520 | fidesplus | [#3544](https://github.com/ethyca/fidesplus/pull/3544) | Wire ICAP scanner into upload path (RESPMOD call, `X-Infection-Found` handling) | [x] |                                       
                                                                                                                                                                                    

### Description Of Changes

Data layer for the data-subject file-upload feature: `attachment_user_provided` table + repository primitives. The upload service + endpoint live in fidesplus and consume this PR.

The table tracks an upload's lifecycle independently of `attachment` so a user can upload before a privacy request exists. Lifecycle: `uploaded → promoted | deleted`. `deleted` rows are kept for audit. The `(field_name, property_id, policy_key)` triple binds an upload to the privacy-center config it was issued under so re-validation at submission can refuse mismatches. `storage_key` is a plain string (no FK) so rows survive storage-config churn.

### Code Changes

* `models/attachment.py`: `AttachmentUserProvidedStatus` enum + `AttachmentUserProvided` model. `(field_name, property_id, policy_key)` are required at insert. Composite index `(status, created_at)` for the orphan-sweep predicate.
* `alembic/.../9b449105864d_add_attachment_user_provided.py`: table + enum + index. `down_revision = "3a91e5d4f7b2"`. Reversible.
* `service/privacy_request_attachments/privacy_request_attachments_repository.py`:
  * `create_uploaded` — insert + flush + refresh, returns `AttachmentUserProvidedRecord`
  * `lock_by_ids` — `SELECT … FOR UPDATE` ordered by `id` (deadlock-safe under overlapping batches), returns `dict[str, row]` so callers can detect missing ids
  * `assert_all_uploaded` — fail-fast precondition
  * `mark_promoted` — pure mutation, caller owns the session
  * `mark_deleted` — in-session mutation, no commit
  * `list_uploaded_older_than` — orphan-sweep, exclusive cutoff
* `service/privacy_request_attachments/privacy_request_attachments_entities.py`: `AttachmentUserProvidedRecord` detach-safe dataclass.
* `service/privacy_request_attachments/privacy_request_attachments_exceptions.py`: `AttachmentsServiceError` base + `InvalidAttachmentStateError`. Other domain errors will land with their consumers.
* `tests/ops/service/privacy_request_attachments/test_repository.py`: lifecycle suite covering every public repo method.
* `.fides/db_dataset.yml`: dataset entries for the new table.

### Steps to Confirm

1. `alembic upgrade head` — revision `9b449105864d` applies.
2. `\d attachment_user_provided` in psql — columns, `attachmentuserprovidedstatus` enum, `ix_attachment_user_provided_status_created_at` index all present.
3. `alembic downgrade -1` — table, enum, and index drop cleanly.
4. `alembic upgrade head` again to land on the new revision.
5. `nox -s "pytest(ops-unit-non-api)" -- tests/ops/service/privacy_request_attachments/test_repository.py` — all green.

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [x] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [x] Ensure that your downrev is up to date with the latest revision on `main`
  * [x] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-3517]: https://ethyca.atlassian.net/browse/ENG-3517
