### PR TITLE
ENG-3617: fix system integration form keys misalignment, make it look more consistent with other forms

### DIFF
--- a/changelog/8131-fix-integration-form-misalignment.yaml
+++ b/changelog/8131-fix-integration-form-misalignment.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Fixed misaligned field labels on the system integration configuration form. Aligned its look more with other forms.
+pr: 8131
+labels: []

--- a/clients/admin-ui/src/features/common/form/FormFieldFromSchema.tsx
+++ b/clients/admin-ui/src/features/common/form/FormFieldFromSchema.tsx
@@ -10,7 +10,6 @@ export type FormFieldProps = {
   name: string;
   fieldSchema: ConnectionTypeSecretSchemaProperty;
   isRequired: boolean;
-  layout?: "stacked" | "inline";
   secretsSchema?: ConnectionTypeSecretSchemaResponse;
   validate?: (value: string | undefined) => string | undefined;
 };
@@ -19,7 +18,6 @@ export const FormFieldFromSchema = ({
   name,
   fieldSchema,
   isRequired,
-  layout = "stacked",
   secretsSchema,
   validate,
 }: FormFieldProps) => {
@@ -64,7 +62,6 @@ export const FormFieldFromSchema = ({
     label: fieldSchema.title,
     tooltip: fieldSchema.description,
     rules,
-    layout: layout === "inline" ? ("horizontal" as const) : undefined,
   };
 
   if (isSelect) {

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParameters.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParameters.tsx
@@ -440,9 +440,7 @@ export const ConnectorParameters = ({
         mb={4}
       >
         <div>
-          Connect to your {connectionOption!.human_readable} environment by
-          providing the information below. Once you have saved the form, you may
-          test the integration to confirm that it&apos;s working correctly.
+          {`Connect to your ${connectionOption!.human_readable} environment by providing the information below. Once you have saved the form, you may test the integration to confirm that it's working correctly.`}
         </div>
         {connectionOption.user_guide && (
           <div style={{ marginTop: "12px" }}>

--- a/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParametersForm.tsx
+++ b/clients/admin-ui/src/features/datastore-connections/system_portal_config/forms/ConnectorParametersForm.tsx
@@ -284,15 +284,13 @@ export const ConnectorParametersForm = ({
       {contextHolder}
       <Form
         form={form}
-        layout="horizontal"
+        layout="vertical"
         initialValues={initialFormValues}
         onFinish={handleFinish}
         key={connectionConfig?.key ?? "create"}
         validateTrigger="onBlur"
-        labelCol={{ flex: "180px" }}
-        labelAlign="left"
       >
-        <Flex vertical>
+        <Flex vertical className="[&_.ant-form-item]:mb-4">
           <Form.Item
             name="name"
             label="Name"
@@ -350,7 +348,6 @@ export const ConnectorParametersForm = ({
                     isRequired={secretsSchema.required?.includes(key)}
                     secretsSchema={secretsSchema}
                     validate={getFieldValidation(key, item)}
-                    layout="inline"
                   />
                 );
               })

--- a/clients/admin-ui/src/features/integrations/add-integration/ConfigureIntegrationForm.tsx
+++ b/clients/admin-ui/src/features/integrations/add-integration/ConfigureIntegrationForm.tsx
@@ -480,7 +480,7 @@ export const ConfigureIntegrationForm = ({
         onFinish={handleSubmit}
         key={connection?.key ?? "create"}
       >
-        <Flex vertical className="mt-4">
+        <Flex vertical className="mt-4 [&_.ant-form-item]:mb-4">
           <Form.Item
             name="name"
             label="Name"


### PR DESCRIPTION
Ticket [ENG-3617] <!-- simply paste the ticket number between the brackets and it will auto-convert to a link -->

### Description Of Changes

The integration form on the system Integrations tab had misaligned field labels: a horizontal layout with a fixed 180px label column produced inconsistent gaps between each label and its input, since label lengths vary. Switched the form to a vertical layout (labels above inputs) to match other admin-ui forms like the Add Integration modal, tightened Form.Item spacing for visual consistency, and fixed a JSX whitespace bug that was rendering the description text as "Amazon S3environment" / "BigQueryenvironment" without a space.

### Before

<img width="2688" height="1660" alt="image" src="https://github.com/user-attachments/assets/5d3a1a33-21b4-42ff-bffd-d3e9f4073aa5" />

### After

<img width="2592" height="1870" alt="image" src="https://github.com/user-attachments/assets/e96dcd12-e0d8-400c-9e4c-30ef11341fac" />


### Code Changes

* Switched `<Form>` in `ConnectorParametersForm.tsx` from `layout="horizontal"` to `layout="vertical"` and dropped `labelCol`/`labelAlign`.
* Removed the now-unused `layout` prop and corresponding `Form.Item` override from `FormFieldFromSchema`.
* Applied `[&_.ant-form-item]:mb-4` to the `<Flex>` wrapper in both `ConnectorParametersForm` and `ConfigureIntegrationForm` to standardize Form.Item bottom spacing at 16px.
* Rewrote the description text in `ConnectorParameters.tsx` as a template literal to preserve the space between the connector name and "environment".

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-3617]: https://ethyca.atlassian.net/browse/ENG-3617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
