### PR TITLE
ENG-3706: Broaden accepted image sources in embedded consent

### DIFF
--- a/changelog/8127-broaden-img-sources-on-embeddedn-consent.yaml
+++ b/changelog/8127-broaden-img-sources-on-embeddedn-consent.yaml
@@ -1,0 +1,7 @@
+# Copy this file and rename it to <pr_number>-<short-description>.yaml (e.g., 1234-add-user-endpoint.yaml)
+# Fill in the required fields and delete this comment block
+
+type: Changed # One of: Added, Changed, Developer Experience, Deprecated, Docs, Fixed, Removed, Security
+description: Broaden image sources on embedded consent.
+pr: 8127 # PR number
+labels: [] # Optional: ["high-risk", "db-migration"]

--- a/clients/privacy-center/app/server-utils/recommendedSecurityHeaders.ts
+++ b/clients/privacy-center/app/server-utils/recommendedSecurityHeaders.ts
@@ -33,7 +33,7 @@ export const embeddedConsentCspHeader = (args: {
     script-src 'self' 'unsafe-inline';
     style-src 'self' 'unsafe-inline';
     connect-src 'self' ${args.fidesApiHost} ${args.geolocationApiHost};
-    img-src 'self' blob: data:;
+    img-src * blob: data:;
     font-src 'self';
     object-src 'none';
     base-uri 'self';


### PR DESCRIPTION
Ticket [ENG-3706] <!-- simply paste the ticket number between the brackets and it will auto-convert to a link -->

### Description Of Changes

Allow images from more sources. 

A client of ours wants to include logos from their CDN in the CSS that they're configuring Fides with for embedded experiences. This change allows that.

### Code Changes

* Changed src from self to *

### Steps to Confirm

1. None.

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-3706]: https://ethyca.atlassian.net/browse/ENG-3706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ