### PR TITLE
feat(form-builder): free field reordering via field_order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.84.0..main)
 
+### Added
+- Privacy center form builder: free reordering of identity and custom fields via a new `field_order` array on each privacy request action, persisted end-to-end through the form builder, the privacy center renderer, and admin/property APIs.
+
+### Deprecated
+- `custom_privacy_request_field_order` on privacy center actions — superseded by `field_order`, which orders identity and custom fields jointly. Existing configs continue to read correctly.
+
 ## [2.84.0](https://github.com/ethyca/fides/compare/2.83.3..2.84.0)
 
 ### Added

--- a/clients/admin-ui/cypress/e2e/properties/form-builder.cy.ts
+++ b/clients/admin-ui/cypress/e2e/properties/form-builder.cy.ts
@@ -111,7 +111,66 @@ describe("Privacy center form builder", () => {
       .should("be.visible");
   });
 
-  // ── Test 2: dropped-features acknowledgement ────────────────────────────────
+  // ── Test 2: field_order persists across save ────────────────────────────────
+  it("saves field_order so a custom field can sit between identity fields", () => {
+    // Spec places `reason` between Email and Phone — i.e. the legacy
+    // hardcoded name → email → phone → customs ordering can't represent this.
+    const spec = {
+      root: "form",
+      elements: {
+        form: {
+          type: "Form",
+          props: {},
+          children: ["f_email", "f_reason", "f_phone"],
+        },
+        f_email: { type: "Email", props: { required: true }, children: [] },
+        f_reason: {
+          type: "Text",
+          props: { name: "reason", label: "Reason", required: false },
+          children: [],
+        },
+        f_phone: { type: "Phone", props: { required: false }, children: [] },
+      },
+    };
+
+    cy.intercept(
+      "POST",
+      `/api/v1/plus/property/${PROPERTY_ID}/form-builder/chat`,
+      {
+        statusCode: 200,
+        headers: { "content-type": "text/event-stream" },
+        body: buildSseBody(spec),
+      },
+    ).as("chatTurn");
+
+    cy.intercept("PUT", `/api/v1/plus/property/${PROPERTY_ID}`, {
+      statusCode: 200,
+      body: buildPropertyFixture(),
+    }).as("savePut");
+
+    cy.visit(`/properties/${PROPERTY_ID}/forms/${POLICY_KEY}`);
+    cy.wait("@getProperty");
+
+    cy.findByPlaceholderText(/tell the builder/i).type(
+      "Add a reason field between email and phone",
+    );
+    cy.findByRole("button", { name: /^send$/i }).click();
+    cy.wait("@chatTurn");
+
+    cy.findByRole("button", { name: /^save$/i }).click();
+    cy.wait("@savePut").then((interception) => {
+      const action = (
+        interception.request.body.privacy_center_config.actions ?? []
+      ).find((a: { policy_key?: string }) => a.policy_key === POLICY_KEY);
+      expect(action.field_order).to.deep.equal(["email", "reason", "phone"]);
+      // Deprecated key should not be re-emitted on save.
+      expect(action).not.to.have.property(
+        "custom_privacy_request_field_order",
+      );
+    });
+  });
+
+  // ── Test 3: dropped-features acknowledgement ────────────────────────────────
   it("warns and gates save when conditional logic is present", () => {
     const spec = buildSpec({
       f_state: {

--- a/clients/admin-ui/cypress/e2e/properties/form-builder.cy.ts
+++ b/clients/admin-ui/cypress/e2e/properties/form-builder.cy.ts
@@ -164,9 +164,7 @@ describe("Privacy center form builder", () => {
       ).find((a: { policy_key?: string }) => a.policy_key === POLICY_KEY);
       expect(action.field_order).to.deep.equal(["email", "reason", "phone"]);
       // Deprecated key should not be re-emitted on save.
-      expect(action).not.to.have.property(
-        "custom_privacy_request_field_order",
-      );
+      expect(action).not.to.have.property("custom_privacy_request_field_order");
     });
   });
 

--- a/clients/admin-ui/src/features/properties/privacy-center-config/form-builder/FormBuilderPage.tsx
+++ b/clients/admin-ui/src/features/properties/privacy-center-config/form-builder/FormBuilderPage.tsx
@@ -35,6 +35,7 @@ interface ActionShape {
   cancelButtonText?: string | null;
   custom_privacy_request_fields?: PcCustomFields;
   identity_inputs?: Record<string, "required" | "optional"> | null;
+  field_order?: string[] | null;
   // eslint-disable-next-line no-underscore-dangle
   _form_builder_spec?: { spec: JsonRenderSpec; version: number };
 }
@@ -55,6 +56,7 @@ interface FormBuilderPageProps {
     actionPolicyKey: string;
     pcShape: PcCustomFields;
     identityInputs: Record<string, "required" | "optional">;
+    fieldOrder: string[];
     richSpec: JsonRenderSpec;
   }) => Promise<void>;
 }
@@ -127,6 +129,7 @@ export const FormBuilderPage = ({
       return synthesizeSpecFromPcShape(
         action.custom_privacy_request_fields ?? {},
         action.identity_inputs,
+        action.field_order,
       );
     }
     // No saved fields yet — seed with the standard DSR defaults so the
@@ -328,6 +331,7 @@ export const FormBuilderPage = ({
         actionPolicyKey,
         pcShape: result.pcShape,
         identityInputs: result.identityInputs,
+        fieldOrder: result.fieldOrder,
         richSpec: builder.spec,
       });
       // Save just wrote rich + legacy in lockstep, so any prior drift is

--- a/clients/admin-ui/src/features/properties/privacy-center-config/form-builder/__tests__/mapper.test.ts
+++ b/clients/admin-ui/src/features/properties/privacy-center-config/form-builder/__tests__/mapper.test.ts
@@ -181,6 +181,69 @@ describe("mapSpecToPcShape", () => {
     expect(result.pcShape.notes.placeholder).toBeUndefined();
   });
 
+  it("emits fieldOrder reflecting children order across identity and custom fields", () => {
+    const spec = buildSpec(
+      {
+        f_email: { type: "Email", props: { required: true }, children: [] },
+        f_reason: {
+          type: "Text",
+          props: { name: "reason", label: "Reason", required: false },
+          children: [],
+        },
+        f_name: { type: "Name", props: { required: false }, children: [] },
+        f_topics: {
+          type: "MultiSelect",
+          props: {
+            name: "topics",
+            label: "Topics",
+            required: false,
+            options: ["A", "B"],
+          },
+          children: [],
+        },
+      },
+      ["f_email", "f_reason", "f_name", "f_topics"],
+    );
+
+    const result = mapSpecToPcShape(spec);
+
+    expect(result.errors).toEqual([]);
+    expect(result.fieldOrder).toEqual(["email", "reason", "name", "topics"]);
+    expect(result.identityInputs).toEqual({ email: "required", name: "optional" });
+    expect(Object.keys(result.pcShape)).toEqual(["reason", "topics"]);
+  });
+
+  it("returns an empty fieldOrder when the spec has no children", () => {
+    const spec = buildSpec({}, []);
+    const result = mapSpecToPcShape(spec);
+    expect(result.fieldOrder).toEqual([]);
+  });
+
+  it("excludes unknown components from fieldOrder while reporting them as dropped", () => {
+    const spec = buildSpec(
+      {
+        ok: {
+          type: "Text",
+          props: { name: "notes", label: "Notes", required: false },
+          children: [],
+        },
+        weird: {
+          type: "Mystery",
+          props: {},
+          children: [],
+        },
+      },
+      ["ok", "weird"],
+    );
+
+    const result = mapSpecToPcShape(spec);
+
+    expect(result.fieldOrder).toEqual(["notes"]);
+    expect(result.droppedFeatures.map((d) => d.kind)).toContain(
+      "unknown_component",
+    );
+  });
+
   it("translates json-render `visible` into legacy `visible_when` and does not drop it", () => {
     const spec = buildSpec(
       {

--- a/clients/admin-ui/src/features/properties/privacy-center-config/form-builder/__tests__/mapper.test.ts
+++ b/clients/admin-ui/src/features/properties/privacy-center-config/form-builder/__tests__/mapper.test.ts
@@ -209,7 +209,10 @@ describe("mapSpecToPcShape", () => {
 
     expect(result.errors).toEqual([]);
     expect(result.fieldOrder).toEqual(["email", "reason", "name", "topics"]);
-    expect(result.identityInputs).toEqual({ email: "required", name: "optional" });
+    expect(result.identityInputs).toEqual({
+      email: "required",
+      name: "optional",
+    });
     expect(Object.keys(result.pcShape)).toEqual(["reason", "topics"]);
   });
 

--- a/clients/admin-ui/src/features/properties/privacy-center-config/form-builder/__tests__/synthesize.test.ts
+++ b/clients/admin-ui/src/features/properties/privacy-center-config/form-builder/__tests__/synthesize.test.ts
@@ -52,4 +52,110 @@ describe("synthesizeSpecFromPcShape", () => {
     expect(back.pcShape.country.field_type).toBe("location");
     expect(back.pcShape.contact_method.field_type).toBe("radio");
   });
+
+  it("uses fieldOrder when provided, interleaving identity and custom fields", () => {
+    const pcShape = {
+      reason: { label: "Reason", field_type: "text" as const, required: false },
+      topics: {
+        label: "Topics",
+        field_type: "multiselect" as const,
+        options: ["A", "B"],
+        required: false,
+      },
+    };
+    const identityInputs = {
+      email: "required" as const,
+      name: "optional" as const,
+    };
+    const fieldOrder = ["email", "reason", "name", "topics"];
+
+    const spec = synthesizeSpecFromPcShape(pcShape, identityInputs, fieldOrder);
+
+    expect(spec.elements.form.children).toEqual([
+      "f_email",
+      "f_reason",
+      "f_name",
+      "f_topics",
+    ]);
+    const back = mapSpecToPcShape(spec);
+    expect(back.fieldOrder).toEqual(["email", "reason", "name", "topics"]);
+  });
+
+  it("falls back to legacy ordering when fieldOrder is absent", () => {
+    const pcShape = {
+      reason: { label: "Reason", field_type: "text" as const, required: false },
+    };
+    const identityInputs = {
+      phone: "optional" as const,
+      email: "required" as const,
+      name: "optional" as const,
+    };
+
+    const spec = synthesizeSpecFromPcShape(pcShape, identityInputs);
+
+    // Canonical legacy order: name → email → phone → customs.
+    expect(spec.elements.form.children).toEqual([
+      "f_name",
+      "f_email",
+      "f_phone",
+      "f_reason",
+    ]);
+  });
+
+  it("appends configured fields missing from fieldOrder using legacy fallback", () => {
+    const pcShape = {
+      reason: { label: "Reason", field_type: "text" as const, required: false },
+      topics: {
+        label: "Topics",
+        field_type: "multiselect" as const,
+        options: ["A"],
+        required: false,
+      },
+    };
+    const identityInputs = { email: "required" as const };
+    const fieldOrder = ["reason", "email"]; // `topics` configured but absent from order
+
+    const spec = synthesizeSpecFromPcShape(pcShape, identityInputs, fieldOrder);
+
+    expect(spec.elements.form.children).toEqual([
+      "f_reason",
+      "f_email",
+      "f_topics",
+    ]);
+  });
+
+  it("skips unknown keys in fieldOrder rather than crashing on stale data", () => {
+    const pcShape = {
+      reason: { label: "Reason", field_type: "text" as const, required: false },
+    };
+    const identityInputs = { email: "required" as const };
+    const fieldOrder = ["email", "ghost_field", "reason"];
+
+    const spec = synthesizeSpecFromPcShape(pcShape, identityInputs, fieldOrder);
+
+    expect(spec.elements.form.children).toEqual(["f_email", "f_reason"]);
+  });
+
+  it("preserves arbitrary order via a synthesize → map round trip", () => {
+    const pcShape = {
+      reason: { label: "Reason", field_type: "text" as const, required: false },
+      topics: {
+        label: "Topics",
+        field_type: "multiselect" as const,
+        options: ["A"],
+        required: false,
+      },
+    };
+    const identityInputs = {
+      email: "required" as const,
+      name: "optional" as const,
+      phone: "optional" as const,
+    };
+    const fieldOrder = ["topics", "email", "phone", "reason", "name"];
+
+    const spec = synthesizeSpecFromPcShape(pcShape, identityInputs, fieldOrder);
+    const back = mapSpecToPcShape(spec);
+
+    expect(back.fieldOrder).toEqual(fieldOrder);
+  });
 });

--- a/clients/admin-ui/src/features/properties/privacy-center-config/form-builder/mapper.ts
+++ b/clients/admin-ui/src/features/properties/privacy-center-config/form-builder/mapper.ts
@@ -77,6 +77,11 @@ export type ValidationError =
 export interface MapResult {
   pcShape: PcCustomFields;
   identityInputs: Record<string, "required" | "optional">;
+  // Unified render order across identity_inputs and pcShape, in the order the
+  // form builder's children list resolved. Persisted as `field_order` on the
+  // privacy center action so the public renderer can interleave identity and
+  // custom fields freely. Empty if the spec has no children.
+  fieldOrder: string[];
   droppedFeatures: DroppedFeature[];
   errors: ValidationError[];
 }
@@ -204,11 +209,12 @@ export function mapSpecToPcShape(spec: JsonRenderSpec): MapResult {
   const errors: ValidationError[] = [];
   const pcShape: PcCustomFields = {};
   const identityInputs: Record<string, "required" | "optional"> = {};
+  const fieldOrder: string[] = [];
 
   const root = spec.elements?.[spec.root];
   if (!root || root.type !== "Form") {
     errors.push({ kind: "missing_form_root", rootId: spec.root });
-    return { pcShape, identityInputs, droppedFeatures, errors };
+    return { pcShape, identityInputs, fieldOrder, droppedFeatures, errors };
   }
 
   const seenNames: Record<string, string[]> = {};
@@ -260,6 +266,7 @@ export function mapSpecToPcShape(spec: JsonRenderSpec): MapResult {
       }
       const { required } = validation.data as { required: boolean };
       identityInputs[identityKey] = required ? "required" : "optional";
+      fieldOrder.push(identityKey);
       return;
     }
 
@@ -380,6 +387,7 @@ export function mapSpecToPcShape(spec: JsonRenderSpec): MapResult {
       }
     }
     pcShape[name] = pcField;
+    fieldOrder.push(name);
   });
 
   Object.entries(seenNames).forEach(([name, ids]) => {
@@ -388,5 +396,5 @@ export function mapSpecToPcShape(spec: JsonRenderSpec): MapResult {
     }
   });
 
-  return { pcShape, identityInputs, droppedFeatures, errors };
+  return { pcShape, identityInputs, fieldOrder, droppedFeatures, errors };
 }

--- a/clients/admin-ui/src/features/properties/privacy-center-config/form-builder/synthesize.ts
+++ b/clients/admin-ui/src/features/properties/privacy-center-config/form-builder/synthesize.ts
@@ -38,118 +38,170 @@ const visibilityToJsonRender = (
     return entry;
   });
 
+const buildIdentityElement = (
+  identityKey: string,
+  mode: "required" | "optional",
+): JsonRenderSpec["elements"][string] => ({
+  type: IDENTITY_COMPONENT_FOR_KEY[identityKey],
+  props: { required: mode === "required" },
+  children: [],
+});
+
+const buildCustomElement = (
+  name: string,
+  field: PcCustomField,
+): JsonRenderSpec["elements"][string] => {
+  const componentType = COMPONENT_FOR_FIELD[field.field_type];
+  const props: Record<string, unknown> = {
+    name,
+    label: field.label,
+    required: field.required ?? false,
+  };
+  if (field.placeholder !== undefined) {
+    props.placeholder = field.placeholder;
+  }
+
+  switch (field.field_type) {
+    case "text": {
+      const text = field as PcTextField;
+      if (text.default_value !== undefined && text.default_value !== null) {
+        props.default_value = text.default_value;
+      }
+      if (text.hidden !== undefined) {
+        props.hidden = text.hidden;
+      }
+      if (
+        text.query_param_key !== undefined &&
+        text.query_param_key !== null
+      ) {
+        props.query_param_key = text.query_param_key;
+      }
+      break;
+    }
+    case "select": {
+      const sel = field as PcSelectField;
+      props.options = sel.options;
+      if (sel.default_value !== undefined && sel.default_value !== null) {
+        props.default_value = sel.default_value;
+      }
+      break;
+    }
+    case "radio": {
+      const rad = field as PcRadioField;
+      props.options = rad.options;
+      if (rad.default_value !== undefined && rad.default_value !== null) {
+        props.default_value = rad.default_value;
+      }
+      break;
+    }
+    case "multiselect": {
+      const ms = field as PcMultiSelectField;
+      props.options = ms.options;
+      if (ms.default_value !== undefined && ms.default_value !== null) {
+        props.default_value = ms.default_value;
+      }
+      break;
+    }
+    case "location": {
+      const loc = field as PcLocationField;
+      if (loc.options !== undefined) {
+        props.options = loc.options;
+      }
+      if (loc.ip_geolocation_hint !== undefined) {
+        props.ip_geolocation_hint = loc.ip_geolocation_hint;
+      }
+      break;
+    }
+    default: {
+      const exhaustive: never = field;
+      throw new Error(
+        `Unhandled field type: ${(exhaustive as PcCustomField).field_type}`,
+      );
+    }
+  }
+
+  const element: JsonRenderSpec["elements"][string] = {
+    type: componentType,
+    props,
+    children: [],
+  };
+  if (field.visible_when && field.visible_when.length > 0) {
+    (element as { visible?: unknown }).visible = visibilityToJsonRender(
+      field.visible_when,
+    );
+  }
+  return element;
+};
+
 export function synthesizeSpecFromPcShape(
   pcShape: PcCustomFields,
   identityInputs?: Record<string, "required" | "optional"> | null,
+  fieldOrder?: string[] | null,
 ): JsonRenderSpec {
   const elements: JsonRenderSpec["elements"] = {
     form: { type: "Form", props: {}, children: [] },
   };
-
   const childIds: string[] = [];
+  const seenKeys = new Set<string>();
 
-  // Seed identity fields first, in canonical order, for any that are present.
+  // When fieldOrder is provided, render keys in that exact sequence so identity
+  // and custom fields can interleave freely. Any keys configured but missing
+  // from fieldOrder fall through to the legacy ordering at the end (so a
+  // hand-edited YAML adding a field without updating field_order still shows it).
+  if (fieldOrder && fieldOrder.length > 0) {
+    fieldOrder.forEach((key) => {
+      if (seenKeys.has(key)) {
+        return;
+      }
+      const elementId = `f_${key}`;
+      if (key in IDENTITY_COMPONENT_FOR_KEY) {
+        const mode = identityInputs?.[key];
+        if (mode !== "required" && mode !== "optional") {
+          return;
+        }
+        elements[elementId] = buildIdentityElement(key, mode);
+        childIds.push(elementId);
+        seenKeys.add(key);
+        return;
+      }
+      const customField = pcShape[key];
+      if (customField) {
+        elements[elementId] = buildCustomElement(key, customField);
+        childIds.push(elementId);
+        seenKeys.add(key);
+      }
+      // Unknown key (neither identity nor custom): skipped silently. Backend
+      // validation rejects this case at save time; we don't crash on stale data.
+    });
+  }
+
+  // Legacy default order for keys not covered by fieldOrder: identity first
+  // (name → email → phone), then customs in pcShape iteration order.
   if (identityInputs) {
     (["name", "email", "phone"] as const).forEach((key) => {
+      if (seenKeys.has(key)) {
+        return;
+      }
       const mode = identityInputs[key];
       if (mode === "required" || mode === "optional") {
         const elementId = `f_${key}`;
+        elements[elementId] = buildIdentityElement(key, mode);
         childIds.push(elementId);
-        elements[elementId] = {
-          type: IDENTITY_COMPONENT_FOR_KEY[key],
-          props: { required: mode === "required" },
-          children: [],
-        };
+        seenKeys.add(key);
       }
     });
   }
 
   Object.entries(pcShape).forEach(([name, field]) => {
+    if (seenKeys.has(name)) {
+      return;
+    }
     const elementId = `f_${name}`;
+    elements[elementId] = buildCustomElement(name, field);
     childIds.push(elementId);
-
-    const componentType = COMPONENT_FOR_FIELD[field.field_type];
-    const props: Record<string, unknown> = {
-      name,
-      label: field.label,
-      required: field.required ?? false,
-    };
-    if (field.placeholder !== undefined) {
-      props.placeholder = field.placeholder;
-    }
-
-    switch (field.field_type) {
-      case "text": {
-        const text = field as PcTextField;
-        if (text.default_value !== undefined && text.default_value !== null) {
-          props.default_value = text.default_value;
-        }
-        if (text.hidden !== undefined) {
-          props.hidden = text.hidden;
-        }
-        if (
-          text.query_param_key !== undefined &&
-          text.query_param_key !== null
-        ) {
-          props.query_param_key = text.query_param_key;
-        }
-        break;
-      }
-      case "select": {
-        const sel = field as PcSelectField;
-        props.options = sel.options;
-        if (sel.default_value !== undefined && sel.default_value !== null) {
-          props.default_value = sel.default_value;
-        }
-        break;
-      }
-      case "radio": {
-        const rad = field as PcRadioField;
-        props.options = rad.options;
-        if (rad.default_value !== undefined && rad.default_value !== null) {
-          props.default_value = rad.default_value;
-        }
-        break;
-      }
-      case "multiselect": {
-        const ms = field as PcMultiSelectField;
-        props.options = ms.options;
-        if (ms.default_value !== undefined && ms.default_value !== null) {
-          props.default_value = ms.default_value;
-        }
-        break;
-      }
-      case "location": {
-        const loc = field as PcLocationField;
-        if (loc.options !== undefined) {
-          props.options = loc.options;
-        }
-        if (loc.ip_geolocation_hint !== undefined) {
-          props.ip_geolocation_hint = loc.ip_geolocation_hint;
-        }
-        break;
-      }
-      default: {
-        const exhaustive: never = field;
-        throw new Error(
-          `Unhandled field type: ${(exhaustive as PcCustomField).field_type}`,
-        );
-      }
-    }
-
-    const element: JsonRenderSpec["elements"][string] = {
-      type: componentType,
-      props,
-      children: [],
-    };
-    if (field.visible_when && field.visible_when.length > 0) {
-      (element as { visible?: unknown }).visible = visibilityToJsonRender(
-        field.visible_when,
-      );
-    }
-    elements[elementId] = element;
+    seenKeys.add(name);
   });
-  elements.form.children = childIds;
 
+  elements.form.children = childIds;
   return { root: "form", elements };
 }

--- a/clients/admin-ui/src/features/properties/privacy-center-config/form-builder/synthesize.ts
+++ b/clients/admin-ui/src/features/properties/privacy-center-config/form-builder/synthesize.ts
@@ -70,10 +70,7 @@ const buildCustomElement = (
       if (text.hidden !== undefined) {
         props.hidden = text.hidden;
       }
-      if (
-        text.query_param_key !== undefined &&
-        text.query_param_key !== null
-      ) {
+      if (text.query_param_key !== undefined && text.query_param_key !== null) {
         props.query_param_key = text.query_param_key;
       }
       break;

--- a/clients/admin-ui/src/pages/properties/[id]/forms/[actionPolicyKey].tsx
+++ b/clients/admin-ui/src/pages/properties/[id]/forms/[actionPolicyKey].tsx
@@ -35,11 +35,13 @@ const FormBuilderRoute: NextPage = () => {
     actionPolicyKey: key,
     pcShape,
     identityInputs,
+    fieldOrder,
     richSpec,
   }: {
     actionPolicyKey: string;
     pcShape: PcCustomFields;
     identityInputs: MapResult["identityInputs"];
+    fieldOrder: MapResult["fieldOrder"];
     richSpec: JsonRenderSpec;
   }) => {
     if (!property) {
@@ -47,22 +49,31 @@ const FormBuilderRoute: NextPage = () => {
     }
     const config = property.privacy_center_config ?? { actions: [] };
     const existingActions = (config as { actions?: any[] }).actions ?? [];
-    const actions = existingActions.map((action: any) =>
-      action.policy_key === key
-        ? {
-            ...action,
-            custom_privacy_request_fields: pcShape,
-            identity_inputs:
-              Object.keys(identityInputs).length > 0 ? identityInputs : null,
-            // eslint-disable-next-line no-underscore-dangle
-            _form_builder_spec: {
-              version: 1,
-              spec: richSpec,
-              updated_at: new Date().toISOString(),
-            },
-          }
-        : action,
-    );
+    const actions = existingActions.map((action: any) => {
+      if (action.policy_key !== key) {
+        return action;
+      }
+      // Drop the deprecated custom_privacy_request_field_order; field_order
+      // supersedes it. Without this, stale legacy ordering can shadow newly
+      // saved customs after a rename or reorder.
+      const {
+        custom_privacy_request_field_order: _legacyOrder,
+        ...rest
+      } = action;
+      return {
+        ...rest,
+        custom_privacy_request_fields: pcShape,
+        identity_inputs:
+          Object.keys(identityInputs).length > 0 ? identityInputs : null,
+        field_order: fieldOrder,
+        // eslint-disable-next-line no-underscore-dangle
+        _form_builder_spec: {
+          version: 1,
+          spec: richSpec,
+          updated_at: new Date().toISOString(),
+        },
+      };
+    });
     // eslint-disable-next-line @typescript-eslint/naming-convention
     const { id: propertyId, messaging_templates, ...rest } = property as any;
     await updateProperty({

--- a/clients/admin-ui/src/pages/properties/[id]/forms/[actionPolicyKey].tsx
+++ b/clients/admin-ui/src/pages/properties/[id]/forms/[actionPolicyKey].tsx
@@ -56,10 +56,8 @@ const FormBuilderRoute: NextPage = () => {
       // Drop the deprecated custom_privacy_request_field_order; field_order
       // supersedes it. Without this, stale legacy ordering can shadow newly
       // saved customs after a rename or reorder.
-      const {
-        custom_privacy_request_field_order: _legacyOrder,
-        ...rest
-      } = action;
+      const rest = { ...action };
+      delete rest.custom_privacy_request_field_order;
       return {
         ...rest,
         custom_privacy_request_fields: pcShape,

--- a/clients/privacy-center/__tests__/components/modals/buildOrderedFields.test.ts
+++ b/clients/privacy-center/__tests__/components/modals/buildOrderedFields.test.ts
@@ -10,6 +10,23 @@ const textField = (label: string): CustomConfigField => ({
   required: false,
 });
 
+// Helper that flattens a descriptor into a stable string for comparison.
+const stringifyField = (f: OrderedField): string => {
+  switch (f.kind) {
+    case "name":
+    case "email":
+    case "phone":
+      return `${f.kind}:${f.mode}`;
+    case "custom-identity":
+    case "custom":
+      return `${f.kind}:${f.key}`;
+    default: {
+      const exhaustive: never = f;
+      throw new Error(`unhandled: ${JSON.stringify(exhaustive)}`);
+    }
+  }
+};
+
 describe("buildOrderedFields", () => {
   describe("with field_order present", () => {
     it("renders strictly in field_order, interleaving identity and customs", () => {
@@ -20,7 +37,7 @@ describe("buildOrderedFields", () => {
         ["email", "reason", "name", "topics", "phone"],
       );
 
-      expect(result.map((f) => describe_(f))).toEqual([
+      expect(result.map((f) => stringifyField(f))).toEqual([
         "email:required",
         "custom:reason",
         "name:optional",
@@ -37,7 +54,7 @@ describe("buildOrderedFields", () => {
         ["loyalty_id", "email"],
       );
 
-      expect(result.map((f) => describe_(f))).toEqual([
+      expect(result.map((f) => stringifyField(f))).toEqual([
         "custom-identity:loyalty_id",
         "email:required",
       ]);
@@ -51,7 +68,7 @@ describe("buildOrderedFields", () => {
         ["reason", "email"], // `phone` configured but not listed
       );
 
-      expect(result.map((f) => describe_(f))).toEqual([
+      expect(result.map((f) => stringifyField(f))).toEqual([
         "custom:reason",
         "email:required",
         "phone:optional",
@@ -66,7 +83,7 @@ describe("buildOrderedFields", () => {
         ["email", "ghost_field", "reason"],
       );
 
-      expect(result.map((f) => describe_(f))).toEqual([
+      expect(result.map((f) => stringifyField(f))).toEqual([
         "email:required",
         "custom:reason",
       ]);
@@ -80,7 +97,7 @@ describe("buildOrderedFields", () => {
         ["email", "reason", "email"],
       );
 
-      expect(result.map((f) => describe_(f))).toEqual([
+      expect(result.map((f) => stringifyField(f))).toEqual([
         "email:required",
         "custom:reason",
       ]);
@@ -95,7 +112,7 @@ describe("buildOrderedFields", () => {
         { reason: textField("Reason"), topics: textField("Topics") },
       );
 
-      expect(result.map((f) => describe_(f))).toEqual([
+      expect(result.map((f) => stringifyField(f))).toEqual([
         "name:optional",
         "email:required",
         "phone:optional",
@@ -112,7 +129,7 @@ describe("buildOrderedFields", () => {
         { reason: textField("Reason") },
       );
 
-      expect(result.map((f) => describe_(f))).toEqual([
+      expect(result.map((f) => stringifyField(f))).toEqual([
         "email:required",
         "custom:reason",
       ]);
@@ -131,31 +148,14 @@ describe("buildOrderedFields", () => {
       const expected = ["email:required", "custom:reason"];
 
       expect(
-        buildOrderedFields(...args, null).map((f) => describe_(f)),
+        buildOrderedFields(...args, null).map((f) => stringifyField(f)),
       ).toEqual(expected);
       expect(
-        buildOrderedFields(...args, undefined).map((f) => describe_(f)),
+        buildOrderedFields(...args, undefined).map((f) => stringifyField(f)),
       ).toEqual(expected);
-      expect(buildOrderedFields(...args, []).map((f) => describe_(f))).toEqual(
-        expected,
-      );
+      expect(
+        buildOrderedFields(...args, []).map((f) => stringifyField(f)),
+      ).toEqual(expected);
     });
   });
 });
-
-// Helper that flattens a descriptor into a stable string for comparison.
-const describe_ = (f: OrderedField): string => {
-  switch (f.kind) {
-    case "name":
-    case "email":
-    case "phone":
-      return `${f.kind}:${f.mode}`;
-    case "custom-identity":
-    case "custom":
-      return `${f.kind}:${f.key}`;
-    default: {
-      const exhaustive: never = f;
-      throw new Error(`unhandled: ${JSON.stringify(exhaustive)}`);
-    }
-  }
-};

--- a/clients/privacy-center/__tests__/components/modals/buildOrderedFields.test.ts
+++ b/clients/privacy-center/__tests__/components/modals/buildOrderedFields.test.ts
@@ -1,0 +1,161 @@
+import {
+  buildOrderedFields,
+  OrderedField,
+} from "~/components/modals/privacy-request-modal/buildOrderedFields";
+import { CustomConfigField } from "~/types/config";
+
+const textField = (label: string): CustomConfigField => ({
+  label,
+  field_type: "text",
+  required: false,
+});
+
+describe("buildOrderedFields", () => {
+  describe("with field_order present", () => {
+    it("renders strictly in field_order, interleaving identity and customs", () => {
+      const result = buildOrderedFields(
+        { name: "optional", email: "required", phone: "optional" },
+        {},
+        { reason: textField("Reason"), topics: textField("Topics") },
+        ["email", "reason", "name", "topics", "phone"],
+      );
+
+      expect(result.map((f) => describe_(f))).toEqual([
+        "email:required",
+        "custom:reason",
+        "name:optional",
+        "custom:topics",
+        "phone:optional",
+      ]);
+    });
+
+    it("places custom identity fields via field_order entries", () => {
+      const result = buildOrderedFields(
+        { email: "required" },
+        { loyalty_id: textField("Loyalty ID") },
+        {},
+        ["loyalty_id", "email"],
+      );
+
+      expect(result.map((f) => describe_(f))).toEqual([
+        "custom-identity:loyalty_id",
+        "email:required",
+      ]);
+    });
+
+    it("appends configured fields missing from field_order to the end", () => {
+      const result = buildOrderedFields(
+        { email: "required", phone: "optional" },
+        {},
+        { reason: textField("Reason") },
+        ["reason", "email"], // `phone` configured but not listed
+      );
+
+      expect(result.map((f) => describe_(f))).toEqual([
+        "custom:reason",
+        "email:required",
+        "phone:optional",
+      ]);
+    });
+
+    it("ignores unknown keys in field_order without crashing", () => {
+      const result = buildOrderedFields(
+        { email: "required" },
+        {},
+        { reason: textField("Reason") },
+        ["email", "ghost_field", "reason"],
+      );
+
+      expect(result.map((f) => describe_(f))).toEqual([
+        "email:required",
+        "custom:reason",
+      ]);
+    });
+
+    it("dedupes repeated keys (defensive against stale data)", () => {
+      const result = buildOrderedFields(
+        { email: "required" },
+        {},
+        { reason: textField("Reason") },
+        ["email", "reason", "email"],
+      );
+
+      expect(result.map((f) => describe_(f))).toEqual([
+        "email:required",
+        "custom:reason",
+      ]);
+    });
+  });
+
+  describe("legacy fallback (no field_order)", () => {
+    it("renders name → email → phone → custom identities → customs", () => {
+      const result = buildOrderedFields(
+        { phone: "optional", email: "required", name: "optional" },
+        { loyalty_id: textField("Loyalty ID") },
+        { reason: textField("Reason"), topics: textField("Topics") },
+      );
+
+      expect(result.map((f) => describe_(f))).toEqual([
+        "name:optional",
+        "email:required",
+        "phone:optional",
+        "custom-identity:loyalty_id",
+        "custom:reason",
+        "custom:topics",
+      ]);
+    });
+
+    it("skips identity fields not configured", () => {
+      const result = buildOrderedFields(
+        { email: "required" },
+        {},
+        { reason: textField("Reason") },
+      );
+
+      expect(result.map((f) => describe_(f))).toEqual([
+        "email:required",
+        "custom:reason",
+      ]);
+    });
+
+    it("returns an empty array when no fields are configured", () => {
+      expect(buildOrderedFields({}, {}, {})).toEqual([]);
+    });
+
+    it("treats null / undefined / empty field_order as absent", () => {
+      const args = [
+        { email: "required" },
+        {},
+        { reason: textField("Reason") },
+      ] as const;
+      const expected = ["email:required", "custom:reason"];
+
+      expect(
+        buildOrderedFields(...args, null).map((f) => describe_(f)),
+      ).toEqual(expected);
+      expect(
+        buildOrderedFields(...args, undefined).map((f) => describe_(f)),
+      ).toEqual(expected);
+      expect(buildOrderedFields(...args, []).map((f) => describe_(f))).toEqual(
+        expected,
+      );
+    });
+  });
+});
+
+// Helper that flattens a descriptor into a stable string for comparison.
+const describe_ = (f: OrderedField): string => {
+  switch (f.kind) {
+    case "name":
+    case "email":
+    case "phone":
+      return `${f.kind}:${f.mode}`;
+    case "custom-identity":
+    case "custom":
+      return `${f.kind}:${f.key}`;
+    default: {
+      const exhaustive: never = f;
+      throw new Error(`unhandled: ${JSON.stringify(exhaustive)}`);
+    }
+  }
+};

--- a/clients/privacy-center/components/modals/privacy-request-modal/PrivacyRequestForm.tsx
+++ b/clients/privacy-center/components/modals/privacy-request-modal/PrivacyRequestForm.tsx
@@ -9,7 +9,7 @@ import { ModalViews } from "~/components/modals/types";
 import { PhoneInput } from "~/components/phone-input";
 import { CustomConfigField, PrivacyRequestOption } from "~/types/config";
 
-import usePrivacyRequestForm from "./usePrivacyRequestForm";
+import usePrivacyRequestForm, { OrderedField } from "./usePrivacyRequestForm";
 
 type PrivacyRequestFormProps = {
   onExit: () => void;
@@ -39,13 +39,7 @@ const PrivacyRequestForm = ({
     touched,
     values,
     isSubmitting,
-    legacyIdentityFields: {
-      name: nameInput,
-      email: emailInput,
-      phone: phoneInput,
-    },
-    customIdentityFields,
-    customPrivacyRequestFields,
+    orderedFields,
   } = usePrivacyRequestForm({
     onExit,
     action,
@@ -58,6 +52,134 @@ const PrivacyRequestForm = ({
   if (!action) {
     return null;
   }
+
+  const buildCustomFieldProps = (
+    key: string,
+    value: string | string[],
+    fieldConfig: CustomConfigField,
+  ): CustomFieldRendererProps => {
+    const sharedProps = {
+      fieldKey: key,
+      onBlur: () => handleBlur({ target: { name: key } }),
+      error: touched[key] && errors[key] ? errors[key] : undefined,
+    };
+    switch (fieldConfig.field_type) {
+      case "multiselect":
+        return {
+          ...fieldConfig,
+          ...sharedProps,
+          value: typeof value === "string" ? [value] : value,
+          onChange: (v: Array<string>) => setFieldValue(key, v),
+        };
+      default:
+        return {
+          ...fieldConfig,
+          ...sharedProps,
+          value: typeof value === "string" ? value : value?.[0],
+          onChange: (v: string) => setFieldValue(key, v),
+        };
+    }
+  };
+
+  const renderField = (field: OrderedField): React.ReactElement | null => {
+    if (field.kind === "name") {
+      return (
+        <Form.Item
+          key="name"
+          validateStatus={
+            touched.name && Boolean(errors.name) ? "error" : undefined
+          }
+          help={touched.name && errors.name}
+          required={field.mode === "required"}
+          label="Name"
+          htmlFor="name"
+        >
+          <Input
+            id="name"
+            name="name"
+            placeholder="Michael Brown"
+            onChange={handleChange}
+            onBlur={handleBlur}
+            value={values.name}
+          />
+        </Form.Item>
+      );
+    }
+    if (field.kind === "email") {
+      return (
+        <Form.Item
+          key="email"
+          validateStatus={
+            touched.email && Boolean(errors.email) ? "error" : undefined
+          }
+          help={touched.email && errors.email}
+          required={field.mode === "required"}
+          label="Email"
+          htmlFor="email"
+        >
+          <Input
+            id="email"
+            name="email"
+            type="email"
+            placeholder="your-email@example.com"
+            onChange={handleChange}
+            onBlur={handleBlur}
+            value={values.email}
+          />
+        </Form.Item>
+      );
+    }
+    if (field.kind === "phone") {
+      return (
+        <Form.Item
+          key="phone"
+          validateStatus={
+            touched.phone && Boolean(errors.phone) ? "error" : undefined
+          }
+          help={touched.phone && errors.phone}
+          required={field.mode === "required"}
+          label="Phone"
+          htmlFor="phone"
+        >
+          <PhoneInput
+            id="phone"
+            name="phone"
+            onChange={(value) => setFieldValue("phone", value, true)}
+            onBlur={handleBlur}
+            value={values.phone}
+          />
+        </Form.Item>
+      );
+    }
+    if (field.kind !== "custom" && field.kind !== "custom-identity") {
+      return null;
+    }
+    // custom + custom-identity render via the same CustomFieldRenderer pipeline
+    // they always have. The hidden / visible_when filters apply only to those —
+    // legacy identity fields above don't honor those props in the existing UX.
+    const { key, field: item } = field;
+    if (!item) {
+      return null;
+    }
+    if (item.hidden || !isFieldVisible(item, values)) {
+      return null;
+    }
+    return (
+      <Form.Item
+        key={key}
+        id={key}
+        validateStatus={touched[key] && !!errors[key] ? "error" : undefined}
+        help={touched[key] && errors[key]}
+        required={item.required !== false}
+        label={item.label}
+        htmlFor={key}
+      >
+        <CustomFieldRenderer
+          {...buildCustomFieldProps(key, values[key], item)}
+        />
+      </Form.Item>
+    );
+  };
 
   return (
     <Flex vertical gap="medium">
@@ -72,123 +194,7 @@ const PrivacyRequestForm = ({
             <Text size="sm">{paragraph}</Text>
           </Form.Item>
         ))}
-        {!!nameInput && (
-          <Form.Item
-            validateStatus={
-              touched.name && Boolean(errors.name) ? "error" : undefined
-            }
-            help={touched.name && errors.name}
-            required={nameInput === "required"}
-            label="Name"
-            htmlFor="name"
-          >
-            <Input
-              id="name"
-              name="name"
-              placeholder="Michael Brown"
-              onChange={handleChange}
-              onBlur={handleBlur}
-              value={values.name}
-            />
-          </Form.Item>
-        )}
-        {!!emailInput && (
-          <Form.Item
-            validateStatus={
-              touched.email && Boolean(errors.email) ? "error" : undefined
-            }
-            help={touched.email && errors.email}
-            required={emailInput === "required"}
-            label="Email"
-            htmlFor="email"
-          >
-            <Input
-              id="email"
-              name="email"
-              type="email"
-              placeholder="your-email@example.com"
-              onChange={handleChange}
-              onBlur={handleBlur}
-              value={values.email}
-            />
-          </Form.Item>
-        )}
-        {!!phoneInput && (
-          <Form.Item
-            validateStatus={
-              touched.phone && Boolean(errors.phone) ? "error" : undefined
-            }
-            help={touched.phone && errors.phone}
-            required={phoneInput === "required"}
-            label="Phone"
-            htmlFor="phone"
-          >
-            <PhoneInput
-              id="phone"
-              name="phone"
-              onChange={(value) => {
-                setFieldValue("phone", value, true);
-              }}
-              onBlur={handleBlur}
-              value={values.phone}
-            />
-          </Form.Item>
-        )}
-        {Object.entries({
-          ...customIdentityFields,
-          ...customPrivacyRequestFields,
-        })
-          .filter(([, field]) => !field?.hidden)
-          .filter(([, field]) => (field ? isFieldVisible(field, values) : true))
-          .map(([key, item]) => {
-            const customFieldProps = (
-              value: string | string[],
-              fieldConfig: CustomConfigField,
-            ): CustomFieldRendererProps => {
-              const sharedProps = {
-                fieldKey: key,
-                onBlur: () => handleBlur({ target: { name: key } }),
-                error: touched[key] && errors[key] ? errors[key] : undefined,
-              };
-
-              switch (fieldConfig.field_type) {
-                case "multiselect":
-                  return {
-                    ...fieldConfig,
-                    ...sharedProps,
-                    value: typeof value === "string" ? [value] : value,
-                    onChange: (v: Array<string>) => {
-                      setFieldValue(key, v);
-                    },
-                  };
-                default:
-                  return {
-                    ...fieldConfig,
-                    ...sharedProps,
-                    value: typeof value === "string" ? value : value?.[0],
-                    onChange: (v: string) => {
-                      setFieldValue(key, v);
-                    },
-                  };
-              }
-            };
-
-            return item ? (
-              <Form.Item
-                key={key}
-                id={key}
-                validateStatus={
-                  touched[key] && !!errors[key] ? "error" : undefined
-                }
-                help={touched[key] && errors[key]}
-                required={item.required !== false}
-                label={item.label}
-                htmlFor={key}
-              >
-                <CustomFieldRenderer {...customFieldProps(values[key], item)} />
-              </Form.Item>
-            ) : null;
-          })}
+        {orderedFields.map(renderField)}
         <Flex justify="stretch" gap="medium">
           <Button type="default" variant="outlined" onClick={onExit} block>
             {action.cancelButtonText || "Cancel"}

--- a/clients/privacy-center/components/modals/privacy-request-modal/buildOrderedFields.ts
+++ b/clients/privacy-center/components/modals/privacy-request-modal/buildOrderedFields.ts
@@ -1,0 +1,93 @@
+import { CustomConfigField } from "~/types/config";
+
+type LegacyIdentityKind = "name" | "email" | "phone";
+type LegacyMode = "required" | "optional";
+
+export type OrderedField =
+  | { kind: LegacyIdentityKind; mode: LegacyMode }
+  | { kind: "custom-identity"; key: string; field: CustomConfigField }
+  | { kind: "custom"; key: string; field: CustomConfigField };
+
+const LEGACY_IDENTITY_KEYS: readonly LegacyIdentityKind[] = [
+  "name",
+  "email",
+  "phone",
+] as const;
+
+const isLegacyIdentityKey = (key: string): key is LegacyIdentityKind =>
+  (LEGACY_IDENTITY_KEYS as readonly string[]).includes(key);
+
+const isLegacyMode = (value: unknown): value is LegacyMode =>
+  value === "required" || value === "optional";
+
+/**
+ * Resolve the list of fields the privacy request form should render, in order.
+ *
+ * When the action has a `field_order` array, fields render strictly in that
+ * sequence — interleaving identity fields with customs is supported, which is
+ * how the form builder surfaces "this custom field above email" to end users.
+ *
+ * When `field_order` is absent (legacy configs) we fall back to the original
+ * hardcoded sequence: name → email → phone → custom identities → customs.
+ *
+ * Configured fields missing from `field_order` are appended at the end via the
+ * legacy fallback so a hand-edited YAML adding a field without updating
+ * `field_order` doesn't silently disappear.
+ */
+export const buildOrderedFields = (
+  legacyIdentityFields: Record<string, unknown>,
+  customIdentityFields: Record<string, CustomConfigField>,
+  customPrivacyRequestFields: Record<string, CustomConfigField>,
+  fieldOrder?: string[] | null,
+): OrderedField[] => {
+  const result: OrderedField[] = [];
+  const seen = new Set<string>();
+
+  const pushLegacyIdentity = (key: LegacyIdentityKind) => {
+    const mode = legacyIdentityFields[key];
+    if (!isLegacyMode(mode) || seen.has(key)) {
+      return;
+    }
+    result.push({ kind: key, mode });
+    seen.add(key);
+  };
+
+  const pushCustomIdentity = (key: string) => {
+    const field = customIdentityFields[key];
+    if (!field || seen.has(key)) {
+      return;
+    }
+    result.push({ kind: "custom-identity", key, field });
+    seen.add(key);
+  };
+
+  const pushCustom = (key: string) => {
+    const field = customPrivacyRequestFields[key];
+    if (!field || seen.has(key)) {
+      return;
+    }
+    result.push({ kind: "custom", key, field });
+    seen.add(key);
+  };
+
+  if (fieldOrder && fieldOrder.length > 0) {
+    fieldOrder.forEach((key) => {
+      if (isLegacyIdentityKey(key)) {
+        pushLegacyIdentity(key);
+      } else if (key in customIdentityFields) {
+        pushCustomIdentity(key);
+      } else if (key in customPrivacyRequestFields) {
+        pushCustom(key);
+      }
+      // Unknown keys are skipped — backend validation already rejects them
+      // at save time; the renderer just stays defensive against stale data.
+    });
+  }
+
+  // Legacy fallback for any keys not listed in `field_order`.
+  LEGACY_IDENTITY_KEYS.forEach(pushLegacyIdentity);
+  Object.keys(customIdentityFields).forEach(pushCustomIdentity);
+  Object.keys(customPrivacyRequestFields).forEach(pushCustom);
+
+  return result;
+};

--- a/clients/privacy-center/components/modals/privacy-request-modal/usePrivacyRequestForm.ts
+++ b/clients/privacy-center/components/modals/privacy-request-modal/usePrivacyRequestForm.ts
@@ -20,8 +20,15 @@ import { useSettings } from "~/features/common/settings.slice";
 import { useCustomFieldsForm } from "~/hooks/useCustomFieldsForm";
 import { PrivacyRequestStatus } from "~/types";
 import { PrivacyRequestSource } from "~/types/api/models/PrivacyRequestSource";
-import { PrivacyRequestOption as ConfigPrivacyRequestOption } from "~/types/config";
+import {
+  CustomConfigField,
+  PrivacyRequestOption as ConfigPrivacyRequestOption,
+} from "~/types/config";
 import { FormValues, MultiselectFieldValue } from "~/types/forms";
+
+import { buildOrderedFields } from "./buildOrderedFields";
+
+export type { OrderedField } from "./buildOrderedFields";
 
 /**
  *
@@ -290,12 +297,20 @@ const usePrivacyRequestForm = ({
     }),
   });
 
+  const orderedFields = buildOrderedFields(
+    legacyIdentityFields,
+    customIdentityFields as Record<string, CustomConfigField>,
+    customPrivacyRequestFields,
+    action?.field_order,
+  );
+
   return {
     ...formik,
     isSubmitting: formik.isSubmitting || isSubmitPending,
     legacyIdentityFields,
     customIdentityFields,
     customPrivacyRequestFields,
+    orderedFields,
   };
 };
 

--- a/clients/privacy-center/types/config.ts
+++ b/clients/privacy-center/types/config.ts
@@ -166,6 +166,11 @@ export type PrivacyRequestOption = {
   cancelButtonText?: string | null;
   identity_inputs?: IdentityInputs | null;
   custom_privacy_request_fields?: CustomPrivacyRequestFields | null;
+  // Unified render order across identity_inputs and custom_privacy_request_fields.
+  // When set, the renderer iterates this list strictly and looks each key up in
+  // either bucket. Absent on legacy configs — those fall back to the hardcoded
+  // name → email → phone → other identities → customs sequence.
+  field_order?: string[] | null;
 };
 
 export enum ConsentNonApplicableFlagMode {

--- a/src/fides/api/schemas/privacy_center_config.py
+++ b/src/fides/api/schemas/privacy_center_config.py
@@ -182,9 +182,7 @@ class PrivacyRequestOption(FidesSchema):
         valid_keys = identity_keys | custom_keys
         unknown = [k for k in self.field_order if k not in valid_keys]
         if unknown:
-            raise ValueError(
-                f"field_order references unknown keys: {sorted(unknown)}"
-            )
+            raise ValueError(f"field_order references unknown keys: {sorted(unknown)}")
         # Configured fields not listed in field_order intentionally fall through
         # to legacy ordering at the end of the rendered list. This path matters
         # only for hand-edited YAML — the form builder always emits a complete

--- a/src/fides/api/schemas/privacy_center_config.py
+++ b/src/fides/api/schemas/privacy_center_config.py
@@ -161,6 +161,35 @@ class PrivacyRequestOption(FidesSchema):
     custom_privacy_request_fields: Optional[
         Dict[str, CustomPrivacyRequestFieldUnion]
     ] = None
+    # Unified render order across identity_inputs and custom_privacy_request_fields.
+    # When set, the privacy center renders fields strictly in this order; absent
+    # legacy configs fall back to the hardcoded name → email → phone → customs
+    # sequence. Supersedes `custom_privacy_request_field_order` (deprecated).
+    field_order: Optional[List[str]] = None
+
+    @model_validator(mode="after")
+    def _validate_field_order(self) -> "PrivacyRequestOption":
+        if self.field_order is None:
+            return self
+        if len(self.field_order) != len(set(self.field_order)):
+            raise ValueError("field_order contains duplicate keys")
+        identity_keys = set(
+            (self.identity_inputs.model_dump(exclude_none=True).keys())
+            if self.identity_inputs is not None
+            else ()
+        )
+        custom_keys = set((self.custom_privacy_request_fields or {}).keys())
+        valid_keys = identity_keys | custom_keys
+        unknown = [k for k in self.field_order if k not in valid_keys]
+        if unknown:
+            raise ValueError(
+                f"field_order references unknown keys: {sorted(unknown)}"
+            )
+        # Configured fields not listed in field_order intentionally fall through
+        # to legacy ordering at the end of the rendered list. This path matters
+        # only for hand-edited YAML — the form builder always emits a complete
+        # field_order on save.
+        return self
 
 
 class ConsentConfigButton(FidesSchema):
@@ -286,11 +315,15 @@ class PartialPrivacyCenterConfig(FidesSchema):
 
 def reorder_custom_privacy_request_fields(config: dict[str, Any]) -> dict[str, Any]:
     """Return a copy of the privacy center config with custom_privacy_request_fields
-    ordered by custom_privacy_request_field_order when present.
+    ordered by the persisted ordering hints.
 
     JSONB does not preserve object key order. This helper reconstructs the desired
-    order using the stored order list and removes that internal key from the result.
-    When no order list exists (legacy config), the existing key order is preserved.
+    order from `field_order` (preferred — orders identity + custom fields jointly)
+    or falls back to the deprecated `custom_privacy_request_field_order` for legacy
+    configs that predate `field_order`. The deprecated key is stripped from the
+    result so it doesn't leak into API responses.
+
+    When neither order list exists (legacy config), the existing key order is preserved.
     """
     result = copy.deepcopy(config)
     actions = result.get("actions")
@@ -304,15 +337,26 @@ def reorder_custom_privacy_request_fields(config: dict[str, Any]) -> dict[str, A
         if not fields or not isinstance(fields, dict):
             continue
 
-        order = action.get("custom_privacy_request_field_order")
-        if isinstance(order, list) and len(order) > 0:
-            ordered = {k: fields[k] for k in order if k in fields}
-            # Append any fields not in order (prevents data loss if order list becomes stale)
+        # Prefer field_order (filtered to custom keys) over the deprecated key.
+        custom_order: List[str] = []
+        unified_order = action.get("field_order")
+        if isinstance(unified_order, list) and len(unified_order) > 0:
+            custom_order = [k for k in unified_order if k in fields]
+        else:
+            legacy_order = action.get("custom_privacy_request_field_order")
+            if isinstance(legacy_order, list):
+                custom_order = [k for k in legacy_order if k in fields]
+
+        if custom_order:
+            ordered = {k: fields[k] for k in custom_order}
+            # Append any fields not in order (prevents data loss if the order
+            # list becomes stale from a hand-edited YAML).
             for k in fields:
                 if k not in ordered:
                     ordered[k] = fields[k]
             action["custom_privacy_request_fields"] = ordered
-            action.pop("custom_privacy_request_field_order", None)
-        # No order list: deep copy already preserved existing key order
+
+        # Always strip the deprecated internal key from the response.
+        action.pop("custom_privacy_request_field_order", None)
 
     return result

--- a/tests/ops/schemas/test_privacy_center_config.py
+++ b/tests/ops/schemas/test_privacy_center_config.py
@@ -593,9 +593,10 @@ class TestReorderCustomPrivacyRequestFields:
         }
         result = reorder_custom_privacy_request_fields(config)
         # Customs are reordered to match field_order, filtered to custom keys.
-        assert list(
-            result["actions"][0]["custom_privacy_request_fields"].keys()
-        ) == ["b", "a"]
+        assert list(result["actions"][0]["custom_privacy_request_fields"].keys()) == [
+            "b",
+            "a",
+        ]
         # Deprecated key is stripped; field_order survives untouched.
         assert "custom_privacy_request_field_order" not in result["actions"][0]
         assert result["actions"][0]["field_order"] == ["b", "email", "a"]
@@ -618,9 +619,10 @@ class TestReorderCustomPrivacyRequestFields:
         }
         result = reorder_custom_privacy_request_fields(config)
         # No custom keys in field_order → fall back to existing dict order.
-        assert list(
-            result["actions"][0]["custom_privacy_request_fields"].keys()
-        ) == ["a", "b"]
+        assert list(result["actions"][0]["custom_privacy_request_fields"].keys()) == [
+            "a",
+            "b",
+        ]
 
 
 class TestPrivacyRequestOptionFieldOrder:
@@ -652,9 +654,7 @@ class TestPrivacyRequestOptionFieldOrder:
 
     def test_valid_mixed_field_order_round_trips(self):
         """field_order mixing identity and custom keys validates and survives a dump."""
-        payload = self._base_payload(
-            field_order=["email", "reason", "name", "topics"]
-        )
+        payload = self._base_payload(field_order=["email", "reason", "name", "topics"])
         option = PrivacyRequestOption.model_validate(payload)
         assert option.field_order == ["email", "reason", "name", "topics"]
         dumped = option.model_dump(by_alias=True, exclude_none=True)
@@ -669,9 +669,7 @@ class TestPrivacyRequestOptionFieldOrder:
 
     def test_unknown_keys_in_field_order_raise(self):
         """Keys not in identity_inputs or custom_privacy_request_fields raise ValidationError."""
-        payload = self._base_payload(
-            field_order=["email", "ghost_field", "reason"]
-        )
+        payload = self._base_payload(field_order=["email", "ghost_field", "reason"])
         with pytest.raises(ValidationError) as exc:
             PrivacyRequestOption.model_validate(payload)
         assert "field_order references unknown keys" in str(exc.value)

--- a/tests/ops/schemas/test_privacy_center_config.py
+++ b/tests/ops/schemas/test_privacy_center_config.py
@@ -1,4 +1,5 @@
 import json
+from typing import Any, Dict
 
 import pytest
 from pydantic import ValidationError
@@ -572,6 +573,134 @@ class TestReorderCustomPrivacyRequestFields:
         result = reorder_custom_privacy_request_fields(config)
         keys = list(result["actions"][0]["custom_privacy_request_fields"].keys())
         assert keys == ["b", "a", "new_field"]  # new_field appended at end
+
+    def test_field_order_takes_precedence_over_deprecated_key(self):
+        """When both keys are present, field_order wins; deprecated key is stripped."""
+        config = {
+            "actions": [
+                {
+                    "policy_key": "p",
+                    "title": "T",
+                    "identity_inputs": {"email": "required"},
+                    "custom_privacy_request_fields": {
+                        "a": {"label": "A"},
+                        "b": {"label": "B"},
+                    },
+                    "field_order": ["b", "email", "a"],
+                    "custom_privacy_request_field_order": ["a", "b"],  # ignored
+                }
+            ]
+        }
+        result = reorder_custom_privacy_request_fields(config)
+        # Customs are reordered to match field_order, filtered to custom keys.
+        assert list(
+            result["actions"][0]["custom_privacy_request_fields"].keys()
+        ) == ["b", "a"]
+        # Deprecated key is stripped; field_order survives untouched.
+        assert "custom_privacy_request_field_order" not in result["actions"][0]
+        assert result["actions"][0]["field_order"] == ["b", "email", "a"]
+
+    def test_field_order_with_only_identity_keys_preserves_custom_dict_order(self):
+        """field_order containing no custom keys leaves custom dict order untouched."""
+        config = {
+            "actions": [
+                {
+                    "policy_key": "p",
+                    "title": "T",
+                    "identity_inputs": {"email": "required", "name": "optional"},
+                    "custom_privacy_request_fields": {
+                        "a": {"label": "A"},
+                        "b": {"label": "B"},
+                    },
+                    "field_order": ["email", "name"],
+                }
+            ]
+        }
+        result = reorder_custom_privacy_request_fields(config)
+        # No custom keys in field_order → fall back to existing dict order.
+        assert list(
+            result["actions"][0]["custom_privacy_request_fields"].keys()
+        ) == ["a", "b"]
+
+
+class TestPrivacyRequestOptionFieldOrder:
+    """Tests for the field_order validator on PrivacyRequestOption."""
+
+    @staticmethod
+    def _base_payload(**overrides: Any) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "icon_path": "/icon.svg",
+            "title": "Access",
+            "description": "Access my data",
+            "identity_inputs": {"email": "required", "name": "optional"},
+            "custom_privacy_request_fields": {
+                "reason": {"label": "Reason", "field_type": "text"},
+                "topics": {
+                    "label": "Topics",
+                    "field_type": "multiselect",
+                    "options": ["A", "B"],
+                },
+            },
+        }
+        payload.update(overrides)
+        return payload
+
+    def test_absent_field_order_is_valid(self):
+        """Legacy configs without field_order continue to validate."""
+        option = PrivacyRequestOption.model_validate(self._base_payload())
+        assert option.field_order is None
+
+    def test_valid_mixed_field_order_round_trips(self):
+        """field_order mixing identity and custom keys validates and survives a dump."""
+        payload = self._base_payload(
+            field_order=["email", "reason", "name", "topics"]
+        )
+        option = PrivacyRequestOption.model_validate(payload)
+        assert option.field_order == ["email", "reason", "name", "topics"]
+        dumped = option.model_dump(by_alias=True, exclude_none=True)
+        assert dumped["field_order"] == ["email", "reason", "name", "topics"]
+
+    def test_partial_field_order_is_valid(self):
+        """Configured fields missing from field_order intentionally fall through (no error)."""
+        # `topics` and `name` are configured but absent from field_order.
+        payload = self._base_payload(field_order=["email", "reason"])
+        option = PrivacyRequestOption.model_validate(payload)
+        assert option.field_order == ["email", "reason"]
+
+    def test_unknown_keys_in_field_order_raise(self):
+        """Keys not in identity_inputs or custom_privacy_request_fields raise ValidationError."""
+        payload = self._base_payload(
+            field_order=["email", "ghost_field", "reason"]
+        )
+        with pytest.raises(ValidationError) as exc:
+            PrivacyRequestOption.model_validate(payload)
+        assert "field_order references unknown keys" in str(exc.value)
+        assert "ghost_field" in str(exc.value)
+
+    def test_duplicate_keys_in_field_order_raise(self):
+        """Duplicates in field_order raise ValidationError."""
+        payload = self._base_payload(field_order=["email", "reason", "email"])
+        with pytest.raises(ValidationError) as exc:
+            PrivacyRequestOption.model_validate(payload)
+        assert "field_order contains duplicate keys" in str(exc.value)
+
+    def test_empty_field_order_is_valid(self):
+        """An empty list validates (renderer falls back to legacy ordering)."""
+        payload = self._base_payload(field_order=[])
+        option = PrivacyRequestOption.model_validate(payload)
+        assert option.field_order == []
+
+    def test_field_order_with_custom_identity_keys(self):
+        """Custom identity keys (extras on IdentityInputs) are valid in field_order."""
+        payload = self._base_payload(
+            identity_inputs={
+                "email": "required",
+                "loyalty_id": {"label": "Loyalty ID"},
+            },
+            field_order=["loyalty_id", "email", "reason", "topics"],
+        )
+        option = PrivacyRequestOption.model_validate(payload)
+        assert option.field_order[0] == "loyalty_id"
 
 
 def test_privacy_request_option_preserves_unknown_extras() -> None:


### PR DESCRIPTION
Ticket [ENG-3652]

### Description Of Changes

Lets the privacy center form builder freely reorder identity and custom fields — including interleaving (e.g. a "reason" input between Email and Phone). The legacy persisted shape splits an action's fields into two top-level buckets (`identity_inputs` and `custom_privacy_request_fields`), so the public renderer hardcoded a fixed sequence (name → email → phone → customs) and the form builder's drag-and-drop order was lost on save.

This adds a single optional `field_order: string[]` on `PrivacyRequestOption`. When present, the privacy center renders strictly in that order, looking each key up in either bucket. When absent, the legacy hardcoded sequence still applies — every existing customer config keeps working with no migration.

`custom_privacy_request_field_order` is now deprecated. It's still read as a fallback for legacy configs, but new writes from the form builder use `field_order`. The fidesplus storage normalizer (separate PR) skips writing the legacy key when `field_order` is already present.

Pairs with a fidesplus PR for the storage-side normalization update + integration test.

### Code Changes

* `field_order: Optional[List[str]]` added to `PrivacyRequestOption` with a Pydantic validator (rejects duplicates and unknown keys; allows partial coverage with a documented fall-through to legacy ordering)
* `reorder_custom_privacy_request_fields` updated to prefer `field_order` over the deprecated `custom_privacy_request_field_order`
* Form builder mapper now emits `fieldOrder` in `MapResult`, walking the spec's children list
* Form builder synthesize accepts an optional `fieldOrder` argument and renders elements in that sequence (falls back to the canonical name → email → phone → customs order otherwise)
* `FormBuilderPage` and the `[actionPolicyKey].tsx` save route plumb `fieldOrder` through; on save we explicitly drop the deprecated `custom_privacy_request_field_order` key so it can't shadow the new source of truth
* Public renderer (`PrivacyRequestForm`) refactored to a single ordered loop driven by `OrderedField[]` from a new pure helper (`buildOrderedFields`); per-field validation, hidden filtering, `isFieldVisible` all preserved
* New unit tests for `mapSpecToPcShape` (3 cases), `synthesizeSpecFromPcShape` (5 cases), `buildOrderedFields` (9 cases), Pydantic validator (7 cases), and the reorder helper (2 cases for the deprecation precedence)
* Cypress e2e test asserting `field_order` is sent in the property PUT body when a custom field sits between identity fields

### Steps to Confirm

1. Spin up admin UI + privacy center against this branch (paired with the fidesplus PR for the storage normalization)
2. Create a property; configure an Access action with default identities + a custom text field "reason"
3. In the form builder, drag "reason" between Email and Phone, save
4. Open the public privacy center for that property → trigger the access form → confirm visual order is name → email → reason → phone
5. Edit the same form, drag identities into a different sequence (e.g. email → name → phone), save and re-verify the public form picks up the new order
6. Open a property created on `demo/april` (no `field_order` in its config), verify it loads in the new admin UI with the legacy order and saves cleanly with `field_order` present after save

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ENG-3652]: https://ethyca.atlassian.net/browse/ENG-3652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ