### PR TITLE
Add new queue size health check endpoint to avoid querying workers

### DIFF
--- a/src/fides/api/v1/endpoints/health.py
+++ b/src/fides/api/v1/endpoints/health.py
@@ -106,6 +106,12 @@ class WorkerHealthCheck(BaseModel):
     queue_counts: Dict[str, int]
 
 
+class QueueHealthCheck(BaseModel):
+    """Celery queue depth healthcheck (queue sizes only)."""
+
+    queue_counts: Dict[str, int]
+
+
 def get_cache_health() -> str:
     """Checks if the cache is reachable"""
 
@@ -328,6 +334,43 @@ async def workers_health() -> Dict:
         response["workers_enabled"] = True
         # Figure out a way to make this faster
         response["workers"] = get_worker_ids()
+        response["queue_counts"] = get_queue_counts()
+
+    return response
+
+
+@HEALTH_ROUTER.get(
+    "/health/queues",
+    response_model=QueueHealthCheck,
+    responses={
+        status.HTTP_200_OK: {
+            "content": {
+                "application/json": {
+                    "example": {
+                        "queue_counts": {"fides": 0, "fides.dsr": 0},
+                    }
+                }
+            }
+        },
+        status.HTTP_503_SERVICE_UNAVAILABLE: {
+            "content": {
+                "application/json": {
+                    "example": {
+                        "detail": {
+                            "queue_counts": {"fides": 0, "fides.dsr": 0},
+                        }
+                    }
+                }
+            }
+        },
+    },
+)
+async def queues_health() -> Dict:
+    """Return Celery queue depths when workers are enabled; empty counts otherwise."""
+    response = QueueHealthCheck(queue_counts={}).model_dump(mode="json")
+
+    fides_is_using_workers = not celery_app.conf["task_always_eager"]
+    if fides_is_using_workers:
         response["queue_counts"] = get_queue_counts()
 
     return response

--- a/tests/ctl/core/test_api.py
+++ b/tests/ctl/core/test_api.py
@@ -3665,6 +3665,36 @@ class TestHealthchecks:
             },
         }
 
+    def test_queue_healthcheck(
+        self,
+        test_config: FidesConfig,
+        test_client: TestClient,
+    ) -> None:
+        """Test the queue depth healthcheck when workers are disabled (eager)."""
+        response = test_client.get(test_config.cli.server_url + "/health/queues")
+        assert response.status_code == 200
+        assert response.json() == {"queue_counts": {}}
+
+    @pytest.mark.usefixtures("enable_celery_worker")
+    def test_queue_health_check_with_workers_enabled(self, test_config, test_client):
+        response = test_client.get(test_config.cli.server_url + "/health/queues")
+        assert response.status_code == 200
+        assert response.json() == {
+            "queue_counts": {
+                "fides.dsr": 0,
+                "fidesops.messaging": 0,
+                "fides.privacy_preferences": 0,
+                "fides.privacy_request_exports": 0,
+                "fides.privacy_request_ingestion": 0,
+                "fidesplus.consent_webhooks": 0,
+                "fidesplus.discovery_monitors_classification": 0,
+                "fidesplus.discovery_monitors_detection": 0,
+                "fidesplus.discovery_monitors_promotion": 0,
+                "fidesplus.bulk_consent_import": 0,
+                "fides": 0,
+            },
+        }
+
 
 @pytest.mark.integration
 @pytest.mark.parametrize("endpoint_name", [f"{API_PREFIX}/organization", "/health"])


### PR DESCRIPTION
This adds a separate health endpoint that only returns queue sizes to avoid querying workers just to see the queue depths and avoid un-needed Celery control traffic