### PR TITLE
ENG-3757: Fix Fides.version showing dev decorations on tagged Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,10 +90,19 @@ RUN git rm --cached -r .
 # This is a required workaround due to: https://github.com/ethyca/fides/issues/2440
 RUN git config --global --add safe.directory /fides
 
-# Export the version to a file for frontend use (hatch-vcs from git tags)
+# Export the version to a file for frontend use (hatch-vcs from git tags).
+# `.dockerignore` excludes files that the host's `.git/index` tracks, so the
+# COPYed tree always looks dirty to setuptools-scm — without intervention,
+# tagged release builds get bumped to `<next>.devN+g<sha>.d<date>`.
+# When HEAD is exactly on a tag, force setuptools-scm to use that tag verbatim
+# via `SETUPTOOLS_SCM_PRETEND_VERSION` (same approach used by the wheel build
+# in .github/workflows/publish_package.yaml).
 RUN uv venv /tmp/hatch-env && \
     uv pip install --python /tmp/hatch-env/bin/python "virtualenv<21" hatch hatch-vcs && \
-    cd /fides && /tmp/hatch-env/bin/hatch version > /fides/version.txt && \
+    cd /fides && \
+    EXACT_TAG=$(git describe --tags --exact-match 2>/dev/null || true) && \
+    if [ -n "$EXACT_TAG" ]; then export SETUPTOOLS_SCM_PRETEND_VERSION="$EXACT_TAG"; fi && \
+    /tmp/hatch-env/bin/hatch version > /fides/version.txt && \
     /opt/fides/bin/python -c "import json; v=open('/fides/version.txt').read().strip(); print(json.dumps({'version': v}))" > /fides/version.json && rm /fides/version.txt && rm -rf /tmp/hatch-env
 
 # Enable detection of running within Docker

--- a/changelog/8147-fix-fides-version-on-tagged-docker-builds.yaml
+++ b/changelog/8147-fix-fides-version-on-tagged-docker-builds.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Fixed Fides.version showing dev decorations instead of the release tag on tagged Docker builds
+pr: 8147
+labels: []


### PR DESCRIPTION
Ticket [ENG-3757]

### Description Of Changes

`Fides.version` (the version exposed by the FidesJS SDK) and `version.json` (its source inside the container) were being decorated with dev-style suffixes — e.g. `2.84.6.dev0+g<sha>.d<date>` — even on tagged release builds where the running container actually corresponds to a clean tag (e.g. `2.84.5`).

**Root cause:** The Docker build copies the host's `.git` directory in but applies `.dockerignore` to the worktree, so files tracked by the host's `.git/index` are missing from the container's worktree. `setuptools-scm` (which `hatch-vcs` wraps) sees this as a dirty tree and applies its `dirty-tag` heuristic — it bumps the version to the next patch, appends `.dev0`, and tacks on a local-version segment with the SHA and date. The previous `versioneer`-based version export was less aggressive about decorating dirty trees, so this regression landed quietly when the version step was switched to `hatch version` in #7328 (the "Switch to uv" PR).

The same problem already existed at PyPI publish time and was solved in `.github/workflows/publish_package.yaml` by setting `SETUPTOOLS_SCM_PRETEND_VERSION` from the tag. This PR applies the equivalent override inside the Dockerfile: when HEAD is on an exact tag, the env var is set to that tag and `hatch version` returns the tag verbatim. Off-tag builds are unaffected and continue to produce `<next>.devN+g<sha>.d<date>` so dev images remain uniquely identifiable.

This also incidentally fixes the Python webserver's reported version on Docker images built outside of the PyPI publish pipeline (the `clean_version()` regex in `src/fides/common/utils.py` was written for `versioneer`'s output format and does not strip `setuptools-scm`'s `dev0+g<sha>.d<date>` decoration). After this change, both `Fides.version` (frontend) and `__version__` (backend) report the clean tag on tagged Docker builds.

### Code Changes

* `Dockerfile` — when HEAD is on an exact tag, set `SETUPTOOLS_SCM_PRETEND_VERSION` from `git describe --tags --exact-match` before invoking `hatch version`, mirroring the override already used in `.github/workflows/publish_package.yaml`. Comment added explaining the `.dockerignore` interaction so this isn't rediscovered later.

### Steps to Confirm

These steps verify both the tagged-release path (clean version) and the off-tag dev path (decorated version) inside the actual Docker build, since the dirty-tree behavior cannot be reproduced on the host.

1. **Pull the branch and create a local test tag on the tip commit.** A test tag is needed because the override only fires when HEAD is on an exact tag. Use any PEP 440-valid version string that doesn't collide with a real release:
   ```
   git fetch origin ENG-3757-fix-fides-js-version-dirty-tree
   git checkout ENG-3757-fix-fides-js-version-dirty-tree
   git tag 99.99.99
   ```

2. **Build the `backend` stage of the Docker image.** Targeting the `backend` stage skips the frontend build and is sufficient for this verification — `version.json` is generated in this stage.
   ```
   docker build --target backend -t fides-vtest .
   ```

3. **Read `version.json` from the built image.** Expected: the clean tag, with no decoration.
   ```
   docker run --rm --entrypoint cat fides-vtest /fides/version.json
   ```
   Expected output: `{"version": "99.99.99"}`
   Pre-fix this would have returned: `{"version": "99.99.100.dev0+g<sha>.d<date>"}`

4. **Verify the off-tag (dev) path still produces a sensible decorated version.** Delete the tag and rebuild without cache so the version step re-runs:
   ```
   git tag -d 99.99.99
   docker build --no-cache --target backend -t fides-vtest-notag .
   docker run --rm --entrypoint cat fides-vtest-notag /fides/version.json
   ```
   Expected output: a string of the form `<next>.devN+g<sha>.d<date>` (e.g. `2.84.1b1.dev81+gcc93122c4.d20260508`). This confirms dev images remain uniquely identifiable and the override is correctly scoped to tagged builds only.

5. **(Optional) End-to-end sanity check via FidesJS.** Build the full image (no `--target`), boot the privacy center / consent flow, and confirm `Fides.version` in the browser console matches the tag rather than a decorated dev string. This is the surface where the bug was originally observed but is not strictly necessary if the `version.json` checks above pass — `version.json` is the single input that flows into the JS bundle.

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-3757]: https://ethyca.atlassian.net/browse/ENG-3757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ