### PR TITLE
chore: ga helios insights [ENG-3734]

### DIFF
--- a/changelog/8130-ga-helios-insights.yaml
+++ b/changelog/8130-ga-helios-insights.yaml
@@ -1,0 +1,4 @@
+type: Changed # One of: Added, Changed, Developer Experience, Deprecated, Docs, Fixed, Removed, Security
+description: GA helios insights feature
+pr: 8130 # PR number
+labels: [] # Optional: ["high-risk", "db-migration"]

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/MonitorDetailsWidget.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/MonitorDetailsWidget.tsx
@@ -1,7 +1,6 @@
 import { skipToken } from "@reduxjs/toolkit/query";
 import { Descriptions, Flex, Paragraph, Text } from "fidesui";
 
-import { useFlags } from "~/features/common/features";
 import { RouterLink } from "~/features/common/nav/RouterLink";
 import {
   EDIT_SYSTEM_ROUTE,
@@ -18,9 +17,6 @@ export interface MonitorDetailsWidgetProps {
 }
 
 const MonitorDetailsWidget = ({ monitorId }: MonitorDetailsWidgetProps) => {
-  const {
-    flags: { heliosInsights },
-  } = useFlags();
   const { data: configData } = useGetMonitorConfigQuery(
     {
       monitor_config_id: monitorId,
@@ -35,66 +31,64 @@ const MonitorDetailsWidget = ({ monitorId }: MonitorDetailsWidgetProps) => {
   );
 
   return (
-    heliosInsights && (
-      <Flex className="w-full" gap="middle" vertical>
-        <Text strong>Details</Text>
-        <Descriptions
-          size="small"
-          items={[
-            {
-              label: "System",
-              children:
-                connectionData?.linked_systems &&
-                connectionData.linked_systems.length > 0 ? (
-                  <Paragraph
-                    ellipsis={{
-                      rows: 1,
-                      tooltip: { title: connectionData?.system_key },
-                    }}
-                  >
-                    {connectionData?.linked_systems?.map((linkedSystem) => (
-                      <RouterLink
-                        key={linkedSystem.fides_key}
-                        href={EDIT_SYSTEM_ROUTE.replace(
-                          "[id]",
-                          linkedSystem.fides_key,
-                        )}
-                      >
-                        {" "}
-                        {linkedSystem.name}
-                      </RouterLink>
-                    ))}
-                  </Paragraph>
-                ) : (
-                  "None"
-                ),
-              span: "filled",
-            },
-            {
-              label: "Integration",
-              children: (
+    <Flex className="w-full" gap="middle" vertical>
+      <Text strong>Details</Text>
+      <Descriptions
+        size="small"
+        items={[
+          {
+            label: "System",
+            children:
+              connectionData?.linked_systems &&
+              connectionData.linked_systems.length > 0 ? (
                 <Paragraph
                   ellipsis={{
                     rows: 1,
-                    tooltip: { title: connectionData?.key },
+                    tooltip: { title: connectionData?.system_key },
                   }}
                 >
-                  <RouterLink
-                    href={INTEGRATION_DETAIL_ROUTE.replace(
-                      "[id]",
-                      connectionData?.key ?? "",
-                    )}
-                  >
-                    {connectionData?.key}
-                  </RouterLink>
+                  {connectionData?.linked_systems?.map((linkedSystem) => (
+                    <RouterLink
+                      key={linkedSystem.fides_key}
+                      href={EDIT_SYSTEM_ROUTE.replace(
+                        "[id]",
+                        linkedSystem.fides_key,
+                      )}
+                    >
+                      {" "}
+                      {linkedSystem.name}
+                    </RouterLink>
+                  ))}
                 </Paragraph>
+              ) : (
+                "None"
               ),
-              span: "filled",
-            },
-          ]}
-        />
-      </Flex>
-    )
+            span: "filled",
+          },
+          {
+            label: "Integration",
+            children: (
+              <Paragraph
+                ellipsis={{
+                  rows: 1,
+                  tooltip: { title: connectionData?.key },
+                }}
+              >
+                <RouterLink
+                  href={INTEGRATION_DETAIL_ROUTE.replace(
+                    "[id]",
+                    connectionData?.key ?? "",
+                  )}
+                >
+                  {connectionData?.key}
+                </RouterLink>
+              </Paragraph>
+            ),
+            span: "filled",
+          },
+        ]}
+      />
+    </Flex>
   );
 };
 

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/MonitorProgressWidget.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/MonitorProgressWidget.tsx
@@ -1,7 +1,6 @@
 import { Button, Flex, Icons, Text, Title } from "fidesui";
 import { useQueryStates } from "nuqs";
 
-import { useFlags } from "~/features/common/features";
 import { RouterLink } from "~/features/common/nav/RouterLink";
 import { INTEGRATION_MANAGEMENT_ROUTE } from "~/features/common/nav/routes";
 import { APIMonitorType } from "~/types/api/models/APIMonitorType";
@@ -31,9 +30,6 @@ const MonitorProgressWidget = ({
   monitorId,
   monitorType,
 }: MonitorProgressWidgetProps) => {
-  const {
-    flags: { heliosInsights },
-  } = useFlags();
   const [filters] = useQueryStates(
     SearchFormQueryState(Object.values(APIMonitorType)),
   );
@@ -52,38 +48,35 @@ const MonitorProgressWidget = ({
   const totalMonitors = data?.total_monitors ?? 0;
 
   return (
-    heliosInsights && (
-      <Flex className="w-full" gap="middle">
-        {(data && totalMonitors > 0) || !!filters.steward_key || isLoading ? (
-          <ProgressCard
-            {...buildWidgetProps({
-              monitor_type: monitorType,
-              total_monitors: totalMonitors,
-              ...data,
-            })}
-            compact={!!monitorId}
-            disabled={
-              (!!filters.monitor_type &&
-                monitorType !== filters.monitor_type) ||
-              (!!filters.steward_key && totalMonitors <= 0)
-            }
-          />
-        ) : (
-          <div>
-            <Flex vertical gap="small" justify="center">
-              <Title level={5}>{MONITOR_TYPE_TO_LABEL[monitorType]}</Title>
-              <Text>{renderIcon(MONITOR_TYPE_TO_ICON[monitorType])}</Text>
-              <Text type="secondary">
-                {MONITOR_TYPE_TO_EMPTY_TEXT[monitorType]}
-              </Text>
-              <RouterLink href={INTEGRATION_MANAGEMENT_ROUTE}>
-                <Button type="primary">Create</Button>
-              </RouterLink>
-            </Flex>
-          </div>
-        )}
-      </Flex>
-    )
+    <Flex className="w-full" gap="middle">
+      {(data && totalMonitors > 0) || !!filters.steward_key || isLoading ? (
+        <ProgressCard
+          {...buildWidgetProps({
+            monitor_type: monitorType,
+            total_monitors: totalMonitors,
+            ...data,
+          })}
+          compact={!!monitorId}
+          disabled={
+            (!!filters.monitor_type && monitorType !== filters.monitor_type) ||
+            (!!filters.steward_key && totalMonitors <= 0)
+          }
+        />
+      ) : (
+        <div>
+          <Flex vertical gap="small" justify="center">
+            <Title level={5}>{MONITOR_TYPE_TO_LABEL[monitorType]}</Title>
+            <Text>{renderIcon(MONITOR_TYPE_TO_ICON[monitorType])}</Text>
+            <Text type="secondary">
+              {MONITOR_TYPE_TO_EMPTY_TEXT[monitorType]}
+            </Text>
+            <RouterLink href={INTEGRATION_MANAGEMENT_ROUTE}>
+              <Button type="primary">Create</Button>
+            </RouterLink>
+          </Flex>
+        </div>
+      )}
+    </Flex>
   );
 };
 

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/MonitorStats.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/MonitorStats.tsx
@@ -1,7 +1,6 @@
 import classNames from "classnames";
 import { Divider, Flex } from "fidesui";
 
-import { useFlags } from "~/features/common/features";
 import { APIMonitorType } from "~/types/api/models/APIMonitorType";
 
 import MonitorDetailsWidget from "./MonitorDetailsWidget";
@@ -19,56 +18,47 @@ const STATS_EXCLUDED_TYPES: Set<APIMonitorType> = new Set([
 ]);
 
 const MonitorStats = ({ monitorId, monitorType }: MonitorStatsProps) => {
-  const {
-    flags: { heliosInsights },
-  } = useFlags();
-
   if (monitorType && STATS_EXCLUDED_TYPES.has(monitorType)) {
     return null;
   }
 
   return (
-    heliosInsights && (
-      <Flex className={classNames("w-full")} gap="middle">
-        {Object.values(monitorType ? [monitorType] : APIMonitorType)
-          .filter((mType) => !STATS_EXCLUDED_TYPES.has(mType))
-          .toReversed()
-          .map((mType) => (
-            <MonitorProgressWidget
-              monitorType={mType}
-              monitorId={monitorId}
-              key={mType}
-            />
-          ))
-          .reduce(
-            (prev, curr) => [
-              prev,
-              ...(prev[0]
-                ? [
-                    <Divider
-                      vertical
-                      className="h-full"
-                      key={`${curr.key}--divider`}
-                    />,
-                  ]
-                : []),
-              curr,
-            ],
-            [] as React.ReactNode[],
-          )}
-        {monitorId && monitorType && (
-          <>
-            <Divider vertical className="h-full" />
-            <MonitorStatsWidget
-              monitorType={monitorType}
-              monitorId={monitorId}
-            />
-            <Divider vertical className="h-full" />
-            <MonitorDetailsWidget monitorId={monitorId} />
-          </>
+    <Flex className={classNames("w-full")} gap="middle">
+      {Object.values(monitorType ? [monitorType] : APIMonitorType)
+        .filter((mType) => !STATS_EXCLUDED_TYPES.has(mType))
+        .toReversed()
+        .map((mType) => (
+          <MonitorProgressWidget
+            monitorType={mType}
+            monitorId={monitorId}
+            key={mType}
+          />
+        ))
+        .reduce(
+          (prev, curr) => [
+            prev,
+            ...(prev[0]
+              ? [
+                  <Divider
+                    vertical
+                    className="h-full"
+                    key={`${curr.key}--divider`}
+                  />,
+                ]
+              : []),
+            curr,
+          ],
+          [] as React.ReactNode[],
         )}
-      </Flex>
-    )
+      {monitorId && monitorType && (
+        <>
+          <Divider vertical className="h-full" />
+          <MonitorStatsWidget monitorType={monitorType} monitorId={monitorId} />
+          <Divider vertical className="h-full" />
+          <MonitorDetailsWidget monitorId={monitorId} />
+        </>
+      )}
+    </Flex>
   );
 };
 

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/MonitorStatsWidget.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/MonitorStatsWidget.tsx
@@ -1,7 +1,6 @@
 import { Descriptions, Flex, Paragraph, Text } from "fidesui";
 import { useQueryStates } from "nuqs";
 
-import { useFlags } from "~/features/common/features";
 import { nFormatter } from "~/features/common/utils";
 import { APIMonitorType } from "~/types/api/models/APIMonitorType";
 
@@ -18,9 +17,6 @@ const MonitorStatsWidget = ({
   monitorId,
   monitorType,
 }: MonitorStatsWidgetProps) => {
-  const {
-    flags: { heliosInsights },
-  } = useFlags();
   const [filters] = useQueryStates(
     SearchFormQueryState(Object.values(APIMonitorType)),
   );
@@ -44,65 +40,60 @@ const MonitorStatsWidget = ({
   });
 
   return (
-    heliosInsights && (
-      <Flex className="w-full" gap="middle" vertical>
-        <Text strong>Classification</Text>
-        <Descriptions
-          size="small"
-          items={[
-            {
-              label: numericStats?.label,
-              children: (
-                <Paragraph
-                  ellipsis={{
-                    rows: 1,
-                    tooltip: {
-                      title: numericStats?.data
-                        .map((stat) => `${stat.count} ${stat.label}`)
-                        .join(", "),
-                    },
-                  }}
-                >
-                  {numericStats && (numericStats?.data.length ?? 0) > 0
-                    ? numericStats.data
-                        .map((stat) => `${stat.count} ${stat.label}`)
-                        .join(", ")
-                    : "None"}
-                </Paragraph>
-              ),
-              span: "filled",
-            },
-            {
-              label: percentageStats?.label,
-              children: (
-                <Paragraph
-                  ellipsis={{
-                    rows: 1,
-                    tooltip: percentageStats?.data
+    <Flex className="w-full" gap="middle" vertical>
+      <Text strong>Classification</Text>
+      <Descriptions
+        size="small"
+        items={[
+          {
+            label: numericStats?.label,
+            children: (
+              <Paragraph
+                ellipsis={{
+                  rows: 1,
+                  tooltip: {
+                    title: numericStats?.data
+                      .map((stat) => `${stat.count} ${stat.label}`)
+                      .join(", "),
+                  },
+                }}
+              >
+                {numericStats && (numericStats?.data.length ?? 0) > 0
+                  ? numericStats.data
+                      .map((stat) => `${stat.count} ${stat.label}`)
+                      .join(", ")
+                  : "None"}
+              </Paragraph>
+            ),
+            span: "filled",
+          },
+          {
+            label: percentageStats?.label,
+            children: (
+              <Paragraph
+                ellipsis={{
+                  rows: 1,
+                  tooltip: percentageStats?.data
+                    .map((stat) => `${stat.label} (${nFormatter(stat.value)}%)`)
+                    .join(", "),
+                }}
+              >
+                {percentageStats?.data &&
+                (percentageStats?.data.length ?? 0) > 0
+                  ? percentageStats.data
                       .map(
                         (stat) => `${stat.label} (${nFormatter(stat.value)}%)`,
                       )
-                      .join(", "),
-                  }}
-                >
-                  {percentageStats?.data &&
-                  (percentageStats?.data.length ?? 0) > 0
-                    ? percentageStats.data
-                        .map(
-                          (stat) =>
-                            `${stat.label} (${nFormatter(stat.value)}%)`,
-                        )
-                        .join(", ")
-                    : "None"}
-                </Paragraph>
-              ),
+                      .join(", ")
+                  : "None"}
+              </Paragraph>
+            ),
 
-              span: "filled",
-            },
-          ]}
-        />
-      </Flex>
-    )
+            span: "filled",
+          },
+        ]}
+      />
+    </Flex>
   );
 };
 

--- a/clients/admin-ui/src/flags.json
+++ b/clients/admin-ui/src/flags.json
@@ -112,13 +112,6 @@
     "test": false,
     "production": false
   },
-  "heliosInsights": {
-    "label": "Helios insights",
-    "description": "Enable the new monitor progress widgets for the action center in Helios",
-    "development": true,
-    "test": true,
-    "production": false
-  },
   "alphaPrivacyDocUpload": {
     "label": "Alpha Privacy Document Upload",
     "description": "Enable users to use and see the UI in PBAC",


### PR DESCRIPTION
Ticket [ENG-3734] <!-- simply paste the ticket number between the brackets and it will auto-convert to a link -->

### Description Of Changes

Removing `HeliosInsights` flag

### Code Changes

* <!-- list your code changes -->

### Steps to Confirm

1. Confirm that the helios insights flag no longer exists in the admin settings
2. Verify that the statistics widget always displays in the action center

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-3734]: https://ethyca.atlassian.net/browse/ENG-3734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ