### PR TITLE
feat(form-builder): show thinking spinner while LLM streams

### DIFF
--- a/changelog/8135-form-builder-thinking-spinner.yaml
+++ b/changelog/8135-form-builder-thinking-spinner.yaml
@@ -1,0 +1,4 @@
+type: Added
+description: Loading spinner in the privacy center form builder chat while the LLM is streaming a response
+pr: 8135
+labels: []

--- a/clients/admin-ui/src/features/properties/privacy-center-config/form-builder/ChatPane.tsx
+++ b/clients/admin-ui/src/features/properties/privacy-center-config/form-builder/ChatPane.tsx
@@ -1,4 +1,4 @@
-import { Alert, Button, Input, SparkleIcon } from "fidesui";
+import { Alert, Button, Input, SparkleIcon, Spin } from "fidesui";
 import { useEffect, useRef, useState } from "react";
 
 import type { ChatMessage, Status } from "./useFormBuilder";
@@ -84,6 +84,20 @@ export const ChatPane = ({
             {m.content}
           </div>
         ))}
+        {isStreaming && (
+          <div
+            data-role="assistant-thinking"
+            style={{
+              padding: 8,
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+            }}
+          >
+            <Spin size="small" />
+            <span>Thinking…</span>
+          </div>
+        )}
       </div>
       <div style={composerStyle}>
         <Input.TextArea

--- a/clients/admin-ui/src/features/properties/privacy-center-config/form-builder/ChatPane.tsx
+++ b/clients/admin-ui/src/features/properties/privacy-center-config/form-builder/ChatPane.tsx
@@ -86,7 +86,9 @@ export const ChatPane = ({
         ))}
         {isStreaming && (
           <div
-            data-role="assistant-thinking"
+            role="status"
+            aria-live="polite"
+            aria-label="Assistant is thinking"
             style={{
               padding: 8,
               display: "flex",
@@ -95,7 +97,6 @@ export const ChatPane = ({
             }}
           >
             <Spin size="small" />
-            <span>Thinking…</span>
           </div>
         )}
       </div>

--- a/clients/admin-ui/src/features/properties/privacy-center-config/form-builder/__tests__/ChatPane.test.tsx
+++ b/clients/admin-ui/src/features/properties/privacy-center-config/form-builder/__tests__/ChatPane.test.tsx
@@ -18,6 +18,32 @@ describe("ChatPane", () => {
     expect(screen.getByRole("textbox")).toBeDisabled();
   });
 
+  it("shows a thinking indicator while streaming", () => {
+    render(
+      <ChatPane
+        messages={[{ role: "user", content: "Add an email field" }]}
+        status="streaming"
+        error={null}
+        onSend={jest.fn()}
+        onAbort={jest.fn()}
+      />,
+    );
+    expect(screen.getByText(/thinking/i)).toBeInTheDocument();
+  });
+
+  it("does not show a thinking indicator when idle", () => {
+    render(
+      <ChatPane
+        messages={[]}
+        status="idle"
+        error={null}
+        onSend={jest.fn()}
+        onAbort={jest.fn()}
+      />,
+    );
+    expect(screen.queryByText(/thinking/i)).not.toBeInTheDocument();
+  });
+
   it("calls onSend with the typed text and clears input", async () => {
     const onSend = jest.fn();
     render(

--- a/clients/admin-ui/src/features/properties/privacy-center-config/form-builder/__tests__/ChatPane.test.tsx
+++ b/clients/admin-ui/src/features/properties/privacy-center-config/form-builder/__tests__/ChatPane.test.tsx
@@ -28,7 +28,9 @@ describe("ChatPane", () => {
         onAbort={jest.fn()}
       />,
     );
-    expect(screen.getByText(/thinking/i)).toBeInTheDocument();
+    const status = screen.getByRole("status", { name: /thinking/i });
+    expect(status).toBeInTheDocument();
+    expect(status.querySelector('[aria-busy="true"]')).toBeInTheDocument();
   });
 
   it("does not show a thinking indicator when idle", () => {
@@ -41,7 +43,9 @@ describe("ChatPane", () => {
         onAbort={jest.fn()}
       />,
     );
-    expect(screen.queryByText(/thinking/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("status", { name: /thinking/i }),
+    ).not.toBeInTheDocument();
   });
 
   it("calls onSend with the typed text and clears input", async () => {


### PR DESCRIPTION
Ticket [] <!-- no ticket -->

### Description Of Changes

While the privacy center form builder's chat is streaming a response from the LLM, the input disabled and Send swapped to Stop, but there was no visual indication that the model was actually working. This PR adds a small antd `Spin` row labelled "Thinking…" at the bottom of the messages list, visible only while `status === "streaming"`.

The spinner uses `Spin` from `fidesui` (the project's shared antd `Spin` wrapper, already used in ~12 places across admin-ui).

### Code Changes

* `clients/admin-ui/src/features/properties/privacy-center-config/form-builder/ChatPane.tsx` — import `Spin` from `fidesui`; render a `<Spin size="small" /> Thinking…` row at the bottom of the messages list while streaming. Reuses the existing auto-scroll `useEffect` (`isStreaming` is already in its dep array).
* `clients/admin-ui/src/features/properties/privacy-center-config/form-builder/__tests__/ChatPane.test.tsx` — two new test cases asserting the indicator is visible while `status="streaming"` and absent when `status="idle"`.

### Steps to Confirm

1. Check out this branch and start admin-ui (`nox -s "dev(slim)" -- fides-pkg fides-admin-ui`).
2. Navigate to a property → privacy center config → a form (e.g. `default_access_policy`).
3. Type any non-trivial request into the chat composer (e.g. "add a date of birth field with validation") and press Send.
4. Confirm a `Thinking…` row with an animated antd spinner appears at the bottom of the messages list while the LLM streams.
5. Confirm the spinner disappears once the assistant message arrives or when Stop is pressed.

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required