### PR TITLE
Cypress test flakiness fixes

### DIFF
--- a/clients/admin-ui/cypress/e2e/datamap-report.cy.ts
+++ b/clients/admin-ui/cypress/e2e/datamap-report.cy.ts
@@ -171,23 +171,11 @@ describe("Data map report table", () => {
     it("should reorder columns", () => {
       cy.getByTestId("more-menu").click();
       cy.selectAntDropdownOption("Edit columns");
-      cy.getAntDropdownOverlay("more-menu-list").should("not.be.visible");
-      // react-dnd's HTML5 backend requires a DataTransfer on every event and
-      // reorders on hover (not drop), so we simulate the full drag lifecycle.
-      const dataTransfer = new DataTransfer();
-      cy.getByTestId("column-dragger-legal_name").trigger("dragstart", {
-        dataTransfer,
-      });
-      cy.getByTestId("column-dragger-data_categories").trigger("dragover", {
-        dataTransfer,
-      });
-      cy.getByTestId("column-dragger-data_categories").trigger("drop", {
-        dataTransfer,
-      });
-      cy.getByTestId("column-dragger-legal_name").trigger("dragend", {
-        dataTransfer,
-      });
-      cy.getByTestId("save-button").click();
+      cy.getAntModal().should("be.visible");
+      cy.getByTestId("column-dragger-legal_name").trigger("dragstart");
+      cy.getByTestId("column-list-item-data_categories").trigger("drop");
+      cy.getByTestId("column-dragger-legal_name").trigger("dragend");
+      cy.getByTestId("save-button").click({ force: true });
 
       // Verify the new order
       cy.getByTestId("fidesTable").within(() => {


### PR DESCRIPTION
### Description Of Changes

Cypress sometimes gets hung up trying to accomplish the drag/drop in the column reordering. This PR addresses that flakiness

### Code Changes

* Remove the `datatransfer` stuff
* Remove `dragover` event
* Make sure save gets clicked using `force`

### Steps to Confirm

1. CI passes

### Pre-Merge Checklist

* [ ] All CI pipelines succeeded
