### PR TITLE
Improve assessment wording

### DIFF
--- a/changelog/8116-privacy-assessments-wording-polish.yaml
+++ b/changelog/8116-privacy-assessments-wording-polish.yaml
@@ -1,0 +1,4 @@
+type: Changed
+description: Improved wording on privacy assessment cards and evaluation status indicator
+pr: 8116
+labels: []

--- a/clients/admin-ui/src/features/privacy-assessments/AssessmentCard.tsx
+++ b/clients/admin-ui/src/features/privacy-assessments/AssessmentCard.tsx
@@ -147,7 +147,7 @@ export const AssessmentCard = ({
                   />
                   <div>
                     <Text strong type="success" size="sm">
-                      Assessment complete
+                      Completed
                     </Text>
                     <Paragraph type="secondary" size="sm">
                       {completionDate}
@@ -163,7 +163,7 @@ export const AssessmentCard = ({
               <>
                 <Flex justify="space-between">
                   <Text type="secondary" size="sm">
-                    Completeness
+                    Questions answered
                   </Text>
                   <Text strong size="sm">
                     {completeness}%

--- a/clients/admin-ui/src/features/privacy-assessments/AssessmentCard.tsx
+++ b/clients/admin-ui/src/features/privacy-assessments/AssessmentCard.tsx
@@ -161,14 +161,15 @@ export const AssessmentCard = ({
             )}
             {!isGenerating && !isComplete && (
               <>
-                <Flex justify="space-between">
-                  <Text type="secondary" size="sm">
-                    Questions answered
-                  </Text>
+                <div>
                   <Text strong size="sm">
-                    {completeness}%
+                    {Math.round(completeness)}%
                   </Text>
-                </Flex>
+                  <Text type="secondary" size="sm">
+                    {" "}
+                    of questions answered
+                  </Text>
+                </div>
                 <Progress
                   percent={completeness}
                   showInfo={false}

--- a/clients/admin-ui/src/features/privacy-assessments/AssessmentGroup.tsx
+++ b/clients/admin-ui/src/features/privacy-assessments/AssessmentGroup.tsx
@@ -48,7 +48,7 @@ export const AssessmentGroup = ({
             </Title>
             <Text type="secondary">
               {systemCount} {systemCount === 1 ? "system" : "systems"} •{" "}
-              {assessments.length} active assessments
+              {assessments.length} assessments
             </Text>
           </div>
         </Flex>

--- a/clients/admin-ui/src/features/privacy-assessments/AssessmentTaskStatusIndicator.tsx
+++ b/clients/admin-ui/src/features/privacy-assessments/AssessmentTaskStatusIndicator.tsx
@@ -151,7 +151,7 @@ export const AssessmentTaskStatusIndicator = ({
         <Flex align="center" gap="small">
           <Icons.CheckmarkFilled size={14} />
           <Text type="secondary" size="sm">
-            Last assessment evaluated {lastAssessmentAgo}
+            Last evaluated {lastAssessmentAgo}
           </Text>
         </Flex>
       );


### PR DESCRIPTION
Ticket [ENG-3286]

### Description Of Changes

Wording polish for the Privacy Assessments UI. The original ticket flagged a contradiction
between the evaluation-run "Completed" state and a card showing "In progress" with a
completeness percentage. That structural conflict was already addressed by the recent
"Improve progress feedback on assessment evaluation" work — evaluation-run status and
per-assessment status now live on different surfaces. This PR is a small follow-up to clean
up the remaining wording so the two surfaces are easier to read individually and don't fall
back on stilted or ambiguous labels.

No behavioural or backend changes — labels only.

### Code Changes

* **`AssessmentCard.tsx`** (in-progress state): replaced the `Completeness  X.X%` label /
  value pair with a single sentence — `**X%** of questions answered`. Percent is bolded,
  rounded to an integer, and inlined into the sentence rather than right-aligned.
* **`AssessmentCard.tsx`** (completed state): `Assessment complete` → `Completed`, to match
  the wording used by the status-label constants, the detail-page tag, and the popover tag.
* **`AssessmentTaskStatusIndicator.tsx`**: page-header indicator
  `Last assessment evaluated {timeAgo}` → `Last evaluated {timeAgo}` — removes the
  singular/plural ambiguity (the indicator summarises a batch run, not a single
  assessment).
* **`AssessmentGroup.tsx`**: group header `{n} system(s) • {m} active assessments` →
  `{n} system(s) • {m} assessments` — completed assessments are also listed in each group,
  so "active" was misleading.

### Steps to Confirm

Open the Vercel preview:
<https://fides-plus-nightly-git-eng-3286-fix-status-incons-88c8b1-ethyca.vercel.app/>

1. Go to **Privacy assessments** and confirm each group header reads `{n} system(s) • {m}
   assessments` (no "active").
2. After an evaluation has run, confirm the page-header indicator reads
   `Last evaluated {timeAgo}`.
3. On a card in the in-progress state, confirm the body reads `**X%** of questions
   answered` (bolded percent, integer rounded), with the progress bar and `In progress` /
   `Resume` row underneath.
4. On a completed card, confirm it reads `Completed` (not "Assessment complete"), followed
   by `Completed on {date}` and a `View` button.

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [x] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [x] No migrations
* Documentation:
  * [x] No documentation updates required


[ENG-3286]: https://ethyca.atlassian.net/browse/ENG-3286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ