### PR TITLE
Change domain validation default from monitor to enabled

### DIFF
--- a/changelog/0000-domain-validation-default-enabled.yaml
+++ b/changelog/0000-domain-validation-default-enabled.yaml
@@ -1,0 +1,4 @@
+type: Changed
+description: Default enforcement level for domain validation (`FIDES__SECURITY__DOMAIN_VALIDATION_MODE`) changed from `monitor` to `enabled`. Disallowed domains will now be blocked instead of only logged.
+pr: 0000
+labels: ["high-risk"]

--- a/changelog/8141-domain-validation-default-enabled.yaml
+++ b/changelog/8141-domain-validation-default-enabled.yaml
@@ -1,4 +1,4 @@
 type: Changed
 description: Default enforcement level for domain validation (`FIDES__SECURITY__DOMAIN_VALIDATION_MODE`) changed from `monitor` to `enabled`. Disallowed domains will now be blocked instead of only logged.
-pr: 0000
+pr: 8141
 labels: ["high-risk"]

--- a/src/fides/api/util/domain_util.py
+++ b/src/fides/api/util/domain_util.py
@@ -44,7 +44,7 @@ def validate_value_against_allowed_list(
     value: str,
     allowed_values: List[str],
     param_name: str,
-    mode: DomainValidationMode = DomainValidationMode.monitor,
+    mode: DomainValidationMode = DomainValidationMode.enabled,
 ) -> None:
     """
     Validate that a value matches at least one of the allowed patterns.

--- a/src/fides/config/security_settings.py
+++ b/src/fides/config/security_settings.py
@@ -161,7 +161,7 @@ class SecuritySettings(FidesSettings):
         description="The number of seconds that a pre-signed download URL when using S3 storage will be valid. The default is equal to 5 days.",
     )
     domain_validation_mode: DomainValidationMode = Field(
-        default=DomainValidationMode.monitor,
+        default=DomainValidationMode.enabled,
         description="Controls domain validation for SaaS connector params globally. "
         "'enabled' enforces validation and blocks disallowed domains. "
         "'monitor' validates but only logs warnings instead of blocking. "


### PR DESCRIPTION
Ticket [ENG-]

### Description Of Changes

Changes the default enforcement level of `FIDES__SECURITY__DOMAIN_VALIDATION_MODE` from `monitor` to `enabled`. After the burn-in period, domain validation now actively blocks disallowed domains instead of only logging warnings.

To revert to the previous behavior, explicitly set:
```
FIDES__SECURITY__DOMAIN_VALIDATION_MODE=monitor
```

### Code Changes

* Changed the default value of `domain_validation_mode` in `SecuritySettings` from `monitor` to `enabled`
* Updated the function parameter default in `validate_value_against_allowed_list` to match

### Steps to Confirm

1. Start the application without setting `FIDES__SECURITY__DOMAIN_VALIDATION_MODE`
2. Configure a SaaS connector with a domain not in the allowed list
3. Confirm the request is **blocked** with a `DomainValidationError`
4. Set `FIDES__SECURITY__DOMAIN_VALIDATION_MODE=monitor` and confirm requests are only warned, not blocked
5. Set `FIDES__SECURITY__DOMAIN_VALIDATION_MODE=disabled` and confirm validation is skipped entirely

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [x] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required