### PR TITLE
Untrack auto-generated next-env.d.ts in admin-ui and privacy-center

### DIFF
--- a/changelog/8150-untrack-next-env-dts.yaml
+++ b/changelog/8150-untrack-next-env-dts.yaml
@@ -1,0 +1,4 @@
+type: Developer Experience
+description: Stop tracking auto-generated `next-env.d.ts` files in admin-ui and privacy-center to eliminate phantom diffs between `next dev` and `next build`
+pr: 8150
+labels: []

--- a/clients/admin-ui/.gitignore
+++ b/clients/admin-ui/.gitignore
@@ -83,6 +83,7 @@ typings/
 # Next.js build output
 .next
 out
+next-env.d.ts
 
 # Nuxt.js build / generate output
 .nuxt

--- a/clients/admin-ui/global.d.ts
+++ b/clients/admin-ui/global.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="next/image-types/global" />
+
 declare module globalThis {
   // needs to be in global scope of Admin UI for when we import fides-js components which contain fidesDebugger
   let fidesDebugger: (...args: unknown[]) => void;

--- a/clients/admin-ui/next-env.d.ts
+++ b/clients/admin-ui/next-env.d.ts
@@ -1,7 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
-import "./.next/dev/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/clients/fides-js/src/components/tcf/TcfOverlay.tsx
+++ b/clients/fides-js/src/components/tcf/TcfOverlay.tsx
@@ -47,7 +47,6 @@ import {
   selectBestNoticeTranslation,
 } from "../../lib/i18n";
 import { useI18n } from "../../lib/i18n/i18n-context";
-import { getOverridesByType } from "../../lib/initialize";
 import { updateConsent } from "../../lib/preferences";
 import { useEvent } from "../../lib/providers/event-context";
 import {

--- a/clients/privacy-center/.gitignore
+++ b/clients/privacy-center/.gitignore
@@ -81,6 +81,7 @@ typings/
 
 # Next.js build output
 .next
+next-env.d.ts
 
 # Fix conflict with root .gitignore Python rule.
 !lib

--- a/clients/privacy-center/global.d.ts
+++ b/clients/privacy-center/global.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="next/image-types/global" />
+
 declare module globalThis {
   /** Wrapper for console.log that only logs if debug mode is enabled. */
   let fidesDebugger: (...args: unknown[]) => void;

--- a/clients/privacy-center/next-env.d.ts
+++ b/clients/privacy-center/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Ticket [no ticket]

### Description Of Changes

Next.js rewrites `next-env.d.ts` differently depending on whether the last command was `next dev` or `next build` (the typed-routes import path differs between dev and prod), which left a phantom diff in `clients/admin-ui/next-env.d.ts` and `clients/privacy-center/next-env.d.ts` whenever you switched between the two. The file is auto-generated on every dev/build run and Next itself flags it as "should not be edited," so there's no value in tracking it.

This PR adds `next-env.d.ts` to each client's `.gitignore` and untracks the existing copies. Next regenerates them on first `dev`/`build`, so nothing breaks locally or in CI.

### Code Changes

* Add `next-env.d.ts` to `clients/admin-ui/.gitignore`
* Add `next-env.d.ts` to `clients/privacy-center/.gitignore`
* Remove the tracked `next-env.d.ts` from both clients (`git rm --cached`)

### Steps to Confirm

1. Check out the branch
2. In `clients/admin-ui`, run `npm run dev`, then stop it and run `npm run build`. Confirm `git status` stays clean (the regenerated `next-env.d.ts` should be ignored).
3. Repeat in `clients/privacy-center`.
4. CI build/typecheck still pass (Next regenerates the file before typecheck).

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required
