### PR TITLE
Move DSR cache sweep to a single pass

### DIFF
--- a/src/fides/api/util/cache.py
+++ b/src/fides/api/util/cache.py
@@ -1,6 +1,6 @@
 import json
 import os
-from typing import Any, Dict, Iterator, List, Optional, Union, cast
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Union, cast
 from urllib.parse import unquote_to_bytes
 
 from loguru import logger
@@ -106,6 +106,55 @@ class FidesopsRedis:
                     yield list(keys)
                 if scan_cursor == 0 or scan_cursor == "0":
                     break
+
+    def sadd_members_chunked(
+        self,
+        key: str,
+        members: Iterable[Any],
+        *,
+        chunk_size: int = 2000,
+    ) -> None:
+        """
+        Add many members to a Redis SET using bounded ``SADD`` calls.
+
+        Avoids sending an unbounded variadic ``SADD`` when ``members`` is huge.
+        """
+        batch: list[Any] = []
+        for m in members:
+            batch.append(m)
+            if len(batch) >= chunk_size:
+                self._client.sadd(key, *batch)
+                batch.clear()
+        if batch:
+            self._client.sadd(key, *batch)
+
+    def unlink_many(self, keys: List[str]) -> tuple[int, int]:
+        """
+        UNLINK many keys. Cluster-safe (per-key on cluster). Returns ``(deleted, errors)``.
+        """
+        if not keys:
+            return 0, 0
+        deleted = 0
+        errors = 0
+        if self.is_cluster:
+            for k in keys:
+                try:
+                    self._client.unlink(k)
+                    deleted += 1
+                except Exception:  # noqa: BLE001
+                    errors += 1
+            return deleted, errors
+        try:
+            self._client.unlink(*keys)
+            return len(keys), 0
+        except Exception:  # noqa: BLE001
+            for k in keys:
+                try:
+                    self._client.unlink(k)
+                    deleted += 1
+                except Exception:  # noqa: BLE001
+                    errors += 1
+            return deleted, errors
 
     def set_with_autoexpire(
         self,

--- a/src/fides/api/util/cache.py
+++ b/src/fides/api/util/cache.py
@@ -46,48 +46,6 @@ def _is_redis_cluster(client: Any) -> bool:
     return RedisCluster is not None and isinstance(client, RedisCluster)
 
 
-def iter_redis_scan_batches(
-    redis_client: Any,
-    *,
-    count: int,
-    match: Optional[str] = None,
-) -> Iterator[List[Any]]:
-    """
-    Yield batches of keys from Redis SCAN (cluster-aware).
-
-    ``redis_client`` may be ``redis.Redis``, ``RedisCluster``, or ``FidesopsRedis``
-    (the latter is unwrapped to ``._client``).
-    When ``match`` is None, the full keyspace is scanned (no MATCH filter).
-    """
-    underlying = getattr(redis_client, "_client", redis_client)
-    scan_kwargs: Dict[str, Any] = {"count": count}
-    if match is not None:
-        scan_kwargs["match"] = match
-
-    if _is_redis_cluster(underlying):
-        cluster = cast(Any, underlying)
-        for node in cluster.get_primaries():
-            conn = node.redis_connection
-            cursor = 0
-            while True:
-                cursor, keys = conn.scan(cursor=cursor, **scan_kwargs)
-                if keys:
-                    yield list(keys)
-                if cursor == 0:
-                    break
-    else:
-        scan_cursor: Union[int, str] = "0"
-        while True:
-            cursor_arg = (
-                int(scan_cursor) if isinstance(scan_cursor, str) else scan_cursor
-            )
-            scan_cursor, keys = underlying.scan(cursor=cursor_arg, **scan_kwargs)
-            if keys:
-                yield list(keys)
-            if scan_cursor == 0 or scan_cursor == "0":
-                break
-
-
 class FidesopsRedis:
     """
     Wrapper around Redis or RedisCluster that adds Fides-specific helpers (auto-expire,
@@ -106,6 +64,49 @@ class FidesopsRedis:
         """Delegate attribute lookups to the underlying Redis client."""
         return getattr(self._client, name)
 
+    @property
+    def is_cluster(self) -> bool:
+        """True when the backing client is Redis Cluster."""
+        return _is_redis_cluster(self._client)
+
+    def iter_scan_batches(
+        self,
+        *,
+        count: int,
+        match: Optional[str] = None,
+    ) -> Iterator[List[Any]]:
+        """
+        Yield batches of keys from Redis SCAN (cluster-aware).
+
+        When ``match`` is None, the full keyspace is scanned (no MATCH filter).
+        """
+        scan_kwargs: Dict[str, Any] = {"count": count}
+        if match is not None:
+            scan_kwargs["match"] = match
+
+        if _is_redis_cluster(self._client):
+            cluster = cast(Any, self._client)
+            for node in cluster.get_primaries():
+                conn = node.redis_connection
+                cursor = 0
+                while True:
+                    cursor, keys = conn.scan(cursor=cursor, **scan_kwargs)
+                    if keys:
+                        yield list(keys)
+                    if cursor == 0:
+                        break
+        else:
+            scan_cursor: Union[int, str] = "0"
+            while True:
+                cursor_arg = (
+                    int(scan_cursor) if isinstance(scan_cursor, str) else scan_cursor
+                )
+                scan_cursor, keys = self._client.scan(cursor=cursor_arg, **scan_kwargs)
+                if keys:
+                    yield list(keys)
+                if scan_cursor == 0 or scan_cursor == "0":
+                    break
+
     def set_with_autoexpire(
         self,
         key: str,
@@ -121,32 +122,8 @@ class FidesopsRedis:
         """Retrieve all keys that match a given prefix. Cluster-aware (scans all nodes)."""
         out: List[str] = []
         match = f"{prefix}*"
-        if _is_redis_cluster(self._client):
-            # Redis Cluster: SCAN must run per node; iterate primaries
-            cluster = cast(Any, self._client)
-            for node in cluster.get_primaries():
-                conn = node.redis_connection
-                cursor = 0
-                while True:
-                    cursor, keys = conn.scan(
-                        cursor=cursor, match=match, count=chunk_size
-                    )
-                    out.extend(keys)
-                    if cursor == 0:
-                        break
-        else:
-            # Standalone Redis: scan returns cursor as str when decode_responses=True
-            scan_cursor: Union[int, str] = "0"
-            while True:
-                cursor_arg = (
-                    int(scan_cursor) if isinstance(scan_cursor, str) else scan_cursor
-                )
-                scan_cursor, keys = self._client.scan(
-                    cursor=cursor_arg, match=match, count=chunk_size
-                )
-                out.extend(keys)
-                if scan_cursor == 0 or scan_cursor == "0":
-                    break
+        for batch in self.iter_scan_batches(count=chunk_size, match=match):
+            out.extend(batch)
         return out
 
     def delete_keys_by_prefix(self, prefix: str) -> None:

--- a/src/fides/api/util/cache.py
+++ b/src/fides/api/util/cache.py
@@ -1,6 +1,6 @@
 import json
 import os
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, Dict, Iterator, List, Optional, Union, cast
 from urllib.parse import unquote_to_bytes
 
 from loguru import logger
@@ -44,6 +44,48 @@ _read_only_connection = None
 def _is_redis_cluster(client: Any) -> bool:
     """Return True if the client is a Redis Cluster (for cluster-aware behavior)."""
     return RedisCluster is not None and isinstance(client, RedisCluster)
+
+
+def iter_redis_scan_batches(
+    redis_client: Any,
+    *,
+    count: int,
+    match: Optional[str] = None,
+) -> Iterator[List[Any]]:
+    """
+    Yield batches of keys from Redis SCAN (cluster-aware).
+
+    ``redis_client`` may be ``redis.Redis``, ``RedisCluster``, or ``FidesopsRedis``
+    (the latter is unwrapped to ``._client``).
+    When ``match`` is None, the full keyspace is scanned (no MATCH filter).
+    """
+    underlying = getattr(redis_client, "_client", redis_client)
+    scan_kwargs: Dict[str, Any] = {"count": count}
+    if match is not None:
+        scan_kwargs["match"] = match
+
+    if _is_redis_cluster(underlying):
+        cluster = cast(Any, underlying)
+        for node in cluster.get_primaries():
+            conn = node.redis_connection
+            cursor = 0
+            while True:
+                cursor, keys = conn.scan(cursor=cursor, **scan_kwargs)
+                if keys:
+                    yield list(keys)
+                if cursor == 0:
+                    break
+    else:
+        scan_cursor: Union[int, str] = "0"
+        while True:
+            cursor_arg = (
+                int(scan_cursor) if isinstance(scan_cursor, str) else scan_cursor
+            )
+            scan_cursor, keys = underlying.scan(cursor=cursor_arg, **scan_kwargs)
+            if keys:
+                yield list(keys)
+            if scan_cursor == 0 or scan_cursor == "0":
+                break
 
 
 class FidesopsRedis:

--- a/src/fides/common/cache/dsr_store.py
+++ b/src/fides/common/cache/dsr_store.py
@@ -1,5 +1,4 @@
-"""
-DSR cache store: single place for all DSR (privacy request) cache access.
+"""DSR cache store: single place for all DSR (privacy request) cache access.
 
 Enforces:
 - Key naming: dsr:{dsr_id}:{part} for every key (part = field_type:field_key)
@@ -14,14 +13,21 @@ whole DSR and a different storage shape; can introduce a hash-backed backend
 later if we want to avoid index consistency concerns.
 """
 
-from typing import Any, Callable, Dict, Optional, Union
+import re
+from typing import Any, Callable, Dict, Optional, Set, Union
 
 from redis import Redis
 
 from fides.common.cache.key_mapping import DSR_KEY_PREFIX, KeyMapper
 from fides.common.cache.manager import RedisCacheManager, RedisValue
 
-__all__ = ["DSR_KEY_PREFIX", "DSRCacheStore"]
+__all__ = [
+    "DSR_KEY_PREFIX",
+    "DSRCacheStore",
+    "candidate_privacy_request_ids_for_sweep",
+    "decode_dsr_redis_key",
+    "redis_key_is_dsr_cache_key_for_id",
+]
 
 
 def _dsr_key(dsr_id: str, part: str) -> str:
@@ -32,6 +38,79 @@ def _dsr_key(dsr_id: str, part: str) -> str:
 def _dsr_index_prefix(dsr_id: str) -> str:
     """Index prefix for this DSR; index set is __idx:dsr:{dsr_id}."""
     return f"{DSR_KEY_PREFIX}{dsr_id}"
+
+
+# Canonical 8-4-4-4-12 UUID tokens (case-insensitive). Privacy request ids are typically
+# ``pri_<uuid>``; sweepers extract uuid substrings then expand to both bare and ``pri_``
+# forms for membership checks against DB ids.
+_DSR_REDIS_KEY_SWEEP_UUID_RE = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+    re.IGNORECASE,
+)
+
+
+def decode_dsr_redis_key(raw: Any) -> str:
+    """Decode a Redis key from SCAN/MGET for consistent string handling."""
+    if isinstance(raw, bytes):
+        return raw.decode("utf-8", errors="replace")
+    return str(raw)
+
+
+def _normalize_uuid_token(token: str) -> str:
+    return token.lower()
+
+
+def _dsr_logical_body_matches_cache_id(body: str, dsr_id_lower: str) -> bool:
+    """True if ``body`` matches a known DSR logical/encoded-object key shape for this id."""
+    if body.startswith(f"{dsr_id_lower}__"):
+        return True
+    if body.startswith(f"WEBHOOK_MANUAL_ACCESS_INPUT__{dsr_id_lower}__"):
+        return True
+    if body.startswith(f"WEBHOOK_MANUAL_ERASURE_INPUT__{dsr_id_lower}__"):
+        return True
+    if body == f"DATA_USE_MAP__{dsr_id_lower}":
+        return True
+    if body.startswith(f"EMAIL_INFORMATION__{dsr_id_lower}__"):
+        return True
+    if body == f"PAUSED_LOCATION__{dsr_id_lower}":
+        return True
+    if body == f"FAILED_LOCATION__{dsr_id_lower}":
+        return True
+    if body.startswith(f"PLACEHOLDER_RESULTS__{dsr_id_lower}__"):
+        return True
+    return False
+
+
+def redis_key_is_dsr_cache_key_for_id(key: str, dsr_id_lower: str) -> bool:
+    """
+    Return True if ``key`` is a known Fides DSR cache Redis key for ``dsr_id_lower``.
+
+    Conservative: avoids deleting unrelated keys that merely embed a UUID substring
+    unless they match ``dsr:`` / index / migration / legacy ``id-`` / ``EN_`` logical
+    patterns documented in ``KeyMapper`` and ``DSRCacheStore``.
+    """
+    if key.startswith(f"dsr:{dsr_id_lower}:"):
+        return True
+    if key == f"__idx:dsr:{dsr_id_lower}":
+        return True
+    if key == f"__migrated:{dsr_id_lower}":
+        return True
+    if key.startswith(f"id-{dsr_id_lower}-"):
+        return True
+    if key.startswith("EN_"):
+        return _dsr_logical_body_matches_cache_id(key[3:], dsr_id_lower)
+    return _dsr_logical_body_matches_cache_id(key, dsr_id_lower)
+
+
+def candidate_privacy_request_ids_for_sweep(key: str) -> Set[str]:
+    """Candidate ids to check with SISMEMBER (normalized lowercase)."""
+    out: set[str] = set()
+    for m in _DSR_REDIS_KEY_SWEEP_UUID_RE.findall(key):
+        u = _normalize_uuid_token(m)
+        out.add(u)
+        # Product privacy request ids are ``pri_<uuid>`` (see DSR package link validation).
+        out.add(f"pri_{u}")
+    return out
 
 
 class DSRCacheStore:

--- a/src/fides/config/execution_settings.py
+++ b/src/fides/config/execution_settings.py
@@ -65,6 +65,42 @@ class DsrCacheSweeperSettings(BaseModel):
             "FIDES__EXECUTION__DSR_CACHE_SWEEPER_* are still accepted via model validation."
         ),
     )
+    single_pass_redis_sweep: bool = Field(
+        default=True,
+        description=(
+            "When true (default), use one Redis SCAN over the keyspace plus a temporary "
+            "maintenance set for eligible IDs. Set false to fall back to per-request "
+            "``DSRCacheStore.clear()`` (legacy, more Redis round-trips)."
+        ),
+    )
+    maintenance_set_ttl_seconds: int = Field(
+        default=14400,
+        ge=300,
+        description=(
+            "TTL (seconds) on the Redis staging set of eligible privacy request IDs. "
+            "Should exceed worst-case sweep duration and the Celery lock TTL so a crashed "
+            "worker does not leave the set forever. Default 4 hours."
+        ),
+    )
+    maintenance_set_key: str = Field(
+        default="__maintenance:dsr_cache_sweeper:eligible_ids",
+        description=(
+            "Redis key for the temporary eligible-ID set (SADD/SISMEMBER). Override for "
+            "multi-tenant or test isolation."
+        ),
+    )
+    redis_scan_count: int = Field(
+        default=750,
+        ge=10,
+        le=10000,
+        description="Hint passed to Redis SCAN COUNT per iteration (single-pass mode).",
+    )
+    redis_delete_batch_size: int = Field(
+        default=500,
+        ge=1,
+        le=10000,
+        description="Max keys per pipeline UNLINK/DEL batch in single-pass mode.",
+    )
 
 
 class ExecutionSettings(FidesSettings):

--- a/src/fides/service/privacy_request/dsr_cache_sweeper.py
+++ b/src/fides/service/privacy_request/dsr_cache_sweeper.py
@@ -1,23 +1,29 @@
 """Periodic DSR cache sweeper: clears Redis cache keys for terminal privacy requests.
 
 Eligible rows are selected from Postgres by terminal status and staleness on
-``updated_at``, including soft-deleted requests (``deleted_at`` set). For each id
-we re-read ``status`` immediately before clearing to avoid races with status
-transitions, then call ``get_dsr_cache_store(id).clear()`` (same effect as
-``PrivacyRequest.clear_cached_values``).
+``updated_at``, including soft-deleted requests (``deleted_at`` set). For each
+eligible id we re-read ``status`` while building the work set (same race semantics
+as the legacy per-row path).
 
-The Celery entrypoint gates on resolved ``execution.dsr_cache_sweeper.enabled``
-(application preference, default off). Server tuning lives under
-``execution.dsr_cache_sweeper`` (see ``DsrCacheSweeperSettings``).
+**Single-pass mode (default):** eligible string IDs are staged in a Redis set
+with a TTL, the keyspace is scanned once in bounded chunks, and keys matching
+known DSR shapes for staged IDs are UNLINKed in batches. The staging set is removed with Redis DEL on success; TTL covers crashed workers.
+
+**Legacy mode:** ``single_pass_redis_sweep=false`` restores per-id
+``get_dsr_cache_store(id).clear()`` (two wide SCANs per id).
+
+The Celery entrypoint gates on resolved ``execution.dsr_cache_sweeper.enabled``.
+Tuning lives under ``execution.dsr_cache_sweeper`` (``DsrCacheSweeperSettings``).
 """
 
 from __future__ import annotations
 
 import random
+import re
 import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import FrozenSet
+from typing import Any, FrozenSet, Iterable, Optional, Set
 
 from loguru import logger
 from sqlalchemy.orm import Session
@@ -27,17 +33,42 @@ from fides.api.schemas.privacy_request import (
     ACTIVE_REQUEST_STATUSES,
     PrivacyRequestStatus,
 )
-from fides.api.util.cache import get_dsr_cache_store
+from fides.api.util.cache import (
+    _is_redis_cluster,
+    get_dsr_cache_store,
+    get_redis_cache_manager,
+    iter_redis_scan_batches,
+)
 from fides.config import CONFIG
+
+# Canonical 8-4-4-4-12 UUID tokens (case-insensitive). Privacy request ids are typically
+# ``pri_<uuid>``; we extract uuid substrings then expand to both bare and ``pri_`` forms
+# for SISMEMBER against the staging set (which stores the DB id string).
+_UUID_RE = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+    re.IGNORECASE,
+)
 
 
 @dataclass(frozen=True)
 class DsrCacheSweeperResult:
+    """Summary of one sweeper run."""
+
     rows_scanned: int
-    redis_clear_attempts: int
     rows_skipped_status_mismatch: int
-    redis_errors: int
+    eligible_dsr_count: int
+    redis_keys_scanned: int
+    dsr_ids_seen_in_redis: int
+    redis_keys_deleted: int
+    redis_delete_errors: int
+    redis_errors: int  # legacy clear failures + single-pass batch failures (aggregated)
     duration_seconds: float
+    maintenance_set_deleted: bool
+
+    @property
+    def redis_clear_attempts(self) -> int:
+        """Back-compat alias for ``redis_keys_deleted``."""
+        return self.redis_keys_deleted
 
 
 def build_dsr_cache_sweeper_statuses(
@@ -73,28 +104,135 @@ def build_dsr_cache_sweeper_statuses(
     return frozenset(statuses)
 
 
-def run_dsr_cache_sweeper(
-    db: Session,
-) -> DsrCacheSweeperResult:
-    """Scan Postgres for stale terminal privacy requests and clear Redis DSR cache."""
-    tc = CONFIG.execution.dsr_cache_sweeper
-    terminal_statuses = build_dsr_cache_sweeper_statuses(
-        include_denied_and_duplicate=tc.include_denied_and_duplicate,
-        include_error=tc.include_error,
-    )
-    staleness_minutes = tc.staleness_minutes
-    batch_size = max(1, int(tc.batch_size))
-    batch_sleep = float(tc.batch_sleep_seconds)
+def _normalize_uuid_token(token: str) -> str:
+    return token.lower()
 
+
+def _decode_redis_key(raw: Any) -> str:
+    if isinstance(raw, bytes):
+        return raw.decode("utf-8", errors="replace")
+    return str(raw)
+
+
+def _logical_body_targets_dsr(body: str, dsr_id_lower: str) -> bool:
+    """True if ``body`` matches a known DSR logical/encoded-object key shape for this id."""
+    if body.startswith(f"{dsr_id_lower}__"):
+        return True
+    if body.startswith(f"WEBHOOK_MANUAL_ACCESS_INPUT__{dsr_id_lower}__"):
+        return True
+    if body.startswith(f"WEBHOOK_MANUAL_ERASURE_INPUT__{dsr_id_lower}__"):
+        return True
+    if body == f"DATA_USE_MAP__{dsr_id_lower}":
+        return True
+    if body.startswith(f"EMAIL_INFORMATION__{dsr_id_lower}__"):
+        return True
+    if body == f"PAUSED_LOCATION__{dsr_id_lower}":
+        return True
+    if body == f"FAILED_LOCATION__{dsr_id_lower}":
+        return True
+    if body.startswith(f"PLACEHOLDER_RESULTS__{dsr_id_lower}__"):
+        return True
+    return False
+
+
+def redis_key_is_dsr_cache_key_for_id(key: str, dsr_id_lower: str) -> bool:
+    """
+    Return True if ``key`` is a known Fides DSR cache Redis key for ``dsr_id_lower``.
+
+    Conservative: avoids deleting unrelated keys that merely embed a UUID substring
+    unless they match ``dsr:`` / index / migration / legacy ``id-`` / ``EN_`` logical
+    patterns documented in ``KeyMapper`` and ``DSRCacheStore``.
+    """
+    if key.startswith(f"dsr:{dsr_id_lower}:"):
+        return True
+    if key == f"__idx:dsr:{dsr_id_lower}":
+        return True
+    if key == f"__migrated:{dsr_id_lower}":
+        return True
+    if key.startswith(f"id-{dsr_id_lower}-"):
+        return True
+    if key.startswith("EN_"):
+        return _logical_body_targets_dsr(key[3:], dsr_id_lower)
+    return _logical_body_targets_dsr(key, dsr_id_lower)
+
+
+def _candidate_privacy_request_ids_in_key(key: str) -> Set[str]:
+    """Candidate ids to check with SISMEMBER (normalized lowercase)."""
+    out: set[str] = set()
+    for m in _UUID_RE.findall(key):
+        u = _normalize_uuid_token(m)
+        out.add(u)
+        # Product privacy request ids are ``pri_<uuid>`` (see DSR package link validation).
+        out.add(f"pri_{u}")
+    return out
+
+
+def _sadd_many(
+    redis: Any, set_key: str, members: Iterable[str], *, chunk: int = 2000
+) -> None:
+    batch: list[str] = []
+    for m in members:
+        batch.append(m)
+        if len(batch) >= chunk:
+            redis.sadd(set_key, *batch)
+            batch.clear()
+    if batch:
+        redis.sadd(set_key, *batch)
+
+
+def _unlink_batch(redis: Any, keys: list[str], *, cluster: bool) -> tuple[int, int]:
+    """Return (deleted_count, error_count)."""
+    if not keys:
+        return 0, 0
+    client = getattr(redis, "_client", redis)
+    deleted = 0
+    errors = 0
+
+    def _one(k: str) -> None:
+        nonlocal deleted, errors
+        try:
+            if hasattr(client, "unlink"):
+                client.unlink(k)
+            else:
+                client.delete(k)
+            deleted += 1
+        except Exception:  # noqa: BLE001
+            errors += 1
+
+    if cluster:
+        for key in keys:
+            _one(key)
+        return deleted, errors
+
+    if hasattr(client, "unlink"):
+        try:
+            client.unlink(*keys)
+            return len(keys), 0
+        except Exception:  # noqa: BLE001
+            deleted = 0
+            errors = 0
+
+    for key in keys:
+        _one(key)
+    return deleted, errors
+
+
+def _run_dsr_cache_sweeper_legacy(
+    db: Session,
+    *,
+    terminal_statuses: FrozenSet[PrivacyRequestStatus],
+    staleness_minutes: int,
+    batch_size: int,
+    batch_sleep: float,
+) -> DsrCacheSweeperResult:
+    """Previous behavior: per-id ``clear()`` with two SCANs each."""
     cutoff = datetime.now(timezone.utc) - timedelta(minutes=staleness_minutes)
 
     rows_scanned = 0
-    redis_clear_attempts = 0
     rows_skipped_status_mismatch = 0
     redis_errors = 0
-
+    redis_keys_deleted = 0
     last_id = ""
-    started = time.perf_counter()
 
     while True:
         batch_rows = (
@@ -133,7 +271,7 @@ def run_dsr_cache_sweeper(
             store = get_dsr_cache_store(str(pr_id))
             try:
                 store.clear()
-                redis_clear_attempts += 1
+                redis_keys_deleted += 1
                 logger.info(
                     "Cleared Redis DSR cache privacy_request_id={} status={} "
                     "staleness_minutes={}",
@@ -156,21 +294,250 @@ def run_dsr_cache_sweeper(
             jitter = random.uniform(0.0, batch_sleep)
             time.sleep(batch_sleep + jitter)
 
-    duration = time.perf_counter() - started
-    logger.info(
-        "DSR cache sweeper finished rows_scanned={} "
-        "redis_clear_attempts={} skipped_status_mismatch={} redis_errors={} "
-        "duration_s={:.3f}",
-        rows_scanned,
-        redis_clear_attempts,
-        rows_skipped_status_mismatch,
-        redis_errors,
-        duration,
-    )
     return DsrCacheSweeperResult(
         rows_scanned=rows_scanned,
-        redis_clear_attempts=redis_clear_attempts,
         rows_skipped_status_mismatch=rows_skipped_status_mismatch,
+        eligible_dsr_count=redis_keys_deleted,  # best-effort legacy: one clear per eligible row
+        redis_keys_scanned=0,
+        dsr_ids_seen_in_redis=redis_keys_deleted,
+        redis_keys_deleted=redis_keys_deleted,
+        redis_delete_errors=0,
         redis_errors=redis_errors,
-        duration_seconds=duration,
+        duration_seconds=0.0,
+        maintenance_set_deleted=True,
+    )
+
+
+def run_dsr_cache_sweeper(
+    db: Session,
+) -> DsrCacheSweeperResult:
+    """Scan Postgres for stale terminal privacy requests and clear Redis DSR cache."""
+    tc = CONFIG.execution.dsr_cache_sweeper
+    terminal_statuses = build_dsr_cache_sweeper_statuses(
+        include_denied_and_duplicate=tc.include_denied_and_duplicate,
+        include_error=tc.include_error,
+    )
+    staleness_minutes = tc.staleness_minutes
+    batch_size = max(1, int(tc.batch_size))
+    batch_sleep = float(tc.batch_sleep_seconds)
+
+    started = time.perf_counter()
+
+    if not tc.single_pass_redis_sweep:
+        res = _run_dsr_cache_sweeper_legacy(
+            db,
+            terminal_statuses=terminal_statuses,
+            staleness_minutes=staleness_minutes,
+            batch_size=batch_size,
+            batch_sleep=batch_sleep,
+        )
+        duration = time.perf_counter() - started
+        logger.info(
+            "DSR cache sweeper (legacy) finished rows_scanned={} "
+            "redis_keys_deleted={} skipped_status_mismatch={} redis_errors={} "
+            "duration_s={:.3f}",
+            res.rows_scanned,
+            res.redis_keys_deleted,
+            res.rows_skipped_status_mismatch,
+            res.redis_errors,
+            duration,
+        )
+        return DsrCacheSweeperResult(
+            rows_scanned=res.rows_scanned,
+            rows_skipped_status_mismatch=res.rows_skipped_status_mismatch,
+            eligible_dsr_count=res.eligible_dsr_count,
+            redis_keys_scanned=0,
+            dsr_ids_seen_in_redis=res.dsr_ids_seen_in_redis,
+            redis_keys_deleted=res.redis_keys_deleted,
+            redis_delete_errors=0,
+            redis_errors=res.redis_errors,
+            duration_seconds=duration,
+            maintenance_set_deleted=True,
+        )
+
+    cutoff = datetime.now(timezone.utc) - timedelta(minutes=staleness_minutes)
+
+    rows_scanned = 0
+    rows_skipped_status_mismatch = 0
+    eligible_ids: list[str] = []
+    last_id = ""
+
+    while True:
+        batch_rows = (
+            db.query(PrivacyRequest.id, PrivacyRequest.status)
+            .filter(
+                PrivacyRequest.status.in_(list(terminal_statuses)),
+                PrivacyRequest.updated_at < cutoff,
+                PrivacyRequest.id > last_id,
+            )
+            .order_by(PrivacyRequest.id)
+            .limit(batch_size)
+            .all()
+        )
+        if not batch_rows:
+            break
+
+        for pr_id, initial_status in batch_rows:
+            rows_scanned += 1
+
+            current = (
+                db.query(PrivacyRequest.status)
+                .filter(PrivacyRequest.id == pr_id)
+                .scalar()
+            )
+            if current is None or current not in terminal_statuses:
+                rows_skipped_status_mismatch += 1
+                logger.debug(
+                    "Skipping DSR cache sweeper staging for privacy_request_id={}: "
+                    "status no longer eligible (batch had {}, current={})",
+                    pr_id,
+                    initial_status.value,
+                    getattr(current, "value", current),
+                )
+                continue
+
+            eligible_ids.append(_normalize_uuid_token(str(pr_id)))
+
+        last_id = batch_rows[-1][0]
+
+        if batch_sleep > 0:
+            jitter = random.uniform(0.0, batch_sleep)
+            time.sleep(batch_sleep + jitter)
+
+    eligible_dsr_count = len(eligible_ids)
+    redis_keys_scanned = 0
+    dsr_ids_touched: set[str] = set()
+    redis_keys_deleted = 0
+    redis_delete_errors = 0
+    redis_errors = 0
+    maintenance_set_deleted = False
+
+    duration = time.perf_counter() - started
+
+    if eligible_dsr_count == 0:
+        logger.info(
+            "DSR cache sweeper finished eligible_dsr_count=0 rows_scanned={} "
+            "skipped_status_mismatch={} redis_keys_scanned=0 redis_keys_deleted=0 "
+            "duration_s={:.3f} maintenance_set_deleted=n/a",
+            rows_scanned,
+            rows_skipped_status_mismatch,
+            duration,
+        )
+        return DsrCacheSweeperResult(
+            rows_scanned=rows_scanned,
+            rows_skipped_status_mismatch=rows_skipped_status_mismatch,
+            eligible_dsr_count=0,
+            redis_keys_scanned=0,
+            dsr_ids_seen_in_redis=0,
+            redis_keys_deleted=0,
+            redis_delete_errors=0,
+            redis_errors=0,
+            duration_seconds=duration,
+            maintenance_set_deleted=True,
+        )
+
+    manager = get_redis_cache_manager()
+    redis = manager._redis
+    set_key = tc.maintenance_set_key
+    ttl = int(tc.maintenance_set_ttl_seconds)
+    scan_count = int(tc.redis_scan_count)
+    del_batch = max(1, int(tc.redis_delete_batch_size))
+
+    cluster = _is_redis_cluster(getattr(redis, "_client", redis))
+
+    sweep_started = time.perf_counter()
+    try:
+        # Fresh staging set for this run
+        redis.delete(set_key)
+        _sadd_many(redis, set_key, eligible_ids)
+        redis.expire(set_key, ttl)
+
+        pending_delete: list[str] = []
+
+        def flush_pending() -> None:
+            nonlocal redis_keys_deleted, redis_delete_errors, redis_errors
+            if not pending_delete:
+                return
+            chunk = pending_delete[:]
+            pending_delete.clear()
+            deleted, err = _unlink_batch(redis, chunk, cluster=cluster)
+            redis_keys_deleted += deleted
+            if err:
+                redis_delete_errors += err
+                redis_errors += err
+
+        for key_batch in iter_redis_scan_batches(redis, count=scan_count):
+            for raw_key in key_batch:
+                redis_keys_scanned += 1
+                key_str = _decode_redis_key(raw_key)
+                candidates = _candidate_privacy_request_ids_in_key(key_str)
+                delete_this_key = False
+                matched_id: Optional[str] = None
+                for uid in candidates:
+                    try:
+                        if not redis.sismember(set_key, uid):
+                            continue
+                    except Exception:  # noqa: BLE001
+                        redis_errors += 1
+                        continue
+                    if redis_key_is_dsr_cache_key_for_id(key_str, uid):
+                        delete_this_key = True
+                        matched_id = uid
+                        break
+                if delete_this_key and matched_id is not None:
+                    dsr_ids_touched.add(matched_id)
+                    pending_delete.append(key_str)
+                    if len(pending_delete) >= del_batch:
+                        flush_pending()
+
+            logger.debug(
+                "DSR cache sweeper SCAN chunk redis_keys_scanned={} "
+                "pending_delete_queue={}",
+                redis_keys_scanned,
+                len(pending_delete),
+            )
+
+        flush_pending()
+
+        redis.delete(set_key)
+        maintenance_set_deleted = True
+    except Exception as exc:  # noqa: BLE001
+        redis_errors += 1
+        logger.warning(
+            "DSR cache sweeper single-pass error (maintenance set TTL will expire): {}",
+            exc,
+        )
+    finally:
+        sweep_duration = time.perf_counter() - sweep_started
+        total_duration = time.perf_counter() - started
+
+    logger.info(
+        "DSR cache sweeper finished eligible_dsr_count={} rows_scanned={} "
+        "skipped_status_mismatch={} redis_keys_scanned={} dsr_ids_seen_in_redis={} "
+        "redis_keys_deleted={} redis_delete_errors={} redis_errors={} "
+        "duration_s={:.3f} sweep_s={:.3f} maintenance_set_deleted={}",
+        eligible_dsr_count,
+        rows_scanned,
+        rows_skipped_status_mismatch,
+        redis_keys_scanned,
+        len(dsr_ids_touched),
+        redis_keys_deleted,
+        redis_delete_errors,
+        redis_errors,
+        total_duration,
+        sweep_duration,
+        maintenance_set_deleted,
+    )
+
+    return DsrCacheSweeperResult(
+        rows_scanned=rows_scanned,
+        rows_skipped_status_mismatch=rows_skipped_status_mismatch,
+        eligible_dsr_count=eligible_dsr_count,
+        redis_keys_scanned=redis_keys_scanned,
+        dsr_ids_seen_in_redis=len(dsr_ids_touched),
+        redis_keys_deleted=redis_keys_deleted,
+        redis_delete_errors=redis_delete_errors,
+        redis_errors=redis_errors,
+        duration_seconds=total_duration,
+        maintenance_set_deleted=maintenance_set_deleted,
     )

--- a/src/fides/service/privacy_request/dsr_cache_sweeper.py
+++ b/src/fides/service/privacy_request/dsr_cache_sweeper.py
@@ -22,7 +22,7 @@ import random
 import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any, FrozenSet, Iterable, Optional
+from typing import Any, FrozenSet, Optional
 
 from loguru import logger
 from sqlalchemy.orm import Session
@@ -93,46 +93,6 @@ def build_dsr_cache_sweeper_statuses(
             f"{overlap}"
         )
     return frozenset(statuses)
-
-
-def _sadd_many(
-    redis: Any, set_key: str, members: Iterable[str], *, chunk: int = 2000
-) -> None:
-    batch: list[str] = []
-    for m in members:
-        batch.append(m)
-        if len(batch) >= chunk:
-            redis.sadd(set_key, *batch)
-            batch.clear()
-    if batch:
-        redis.sadd(set_key, *batch)
-
-
-def _unlink_batch(redis: Any, keys: list[str], *, cluster: bool) -> tuple[int, int]:
-    """Return (deleted_count, error_count)."""
-    if not keys:
-        return 0, 0
-    deleted = 0
-    errors = 0
-    if cluster:
-        for key in keys:
-            try:
-                redis.unlink(key)
-                deleted += 1
-            except Exception:  # noqa: BLE001
-                errors += 1
-        return deleted, errors
-    try:
-        redis.unlink(*keys)
-        return len(keys), 0
-    except Exception:  # noqa: BLE001
-        for key in keys:
-            try:
-                redis.unlink(key)
-                deleted += 1
-            except Exception:  # noqa: BLE001
-                errors += 1
-        return deleted, errors
 
 
 def _run_dsr_cache_sweeper_legacy(
@@ -361,13 +321,11 @@ def run_dsr_cache_sweeper(
     scan_count = int(tc.redis_scan_count)
     del_batch = max(1, int(tc.redis_delete_batch_size))
 
-    cluster = redis.is_cluster
-
     sweep_started = time.perf_counter()
     try:
         # Fresh staging set for this run
         redis.delete(set_key)
-        _sadd_many(redis, set_key, eligible_ids)
+        redis.sadd_members_chunked(set_key, eligible_ids)
         redis.expire(set_key, ttl)
 
         pending_delete: list[str] = []
@@ -378,7 +336,7 @@ def run_dsr_cache_sweeper(
                 return
             chunk = pending_delete[:]
             pending_delete.clear()
-            deleted, err = _unlink_batch(redis, chunk, cluster=cluster)
+            deleted, err = redis.unlink_many(chunk)
             redis_keys_deleted += deleted
             if err:
                 redis_delete_errors += err

--- a/src/fides/service/privacy_request/dsr_cache_sweeper.py
+++ b/src/fides/service/privacy_request/dsr_cache_sweeper.py
@@ -19,11 +19,10 @@ Tuning lives under ``execution.dsr_cache_sweeper`` (``DsrCacheSweeperSettings``)
 from __future__ import annotations
 
 import random
-import re
 import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any, FrozenSet, Iterable, Optional, Set
+from typing import Any, FrozenSet, Iterable, Optional
 
 from loguru import logger
 from sqlalchemy.orm import Session
@@ -33,21 +32,13 @@ from fides.api.schemas.privacy_request import (
     ACTIVE_REQUEST_STATUSES,
     PrivacyRequestStatus,
 )
-from fides.api.util.cache import (
-    _is_redis_cluster,
-    get_dsr_cache_store,
-    get_redis_cache_manager,
-    iter_redis_scan_batches,
+from fides.api.util.cache import get_dsr_cache_store, get_redis_cache_manager
+from fides.common.cache.dsr_store import (
+    candidate_privacy_request_ids_for_sweep,
+    decode_dsr_redis_key,
+    redis_key_is_dsr_cache_key_for_id,
 )
 from fides.config import CONFIG
-
-# Canonical 8-4-4-4-12 UUID tokens (case-insensitive). Privacy request ids are typically
-# ``pri_<uuid>``; we extract uuid substrings then expand to both bare and ``pri_`` forms
-# for SISMEMBER against the staging set (which stores the DB id string).
-_UUID_RE = re.compile(
-    r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
-    re.IGNORECASE,
-)
 
 
 @dataclass(frozen=True)
@@ -104,69 +95,6 @@ def build_dsr_cache_sweeper_statuses(
     return frozenset(statuses)
 
 
-def _normalize_uuid_token(token: str) -> str:
-    return token.lower()
-
-
-def _decode_redis_key(raw: Any) -> str:
-    if isinstance(raw, bytes):
-        return raw.decode("utf-8", errors="replace")
-    return str(raw)
-
-
-def _logical_body_targets_dsr(body: str, dsr_id_lower: str) -> bool:
-    """True if ``body`` matches a known DSR logical/encoded-object key shape for this id."""
-    if body.startswith(f"{dsr_id_lower}__"):
-        return True
-    if body.startswith(f"WEBHOOK_MANUAL_ACCESS_INPUT__{dsr_id_lower}__"):
-        return True
-    if body.startswith(f"WEBHOOK_MANUAL_ERASURE_INPUT__{dsr_id_lower}__"):
-        return True
-    if body == f"DATA_USE_MAP__{dsr_id_lower}":
-        return True
-    if body.startswith(f"EMAIL_INFORMATION__{dsr_id_lower}__"):
-        return True
-    if body == f"PAUSED_LOCATION__{dsr_id_lower}":
-        return True
-    if body == f"FAILED_LOCATION__{dsr_id_lower}":
-        return True
-    if body.startswith(f"PLACEHOLDER_RESULTS__{dsr_id_lower}__"):
-        return True
-    return False
-
-
-def redis_key_is_dsr_cache_key_for_id(key: str, dsr_id_lower: str) -> bool:
-    """
-    Return True if ``key`` is a known Fides DSR cache Redis key for ``dsr_id_lower``.
-
-    Conservative: avoids deleting unrelated keys that merely embed a UUID substring
-    unless they match ``dsr:`` / index / migration / legacy ``id-`` / ``EN_`` logical
-    patterns documented in ``KeyMapper`` and ``DSRCacheStore``.
-    """
-    if key.startswith(f"dsr:{dsr_id_lower}:"):
-        return True
-    if key == f"__idx:dsr:{dsr_id_lower}":
-        return True
-    if key == f"__migrated:{dsr_id_lower}":
-        return True
-    if key.startswith(f"id-{dsr_id_lower}-"):
-        return True
-    if key.startswith("EN_"):
-        return _logical_body_targets_dsr(key[3:], dsr_id_lower)
-    return _logical_body_targets_dsr(key, dsr_id_lower)
-
-
-def _candidate_privacy_request_ids_in_key(key: str) -> Set[str]:
-    """Candidate ids to check with SISMEMBER (normalized lowercase)."""
-    out: set[str] = set()
-    for m in _UUID_RE.findall(key):
-        u = _normalize_uuid_token(m)
-        out.add(u)
-        # Product privacy request ids are ``pri_<uuid>`` (see DSR package link validation).
-        out.add(f"pri_{u}")
-    return out
-
-
 def _sadd_many(
     redis: Any, set_key: str, members: Iterable[str], *, chunk: int = 2000
 ) -> None:
@@ -184,37 +112,27 @@ def _unlink_batch(redis: Any, keys: list[str], *, cluster: bool) -> tuple[int, i
     """Return (deleted_count, error_count)."""
     if not keys:
         return 0, 0
-    client = getattr(redis, "_client", redis)
     deleted = 0
     errors = 0
-
-    def _one(k: str) -> None:
-        nonlocal deleted, errors
-        try:
-            if hasattr(client, "unlink"):
-                client.unlink(k)
-            else:
-                client.delete(k)
-            deleted += 1
-        except Exception:  # noqa: BLE001
-            errors += 1
-
     if cluster:
         for key in keys:
-            _one(key)
+            try:
+                redis.unlink(key)
+                deleted += 1
+            except Exception:  # noqa: BLE001
+                errors += 1
         return deleted, errors
-
-    if hasattr(client, "unlink"):
-        try:
-            client.unlink(*keys)
-            return len(keys), 0
-        except Exception:  # noqa: BLE001
-            deleted = 0
-            errors = 0
-
-    for key in keys:
-        _one(key)
-    return deleted, errors
+    try:
+        redis.unlink(*keys)
+        return len(keys), 0
+    except Exception:  # noqa: BLE001
+        for key in keys:
+            try:
+                redis.unlink(key)
+                deleted += 1
+            except Exception:  # noqa: BLE001
+                errors += 1
+        return deleted, errors
 
 
 def _run_dsr_cache_sweeper_legacy(
@@ -396,7 +314,7 @@ def run_dsr_cache_sweeper(
                 )
                 continue
 
-            eligible_ids.append(_normalize_uuid_token(str(pr_id)))
+            eligible_ids.append(str(pr_id).lower())
 
         last_id = batch_rows[-1][0]
 
@@ -443,7 +361,7 @@ def run_dsr_cache_sweeper(
     scan_count = int(tc.redis_scan_count)
     del_batch = max(1, int(tc.redis_delete_batch_size))
 
-    cluster = _is_redis_cluster(getattr(redis, "_client", redis))
+    cluster = redis.is_cluster
 
     sweep_started = time.perf_counter()
     try:
@@ -466,11 +384,11 @@ def run_dsr_cache_sweeper(
                 redis_delete_errors += err
                 redis_errors += err
 
-        for key_batch in iter_redis_scan_batches(redis, count=scan_count):
+        for key_batch in redis.iter_scan_batches(count=scan_count):
             for raw_key in key_batch:
                 redis_keys_scanned += 1
-                key_str = _decode_redis_key(raw_key)
-                candidates = _candidate_privacy_request_ids_in_key(key_str)
+                key_str = decode_dsr_redis_key(raw_key)
+                candidates = candidate_privacy_request_ids_for_sweep(key_str)
                 delete_this_key = False
                 matched_id: Optional[str] = None
                 for uid in candidates:

--- a/tests/service/privacy_request/test_dsr_cache_sweeper.py
+++ b/tests/service/privacy_request/test_dsr_cache_sweeper.py
@@ -5,7 +5,9 @@ from fides.api.schemas.privacy_request import (
     PrivacyRequestStatus,
 )
 from fides.service.privacy_request.dsr_cache_sweeper import (
+    _candidate_privacy_request_ids_in_key,
     build_dsr_cache_sweeper_statuses,
+    redis_key_is_dsr_cache_key_for_id,
 )
 
 
@@ -43,3 +45,31 @@ def test_terminal_allowlist_never_overlaps_active() -> None:
         include_error=True,
     )
     assert not (statuses & ACTIVE_REQUEST_STATUSES)
+
+
+def test_redis_key_shape_matches_dsr_prefixes() -> None:
+    uid = "aaaaaaaa-bbbb-4ccc-dddd-eeeeeeeeeeee"
+    pri = f"pri_{uid}"
+    assert redis_key_is_dsr_cache_key_for_id(f"dsr:{uid}:async_execution", uid)
+    assert redis_key_is_dsr_cache_key_for_id(f"dsr:{pri}:async_execution", pri)
+    assert redis_key_is_dsr_cache_key_for_id(f"__idx:dsr:{uid}", uid)
+    assert redis_key_is_dsr_cache_key_for_id(f"__idx:dsr:{pri}", pri)
+    assert redis_key_is_dsr_cache_key_for_id(f"__migrated:{uid}", uid)
+    assert redis_key_is_dsr_cache_key_for_id(f"id-{uid}-async-execution", uid)
+    assert redis_key_is_dsr_cache_key_for_id(f"id-{pri}-async-execution", pri)
+    assert redis_key_is_dsr_cache_key_for_id(f"EN_DATA_USE_MAP__{uid}", uid)
+    assert redis_key_is_dsr_cache_key_for_id(f"EN_DATA_USE_MAP__{pri}", pri)
+
+
+def test_redis_key_shape_rejects_decoy_with_uuid() -> None:
+    uid = "aaaaaaaa-bbbb-4ccc-dddd-eeeeeeeeeeee"
+    pri = f"pri_{uid}"
+    assert not redis_key_is_dsr_cache_key_for_id(f"DECOY-{uid}-noise", uid)
+    assert not redis_key_is_dsr_cache_key_for_id(f"DECOY-{pri}-noise", pri)
+
+
+def test_candidate_privacy_request_ids_expand_pri_prefix() -> None:
+    uid = "AAAAAAAA-BBBB-4CCC-DDDD-EEEEEEEEEEEE"
+    u = uid.lower()
+    found = _candidate_privacy_request_ids_in_key(f"prefix-{uid}-suffix")
+    assert found == {u, f"pri_{u}"}

--- a/tests/service/privacy_request/test_dsr_cache_sweeper.py
+++ b/tests/service/privacy_request/test_dsr_cache_sweeper.py
@@ -4,10 +4,12 @@ from fides.api.schemas.privacy_request import (
     ACTIVE_REQUEST_STATUSES,
     PrivacyRequestStatus,
 )
-from fides.service.privacy_request.dsr_cache_sweeper import (
-    _candidate_privacy_request_ids_in_key,
-    build_dsr_cache_sweeper_statuses,
+from fides.common.cache.dsr_store import (
+    candidate_privacy_request_ids_for_sweep,
     redis_key_is_dsr_cache_key_for_id,
+)
+from fides.service.privacy_request.dsr_cache_sweeper import (
+    build_dsr_cache_sweeper_statuses,
 )
 
 
@@ -71,5 +73,5 @@ def test_redis_key_shape_rejects_decoy_with_uuid() -> None:
 def test_candidate_privacy_request_ids_expand_pri_prefix() -> None:
     uid = "AAAAAAAA-BBBB-4CCC-DDDD-EEEEEEEEEEEE"
     u = uid.lower()
-    found = _candidate_privacy_request_ids_in_key(f"prefix-{uid}-suffix")
+    found = candidate_privacy_request_ids_for_sweep(f"prefix-{uid}-suffix")
     assert found == {u, f"pri_{u}"}

--- a/tests/service/privacy_request/test_dsr_cache_sweeper_functional.py
+++ b/tests/service/privacy_request/test_dsr_cache_sweeper_functional.py
@@ -17,7 +17,7 @@ from sqlalchemy.orm import Session
 from fides.api.models.policy import Policy
 from fides.api.models.privacy_request import PrivacyRequest
 from fides.api.schemas.privacy_request import PrivacyRequestStatus
-from fides.api.util.cache import get_dsr_cache_store
+from fides.api.util.cache import get_cache, get_dsr_cache_store
 from fides.config import CONFIG
 from fides.service.privacy_request import dsr_cache_sweeper as sweeper_module
 from fides.service.privacy_request.dsr_cache_sweeper import run_dsr_cache_sweeper
@@ -78,9 +78,13 @@ class TestDsrCacheSweeperFunctional:
             result = run_dsr_cache_sweeper(db)
 
             assert result.rows_scanned >= 1
+            assert result.eligible_dsr_count >= 1
             assert result.redis_clear_attempts >= 1
+            assert result.redis_keys_deleted >= 1
             assert result.redis_errors == 0
             assert len(get_dsr_cache_store(pr.id).get_all_keys()) == 0
+            r = get_cache()
+            assert not r.exists(CONFIG.execution.dsr_cache_sweeper.maintenance_set_key)
         finally:
             get_dsr_cache_store(pr.id).clear()
             pr.delete(db)
@@ -110,9 +114,13 @@ class TestDsrCacheSweeperFunctional:
             result = run_dsr_cache_sweeper(db)
 
             assert result.rows_scanned >= 1
+            assert result.eligible_dsr_count >= 1
             assert result.redis_clear_attempts >= 1
+            assert result.redis_keys_deleted >= 1
             assert result.redis_errors == 0
             assert len(get_dsr_cache_store(pr.id).get_all_keys()) == 0
+            r = get_cache()
+            assert not r.exists(CONFIG.execution.dsr_cache_sweeper.maintenance_set_key)
         finally:
             get_dsr_cache_store(pr.id).clear()
             pr.delete(db)
@@ -139,6 +147,8 @@ class TestDsrCacheSweeperFunctional:
             result = run_dsr_cache_sweeper(db)
 
             assert result.rows_scanned == 0
+            assert result.eligible_dsr_count == 0
+            assert result.redis_keys_deleted == 0
             assert len(store.get_all_keys()) == keys_before
         finally:
             get_dsr_cache_store(pr.id).clear()
@@ -167,7 +177,197 @@ class TestDsrCacheSweeperFunctional:
             result = run_dsr_cache_sweeper(db)
 
             assert result.rows_scanned == 0
+            assert result.eligible_dsr_count == 0
+            assert result.redis_keys_deleted == 0
             assert len(store.get_all_keys()) == keys_before
+        finally:
+            get_dsr_cache_store(pr.id).clear()
+            pr.delete(db)
+
+    def test_decoy_key_containing_eligible_uuid_not_deleted(
+        self,
+        db: Session,
+        policy: Policy,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Keys that embed a UUID but do not match DSR key shapes must not be deleted."""
+        _patch_dsr_cache_sweeper_execution(monkeypatch)
+
+        pr = _create_privacy_request_for_policy(
+            db,
+            policy,
+            status=PrivacyRequestStatus.complete,
+        )
+        decoy = f"DECOY-{pr.id}-not-a-dsr-key"
+        r = get_cache()
+        try:
+            _force_stale_updated_at(db, pr.id)
+
+            store = get_dsr_cache_store(pr.id)
+            store.write_async_execution(b"swept", _TTL)
+            r.set(decoy, b"1", ex=_TTL)
+
+            run_dsr_cache_sweeper(db)
+
+            assert r.get(decoy) is not None
+            # get_all_keys() uses SCAN match *{pr.id}*, so the decoy (which embeds the id)
+            # still appears in the listing even though the sweeper correctly skips deleting it.
+            keys_after = get_dsr_cache_store(pr.id).get_all_keys()
+            assert decoy in keys_after
+            assert not any(k.startswith(f"dsr:{pr.id}:") for k in keys_after)
+        finally:
+            r.delete(decoy)
+            get_dsr_cache_store(pr.id).clear()
+            pr.delete(db)
+
+    def test_two_privacy_requests_only_eligible_redis_is_cleared(
+        self,
+        db: Session,
+        policy: Policy,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Stale terminal PR is swept; a stale non-terminal PR must keep its DSR cache keys."""
+        _patch_dsr_cache_sweeper_execution(monkeypatch)
+
+        pr_eligible = _create_privacy_request_for_policy(
+            db,
+            policy,
+            status=PrivacyRequestStatus.complete,
+        )
+        pr_other = _create_privacy_request_for_policy(
+            db,
+            policy,
+            status=PrivacyRequestStatus.in_processing,
+        )
+        try:
+            _force_stale_updated_at(db, pr_eligible.id)
+            _force_stale_updated_at(db, pr_other.id)
+
+            store_a = get_dsr_cache_store(pr_eligible.id)
+            store_b = get_dsr_cache_store(pr_other.id)
+            store_a.write_async_execution(b"eligible-a", _TTL)
+            store_b.write_async_execution(b"keep-b", _TTL)
+
+            assert any(
+                k.startswith(f"dsr:{pr_eligible.id}:") for k in store_a.get_all_keys()
+            )
+            assert any(
+                k.startswith(f"dsr:{pr_other.id}:") for k in store_b.get_all_keys()
+            )
+
+            result = run_dsr_cache_sweeper(db)
+
+            assert result.rows_scanned >= 1
+            assert result.eligible_dsr_count >= 1
+            keys_a = get_dsr_cache_store(pr_eligible.id).get_all_keys()
+            keys_b = get_dsr_cache_store(pr_other.id).get_all_keys()
+            assert not any(k.startswith(f"dsr:{pr_eligible.id}:") for k in keys_a)
+            assert any(k.startswith(f"dsr:{pr_other.id}:") for k in keys_b)
+        finally:
+            get_dsr_cache_store(pr_eligible.id).clear()
+            get_dsr_cache_store(pr_other.id).clear()
+            pr_eligible.delete(db)
+            pr_other.delete(db)
+
+    def test_single_pass_deletes_en_and_legacy_id_prefixed_keys(
+        self,
+        db: Session,
+        policy: Policy,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """SCAN path must remove encoded-object (EN_) and legacy id- keys for eligible PRs."""
+        _patch_dsr_cache_sweeper_execution(monkeypatch)
+
+        pr = _create_privacy_request_for_policy(
+            db,
+            policy,
+            status=PrivacyRequestStatus.complete,
+        )
+        r = get_cache()
+        en_key = f"EN_DATA_USE_MAP__{pr.id}"
+        legacy_key = f"id-{pr.id}-async-execution"
+        try:
+            _force_stale_updated_at(db, pr.id)
+
+            get_dsr_cache_store(pr.id).write_async_execution(b"new-format", _TTL)
+            r.set(en_key, b"encoded-placeholder", ex=_TTL)
+            r.set(legacy_key, b"legacy-value", ex=_TTL)
+
+            run_dsr_cache_sweeper(db)
+
+            assert r.get(en_key) is None
+            assert r.get(legacy_key) is None
+            keys_after = get_dsr_cache_store(pr.id).get_all_keys()
+            assert not any(k.startswith(f"dsr:{pr.id}:") for k in keys_after)
+        finally:
+            r.delete(en_key)
+            r.delete(legacy_key)
+            get_dsr_cache_store(pr.id).clear()
+            pr.delete(db)
+
+    def test_single_pass_deletes_idx_set_and_migrated_keys(
+        self,
+        db: Session,
+        policy: Policy,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Index set and migration marker keys must be removed when the PR is eligible."""
+        _patch_dsr_cache_sweeper_execution(monkeypatch)
+
+        pr = _create_privacy_request_for_policy(
+            db,
+            policy,
+            status=PrivacyRequestStatus.complete,
+        )
+        r = get_cache()
+        idx_key = f"__idx:dsr:{pr.id}"
+        mig_key = f"__migrated:{pr.id}"
+        try:
+            _force_stale_updated_at(db, pr.id)
+
+            get_dsr_cache_store(pr.id).write_async_execution(b"dsr-value", _TTL)
+            r.sadd(idx_key, "dummy-member")
+            r.setex(mig_key, _TTL, "1")
+
+            run_dsr_cache_sweeper(db)
+
+            assert not r.exists(idx_key)
+            assert not r.exists(mig_key)
+            keys_after = get_dsr_cache_store(pr.id).get_all_keys()
+            assert not any(k.startswith(f"dsr:{pr.id}:") for k in keys_after)
+        finally:
+            r.delete(idx_key)
+            r.delete(mig_key)
+            get_dsr_cache_store(pr.id).clear()
+            pr.delete(db)
+
+    def test_legacy_single_pass_disabled_uses_clear_per_request(
+        self,
+        db: Session,
+        policy: Policy,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Rollback toggle: legacy path still clears Redis via DSRCacheStore.clear()."""
+        _patch_dsr_cache_sweeper_execution(monkeypatch, single_pass_redis_sweep=False)
+
+        pr = _create_privacy_request_for_policy(
+            db,
+            policy,
+            status=PrivacyRequestStatus.complete,
+        )
+        try:
+            _force_stale_updated_at(db, pr.id)
+
+            store = get_dsr_cache_store(pr.id)
+            store.write_async_execution(b"legacy-path", _TTL)
+            assert len(store.get_all_keys()) >= 1
+
+            result = run_dsr_cache_sweeper(db)
+
+            assert result.rows_scanned >= 1
+            assert result.redis_keys_deleted >= 1
+            assert result.redis_keys_scanned == 0
+            assert len(get_dsr_cache_store(pr.id).get_all_keys()) == 0
         finally:
             get_dsr_cache_store(pr.id).clear()
             pr.delete(db)


### PR DESCRIPTION
This will make the DSR cache sweeper operate in a single SCAN pass rather than make multiple passes; also adds some convenience methods to our Redis client that were needed here and can be used elsewhere.