### PR TITLE
ENG-3000: stop using deprecated /system/{key}/connection endpoints, surface DSR controls

### DIFF
--- a/changelog/8121-fix-integrations-form-deprecated-system-endpoints.yaml
+++ b/changelog/8121-fix-integrations-form-deprecated-system-endpoints.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Fixed SaaS integration creation and edit flows on the new Integrations page by routing off deprecated system-scoped connection endpoints.
+pr: 8121
+labels: []

--- a/changelog/8121-integrations-form-dsr-datasets-picker.yaml
+++ b/changelog/8121-integrations-form-dsr-datasets-picker.yaml
@@ -1,0 +1,4 @@
+type: Added
+description: Added a "Privacy request datasets" picker to the new Integrations form for editing database integrations.
+pr: 8121
+labels: []

--- a/changelog/8121-integrations-form-enable-toggle.yaml
+++ b/changelog/8121-integrations-form-enable-toggle.yaml
@@ -1,4 +1,4 @@
 type: Added
-description: Added an "Enable integration" toggle to the new Integrations form for managing whether an integration is used by privacy requests.
+description: Added an "Enable for privacy requests" toggle to the new Integrations form for controlling whether an integration is used during privacy request execution.
 pr: 8121
 labels: []

--- a/changelog/8121-integrations-form-enable-toggle.yaml
+++ b/changelog/8121-integrations-form-enable-toggle.yaml
@@ -1,0 +1,4 @@
+type: Added
+description: Added an "Enable integration" toggle to the new Integrations form for managing whether an integration is used by privacy requests.
+pr: 8121
+labels: []

--- a/clients/admin-ui/cypress/e2e/integration-management.cy.ts
+++ b/clients/admin-ui/cypress/e2e/integration-management.cy.ts
@@ -199,12 +199,15 @@ describe("Integration management for data detection & discovery", () => {
 
       it("should be able to add a new integration associated with a system", () => {
         stubSystemCrud();
+        cy.intercept("PATCH", "/api/v1/connection", { statusCode: 200 }).as(
+          "patchConnection",
+        );
         cy.intercept("PATCH", "/api/v1/connection/*/secret*", {
           response: 200,
         }).as("patchConnectionSecrets");
-        cy.intercept("PATCH", "/api/v1/system/*/connection", {
-          response: 200,
-        }).as("patchSystemConnection");
+        cy.intercept("PUT", "/api/v1/connection/*/system-links", {
+          statusCode: 200,
+        }).as("setSystemLinks");
         cy.intercept("GET", "/api/v1/system", {
           fixture: "systems/systems.json",
         }).as("getSystems");
@@ -230,7 +233,11 @@ describe("Integration management for data detection & discovery", () => {
           "Fidesctl System",
         );
         cy.getByTestId("save-btn").click();
-        cy.wait("@patchSystemConnection");
+        // Connection is created via the top-level PATCH /connection endpoint and
+        // the system link is reconciled via PUT /connection/{key}/system-links —
+        // the form no longer hits the deprecated PATCH /system/{key}/connection.
+        cy.wait("@patchConnection");
+        cy.wait("@setSystemLinks");
       });
 
       it("should display an API integration under the CRM category", () => {

--- a/clients/admin-ui/src/features/integrations/add-integration/ConfigureIntegrationForm.tsx
+++ b/clients/admin-ui/src/features/integrations/add-integration/ConfigureIntegrationForm.tsx
@@ -22,6 +22,7 @@ import { debounce } from "~/features/common/utils";
 import { useGetConnectionTypeSecretSchemaQuery } from "~/features/connection-type";
 import type { ConnectionTypeSecretSchemaResponse } from "~/features/connection-type/types";
 import { useGetAllFilteredDatasetsQuery } from "~/features/dataset";
+import DatasetSelectOption from "~/features/dataset/DatasetSelectOption";
 import {
   useCreateUnlinkedSassConnectionConfigMutation,
   usePatchDatastoreConnectionMutation,
@@ -166,10 +167,13 @@ export const ConfigureIntegrationForm = ({
     value: d.fides_key,
   }));
 
-  const { patchConnectionDatasetConfig, initialDatasets } =
-    useDatasetConfigField({
-      connectionConfig: connection,
-    });
+  const {
+    patchConnectionDatasetConfig,
+    initialDatasets,
+    dropdownOptions: datasetConfigDropdownOptions,
+  } = useDatasetConfigField({
+    connectionConfig: connection,
+  });
 
   const { getFieldValidation, preprocessValues } =
     useFormFieldsFromSchema(secrets);
@@ -348,7 +352,8 @@ export const ConfigureIntegrationForm = ({
       if (
         connectionPayload &&
         values.dataset &&
-        connectionOption.identifier === ConnectionType.DATAHUB
+        (connectionOption.identifier === ConnectionType.DATAHUB ||
+          (isEditing && connectionOption.type === SystemType.DATABASE))
       ) {
         await patchConnectionDatasetConfig(values, connectionPayload.key, {
           showSuccessAlert: false,
@@ -406,7 +411,8 @@ export const ConfigureIntegrationForm = ({
     if (
       connectionPayload &&
       values.dataset &&
-      connectionOption.identifier === ConnectionType.DATAHUB
+      (connectionOption.identifier === ConnectionType.DATAHUB ||
+        (isEditing && connectionOption.type === SystemType.DATABASE))
     ) {
       await patchConnectionDatasetConfig(values, connectionPayload.key, {
         showSuccessAlert: false,
@@ -533,6 +539,22 @@ export const ConfigureIntegrationForm = ({
                 loading={isLoadingProperties}
                 allowClear
                 placeholder="Select properties..."
+              />
+            </Form.Item>
+          )}
+          {isEditing && connectionOption.type === SystemType.DATABASE && (
+            <Form.Item
+              name="dataset"
+              label="Privacy request datasets"
+              tooltip="Datasets associated with this integration are used during privacy request execution to discover and act on relevant data."
+              className="w-full"
+            >
+              <Select
+                aria-label="Privacy request datasets"
+                data-testid="controlled-select-dataset"
+                mode="multiple"
+                options={datasetConfigDropdownOptions}
+                optionRender={DatasetSelectOption}
               />
             </Form.Item>
           )}

--- a/clients/admin-ui/src/features/integrations/add-integration/ConfigureIntegrationForm.tsx
+++ b/clients/admin-ui/src/features/integrations/add-integration/ConfigureIntegrationForm.tsx
@@ -546,7 +546,7 @@ export const ConfigureIntegrationForm = ({
             <Form.Item
               name="dataset"
               label="Privacy request datasets"
-              tooltip="Datasets associated with this integration are used during privacy request execution to discover and act on relevant data."
+              tooltip="Datasets associated with this integration for privacy request fulfillment."
               className="w-full"
             >
               <Select

--- a/clients/admin-ui/src/features/integrations/add-integration/ConfigureIntegrationForm.tsx
+++ b/clients/admin-ui/src/features/integrations/add-integration/ConfigureIntegrationForm.tsx
@@ -5,6 +5,7 @@ import {
   Input,
   Select,
   Spin,
+  Switch,
   Text,
   useMessage,
 } from "fidesui";
@@ -51,6 +52,10 @@ type FormValues = {
   name: string;
   description: string;
   system_fides_key?: string;
+  // Inverted form of ConnectionConfig.disabled. Controls whether the
+  // integration is used by privacy requests; does not affect discovery
+  // monitors or connection tests.
+  enabled: boolean;
   secrets?: ConnectionSecrets;
   dataset?: string[];
   property_ids?: string[];
@@ -174,6 +179,7 @@ export const ConfigureIntegrationForm = ({
       name: connection?.name ?? "",
       description: connection?.description ?? "",
       system_fides_key: initialSystemFidesKey,
+      enabled: connection ? !connection.disabled : true,
       ...(hasSecrets && {
         secrets: mapValues(secrets?.properties, (s, key) => {
           const value = connection?.secrets?.[key] ?? s.default;
@@ -234,7 +240,7 @@ export const ConfigureIntegrationForm = ({
     const connectionPayload = isEditing
       ? {
           ...connection,
-          disabled: connection.disabled ?? false,
+          disabled: !values.enabled,
           name: values.name,
           description: values.description,
           secrets: undefined,
@@ -246,7 +252,7 @@ export const ConfigureIntegrationForm = ({
             ? ConnectionType.SAAS
             : connectionOption.identifier) as ConnectionType,
           access: AccessLevel.READ,
-          disabled: false,
+          disabled: !values.enabled,
           description: values.description,
           secrets: processedValues.secrets,
           dataset: values.dataset,
@@ -480,6 +486,15 @@ export const ConfigureIntegrationForm = ({
           </Form.Item>
           <Form.Item name="description" label="Description" className="w-full">
             <Input data-testid="input-description" />
+          </Form.Item>
+          <Form.Item
+            name="enabled"
+            label="Enable integration"
+            tooltip="When enabled, this integration is used to fulfill privacy requests. Disabling excludes it from privacy request execution; it has no effect on discovery monitors or connection tests."
+            valuePropName="checked"
+            className="w-full"
+          >
+            <Switch data-testid="input-enabled" />
           </Form.Item>
           {connectionOption.identifier !== ConnectionType.MANUAL_TASK &&
             connectionOption.identifier !== ConnectionType.JIRA_TICKET &&

--- a/clients/admin-ui/src/features/integrations/add-integration/ConfigureIntegrationForm.tsx
+++ b/clients/admin-ui/src/features/integrations/add-integration/ConfigureIntegrationForm.tsx
@@ -30,10 +30,7 @@ import { useDatasetConfigField } from "~/features/datastore-connections/system_p
 import { formatKey } from "~/features/datastore-connections/system_portal_config/helpers";
 import { useSetSystemLinksMutation } from "~/features/integrations/system-links.slice";
 import { useIntegrationPropertySelect } from "~/features/properties/useIntegrationPropertySelect";
-import {
-  useGetSystemsQuery,
-  usePatchSystemConnectionConfigsMutation,
-} from "~/features/system";
+import { useGetSystemsQuery } from "~/features/system";
 import {
   AccessLevel,
   BigQueryDocsSchema,
@@ -88,8 +85,6 @@ export const ConfigureIntegrationForm = ({
   ] = usePatchDatastoreConnectionSecretsMutation();
   const [patchDatastoreConnectionsTrigger, { isLoading: patchIsLoading }] =
     usePatchDatastoreConnectionMutation();
-  const [patchSystemConnectionsTrigger, { isLoading: systemPatchIsLoading }] =
-    usePatchSystemConnectionConfigsMutation();
   const router = useRouter();
 
   const [createUnlinkedSassConnectionConfigTrigger] =
@@ -260,14 +255,18 @@ export const ConfigureIntegrationForm = ({
             : {}),
         };
 
-    // if system is attached, use patch request that attaches to system
+    // Two-step approach for both create and edit, intentionally avoiding the
+    // deprecated /system/{key}/connection endpoints (atomic but conflate the
+    // connection and link, and don't compose with multi-integration systems):
+    //   1. Create or update the connection config via the top-level endpoints.
+    //      For new SaaS connections this is POST /connection/instantiate/{type}
+    //      (createUnlinkedSassConnectionConfig) which builds the connection,
+    //      saas_config, and dataset from the template. For everything else
+    //      (non-SaaS create, all edits) it's PATCH /connection.
+    //   2. Reconcile the system link state via PUT /connection/{key}/system-links
+    //      below — only if the desired state differs from the initial state.
     let patchResult;
-    if (values.system_fides_key) {
-      patchResult = await patchSystemConnectionsTrigger({
-        systemFidesKey: values.system_fides_key,
-        connectionConfigs: [connectionPayload],
-      });
-    } else if (isSaas && !isEditing) {
+    if (!isEditing && isSaas) {
       patchResult = await createUnlinkedSassConnectionConfigTrigger({
         ...connectionPayload,
         instance_key: formatKey(values.name),
@@ -287,26 +286,37 @@ export const ConfigureIntegrationForm = ({
       messageApi.error(patchErrorMsg);
       return;
     }
-    if (!hasSecrets || !values.secrets) {
-      // Link system if provided (using system-links API)
-      if (values.system_fides_key && connectionPayload.key) {
-        try {
-          await setSystemLinks({
-            connectionKey: connectionPayload.key,
-            body: {
-              links: [
-                {
-                  system_fides_key: values.system_fides_key,
-                },
-              ],
-            },
-          }).unwrap();
-        } catch (error) {
-          messageApi.error(
-            "Integration saved but system linking failed. You can link it later.",
-          );
-        }
+    // Reconcile the system link state via PUT /connection/{key}/system-links —
+    // but only when the desired state differs from the initial state. The
+    // endpoint is idempotent, so this is purely a no-op-skip optimisation.
+    const desiredSystemFidesKey = values.system_fides_key || undefined;
+    const linkStateChanged = desiredSystemFidesKey !== initialSystemFidesKey;
+    const reconcileSystemLink = async () => {
+      if (!linkStateChanged || !connectionPayload.key) {
+        return;
       }
+      try {
+        await setSystemLinks({
+          connectionKey: connectionPayload.key,
+          body: {
+            links: desiredSystemFidesKey
+              ? [{ system_fides_key: desiredSystemFidesKey }]
+              : [],
+          },
+        }).unwrap();
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error("Failed to reconcile system link:", error);
+        messageApi.error(
+          isEditing
+            ? "Failed to update the system link for this integration. The integration was saved, please try again."
+            : "Integration saved but system linking failed. You can link it later.",
+        );
+      }
+    };
+
+    if (!hasSecrets || !values.secrets) {
+      await reconcileSystemLink();
 
       // Save property assignments if editing
       if (isEditing && values.property_ids !== undefined && hasDatasets) {
@@ -373,28 +383,7 @@ export const ConfigureIntegrationForm = ({
       `Integration secret ${isEditing ? "updated" : "created"} successfully`,
     );
 
-    // If a system is provided, link it to the integration
-    if (values.system_fides_key && connectionPayload.key) {
-      try {
-        await setSystemLinks({
-          connectionKey: connectionPayload.key,
-          body: {
-            links: [
-              {
-                system_fides_key: values.system_fides_key,
-              },
-            ],
-          },
-        }).unwrap();
-      } catch (error) {
-        // Log error but don't fail the form submission
-        // eslint-disable-next-line no-console
-        console.error("Failed to link system:", error);
-        messageApi.error(
-          "Failed to link this integration to a system.  The integration was saved, please try again.",
-        );
-      }
-    }
+    await reconcileSystemLink();
 
     onClose();
 
@@ -419,7 +408,7 @@ export const ConfigureIntegrationForm = ({
     }
   };
 
-  const loading = secretsIsLoading || patchIsLoading || systemPatchIsLoading;
+  const loading = secretsIsLoading || patchIsLoading;
 
   // Form state tracking for parent component
   const allValues = Form.useWatch([], form);

--- a/clients/admin-ui/src/features/integrations/add-integration/ConfigureIntegrationForm.tsx
+++ b/clients/admin-ui/src/features/integrations/add-integration/ConfigureIntegrationForm.tsx
@@ -489,8 +489,8 @@ export const ConfigureIntegrationForm = ({
           </Form.Item>
           <Form.Item
             name="enabled"
-            label="Enable integration"
-            tooltip="When enabled, this integration is used to fulfill privacy requests. Disabling excludes it from privacy request execution; it has no effect on discovery monitors or connection tests."
+            label="Enable for privacy requests"
+            tooltip="When enabled, this integration is used during privacy request execution."
             valuePropName="checked"
             className="w-full"
           >

--- a/src/fides/api/models/connectionconfig.py
+++ b/src/fides/api/models/connectionconfig.py
@@ -208,6 +208,12 @@ class ConnectionConfig(Base):
     )  # Type bytes in the db
     last_test_timestamp = Column(DateTime(timezone=True))
     last_test_succeeded = Column(Boolean)
+    # When True, this connection is excluded from privacy request (DSR)
+    # execution — see graph_task.skip_if_disabled, the request runner's
+    # collection / dataset filters, and the manual-webhook DSR utilities.
+    # It does NOT exclude the connection from discovery monitors, connection
+    # tests, or any non-DSR consumer; those have their own enable/disable
+    # controls.
     disabled = Column(Boolean, server_default="f", default=False)
     disabled_at = Column(DateTime(timezone=True))
 

--- a/src/fides/api/schemas/connection_configuration/connection_config.py
+++ b/src/fides/api/schemas/connection_configuration/connection_config.py
@@ -32,6 +32,9 @@ class CreateConnectionConfiguration(BaseModel):
     key: Optional[FidesKey] = None
     connection_type: ConnectionType
     access: AccessLevel
+    # See ConnectionConfig.disabled — excludes the connection from privacy
+    # request (DSR) execution only; does not affect discovery monitors or
+    # connection tests.
     disabled: Optional[bool] = False
     description: Optional[str] = None
     model_config = ConfigDict(
@@ -100,6 +103,9 @@ class ConnectionConfigurationResponseBase(ConnectionConfigSecretsMixin):
     access: AccessLevel
     created_at: datetime
     updated_at: Optional[datetime] = None
+    # See ConnectionConfig.disabled — excludes the connection from privacy
+    # request (DSR) execution only; does not affect discovery monitors or
+    # connection tests.
     disabled: Optional[bool] = False
     last_test_timestamp: Optional[datetime] = None
     last_test_succeeded: Optional[bool] = None


### PR DESCRIPTION
Ticket [ENG-3000]

### Description Of Changes

Four related changes to `ConfigureIntegrationForm` (the new top-level Integrations page):

**1. Stop using deprecated `/system/{key}/connection` endpoints.** The form was wired to two system-scoped, deprecated endpoints that conflate connection lifecycle with system linking:

- `PATCH /system/{fides_key}/connection`
- `POST /(plus/)system/{fides_key}/connection/instantiate/{type}`

Both bake a single system into the connection-create/update call. That implicitly assumes one-integration-per-system semantics, and now that the linking refactor (#7432) supports multiple integrations per system, the system-scoped endpoints don't compose cleanly. The most visible symptom is the bug reported in ENG-3000: creating a SaaS integration with a system selected on the new Integrations page errors out / produces an incomplete connection. The patch path was made SaaS-aware in #7978, but it routes to template instantiation only when both `connection_type == 'saas'` AND `secrets` is truthy ([connection_service.py:476](https://github.com/ethyca/fides/blob/main/src/fides/service/connection/connection_service.py#L476)), so a SaaS connector with no required secrets falls through to the standard path and never builds a `saas_config` or dataset.

The deprecation notes on both system-scoped endpoints already point at the right replacement: do connection work via the top-level `/connection` endpoints, then manage links via `PUT /connection/{key}/system-links`.

`handleSubmit` is refactored to that two-step flow:

1. **Create / update the connection** without any system context. New SaaS connections go through `POST /connection/instantiate/{type}` (`createUnlinkedSassConnectionConfig`); everything else (non-SaaS create, all edits) goes through `PATCH /connection` (`patchDatastoreConnection`).
2. **Reconcile the system link** via `PUT /connection/{key}/system-links` — but only when the desired state differs from `initialSystemFidesKey`, so common edits (e.g. updating only secrets) skip a redundant idempotent call. Passing `links: []` correctly unlinks, fixing the secondary bug where clearing the System field on edit silently left the prior link in place.

The form no longer references `usePatchSystemConnectionConfigsMutation`, `useCreatePlusSaasConnectionConfigMutation`, or `useCreateSassConnectionConfigMutation`.

**2. Add an "Enable for privacy requests" toggle.** The System → Integrations form already exposes the equivalent control via `ConnectorParametersForm`, backed by `ConnectionConfig.disabled`. The new top-level Integrations form was missing it, so once an integration was created its DSR-usage state could only be flipped by going back through the System page. Added a `Switch` to `ConfigureIntegrationForm` (always visible, defaults to enabled, saved with the rest of the form on Save). Label and tooltip make the privacy-request scope visible in the form itself.

**3. Add a "Privacy request datasets" picker.** Mirrors the dataset picker in System → Integrations: edit-only, gated to `SystemType.DATABASE` integrations, backed by the existing `useDatasetConfigField` hook and the same `PUT /connection/{key}/datasetconfig` endpoint. DataHub keeps its own BigQuery-filtered picker untouched.

**4. Document `ConnectionConfig.disabled` as a DSR-scoped flag.** It excludes the connection from privacy request execution only — discovery monitors, connection tests, and other non-DSR consumers all have their own enable/disable controls. Added comments to the model column and the two related Pydantic schemas. No behaviour change.

### Code Changes

- `clients/admin-ui/src/features/integrations/add-integration/ConfigureIntegrationForm.tsx`:
  - Drop imports/hook calls for the three system-scoped mutations and the now-unused `systemPatchIsLoading`.
  - Replace the three-way connection-creation branch with a binary one: SaaS-create → `createUnlinkedSassConnectionConfig`, everything else → `patchDatastoreConnection`.
  - Extract a single `reconcileSystemLink()` helper that fires only when `values.system_fides_key !== initialSystemFidesKey`, sends `[]` to unlink, and consolidates the two prior `setSystemLinks` invocations.
  - Add an `enabled` form field (Switch) backed by `!ConnectionConfig.disabled`; default `true` for new integrations, mirror existing connection state on edit; route the value into the patch payload as `disabled: !values.enabled`.
  - Add a "Privacy request datasets" `Form.Item` for `SystemType.DATABASE` integrations on edit, using `useDatasetConfigField`'s `dropdownOptions` and the shared `DatasetSelectOption` renderer; extend the `patchConnectionDatasetConfig` calls in `handleSubmit` to fire for both DataHub and DATABASE-type edits.
- `src/fides/api/models/connectionconfig.py`: comment on the `disabled` column documenting that it gates DSR execution only.
- `src/fides/api/schemas/connection_configuration/connection_config.py`: matching comments on `CreateConnectionConfiguration.disabled` and `ConnectionConfigurationResponse.disabled`.

### Steps to Confirm

In the new top-level Integrations management UI (`/integrations`):

1. **Create a SaaS integration linked to a system** (e.g. Stripe). Pick a system from the System dropdown. Submit and confirm the integration is created, the system link shows on the detail page, and a corresponding `DatasetConfig` exists. Network tab: `POST /api/v1/connection/instantiate/{type}` then `PUT /api/v1/connection/{key}/system-links`. No call to `/system/{key}/connection`.
2. **Repeat with a system that already has another integration linked** to it. Confirm both integrations end up linked to the system (no replacement, no errors).
3. **Edit an existing linked integration → change name/description only** (don't touch the System field). Confirm `setSystemLinks` is **not** called (no-op skip).
4. **Edit an existing linked integration → clear the System field** and save. Confirm the system link is removed (`GET /api/v1/connection/{key}/system-links` returns `[]`).
5. **Edit an existing linked integration → change to a different system**. Confirm the link is replaced.
6. **Create a non-SaaS integration with a system** (e.g. Postgres). Should now go through `PATCH /connection` followed by `setSystemLinks`. Connection works and is linked.
7. **Create a SaaS integration with no required secrets** (the original bug — a connector type whose secrets schema has no required fields, with a system selected). Confirm a `saas_config` and dataset are created.
8. **Enable toggle, create flow.** New integrations default to enabled; toggling off before save persists `disabled: true` on the connection.
9. **Enable toggle, edit flow.** Toggling the switch and saving updates `connection.disabled` (verify via `GET /api/v1/connection/{key}`). Confirm a privacy request that would have hit this connection now skips it (e.g. `graph_task.skip_if_disabled` raises `CollectionDisabled`).
10. **Datasets picker, database integration.** Edit a BigQuery integration. The "Privacy request datasets" multi-select shows currently linked datasets plus any unlinked ones; selecting a new combination and saving updates the connection's `DatasetConfig` set.

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [x] No migrations
* Documentation:
  * [x] No documentation updates required

[ENG-3000]: https://ethyca.atlassian.net/browse/ENG-3000

🤖 Generated with [Claude Code](https://claude.com/claude-code)