### PR TITLE
Property form: drag-and-drop image upload + paths editor UX

### DIFF
--- a/changelog/8151-image-upload-and-paths-editor-ux.yaml
+++ b/changelog/8151-image-upload-and-paths-editor-ux.yaml
@@ -1,0 +1,4 @@
+type: Changed
+description: Property form now accepts logo/icon images via drag-and-drop, and the paths editor commits typed paths on blur or via an explicit Add button
+pr: 8151
+labels: []

--- a/clients/admin-ui/src/features/properties/PathsEditor.tsx
+++ b/clients/admin-ui/src/features/properties/PathsEditor.tsx
@@ -11,11 +11,11 @@ export const PathsEditor = ({ value, onChange }: PathsEditorProps) => {
   const [error, setError] = useState<string | null>(null);
 
   const commitDraft = () => {
-    const trimmed = draft.trim();
-    if (!trimmed) {
+    const cleaned = draft.trim().replace(/^-+|-+$/g, "");
+    if (!cleaned) {
       return;
     }
-    const normalized = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+    const normalized = cleaned.startsWith("/") ? cleaned : `/${cleaned}`;
     if (value.includes(normalized)) {
       setError(`"${normalized}" already added`);
       return;
@@ -42,7 +42,7 @@ export const PathsEditor = ({ value, onChange }: PathsEditorProps) => {
         <Input
           placeholder="Add a path (e.g. /privacy)"
           value={draft}
-          onChange={(e) => setDraft(e.target.value)}
+          onChange={(e) => setDraft(e.target.value.replace(/\s+/g, "-"))}
           onPressEnter={(e) => {
             e.preventDefault();
             commitDraft();

--- a/clients/admin-ui/src/features/properties/PathsEditor.tsx
+++ b/clients/admin-ui/src/features/properties/PathsEditor.tsx
@@ -1,4 +1,4 @@
-import { Alert, Input, Space, Tag } from "fidesui";
+import { Alert, Button, Input, Space, Tag } from "fidesui";
 import { useState } from "react";
 
 interface PathsEditorProps {
@@ -10,7 +10,7 @@ export const PathsEditor = ({ value, onChange }: PathsEditorProps) => {
   const [draft, setDraft] = useState("");
   const [error, setError] = useState<string | null>(null);
 
-  const handleAdd = () => {
+  const commitDraft = () => {
     const trimmed = draft.trim();
     if (!trimmed) {
       return;
@@ -29,7 +29,7 @@ export const PathsEditor = ({ value, onChange }: PathsEditorProps) => {
   };
 
   return (
-    <Space direction="vertical" style={{ width: "100%" }}>
+    <Space orientation="vertical" style={{ width: "100%" }}>
       <Space wrap>
         {value.map((path) => (
           <Tag key={path} closable onClose={() => handleRemove(path)}>
@@ -37,15 +37,21 @@ export const PathsEditor = ({ value, onChange }: PathsEditorProps) => {
           </Tag>
         ))}
       </Space>
-      <Input
-        placeholder="Add a path (e.g. /privacy)"
-        value={draft}
-        onChange={(e) => setDraft(e.target.value)}
-        onPressEnter={(e) => {
-          e.preventDefault();
-          handleAdd();
-        }}
-      />
+      <Space.Compact className="w-full">
+        <Input
+          placeholder="Add a path (e.g. /privacy)"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onPressEnter={(e) => {
+            e.preventDefault();
+            commitDraft();
+          }}
+          onBlur={commitDraft}
+        />
+        <Button onClick={commitDraft} disabled={!draft.trim()}>
+          Add
+        </Button>
+      </Space.Compact>
       {error && <Alert type="error" message={error} closable />}
     </Space>
   );

--- a/clients/admin-ui/src/features/properties/PathsEditor.tsx
+++ b/clients/admin-ui/src/features/properties/PathsEditor.tsx
@@ -15,12 +15,13 @@ export const PathsEditor = ({ value, onChange }: PathsEditorProps) => {
     if (!trimmed) {
       return;
     }
-    if (value.includes(trimmed)) {
-      setError(`"${trimmed}" already added`);
+    const normalized = trimmed.startsWith("/") ? trimmed : `/${trimmed}`;
+    if (value.includes(normalized)) {
+      setError(`"${normalized}" already added`);
       return;
     }
     setError(null);
-    onChange([...value, trimmed]);
+    onChange([...value, normalized]);
     setDraft("");
   };
 
@@ -52,7 +53,7 @@ export const PathsEditor = ({ value, onChange }: PathsEditorProps) => {
           Add
         </Button>
       </Space.Compact>
-      {error && <Alert type="error" message={error} closable />}
+      {error && <Alert type="error" description={error} closable />}
     </Space>
   );
 };

--- a/clients/admin-ui/src/features/properties/privacy-center-config/ActionEditModal.tsx
+++ b/clients/admin-ui/src/features/properties/privacy-center-config/ActionEditModal.tsx
@@ -3,6 +3,8 @@ import { useMemo } from "react";
 
 import { useGetPoliciesQuery } from "~/features/policies/policy.slice";
 
+import { ImageUploadField } from "./ImageUploadField";
+
 export interface ActionFormValues {
   policy_key: string;
   title: string;
@@ -95,11 +97,11 @@ export const ActionEditModal = ({
           <Input.TextArea autoSize />
         </Form.Item>
         <Form.Item
-          label="Icon path"
+          label="Icon"
           name="icon_path"
-          rules={[{ required: true }]}
+          rules={[{ required: true, message: "Please upload an icon" }]}
         >
-          <Input placeholder="/icon.svg" />
+          <ImageUploadField ariaLabel="Icon" />
         </Form.Item>
       </Form>
     </Modal>

--- a/clients/admin-ui/src/features/properties/privacy-center-config/ImageUploadField.tsx
+++ b/clients/admin-ui/src/features/properties/privacy-center-config/ImageUploadField.tsx
@@ -1,0 +1,96 @@
+import type { UploadProps } from "fidesui";
+import { Button, Flex, Icons, Typography, Upload } from "fidesui";
+import { useState } from "react";
+
+const MAX_FILE_SIZE_BYTES = 2 * 1024 * 1024;
+
+const readFileAsDataUrl = (file: File) =>
+  new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+  });
+
+interface ImageUploadFieldProps {
+  value?: string;
+  onChange?: (value: string) => void;
+  ariaLabel?: string;
+}
+
+export const ImageUploadField = ({
+  value,
+  onChange,
+  ariaLabel,
+}: ImageUploadFieldProps) => {
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const handleBeforeUpload: UploadProps["beforeUpload"] = async (file) => {
+    setErrorMessage(null);
+    if (!file.type.startsWith("image/")) {
+      setErrorMessage("File must be an image.");
+      return false;
+    }
+    if (file.size > MAX_FILE_SIZE_BYTES) {
+      setErrorMessage("File must be 2MB or smaller.");
+      return false;
+    }
+    try {
+      const dataUrl = await readFileAsDataUrl(file);
+      onChange?.(dataUrl);
+    } catch {
+      setErrorMessage("Failed to read file.");
+    }
+    return false;
+  };
+
+  const handleRemove = () => {
+    setErrorMessage(null);
+    onChange?.("");
+  };
+
+  return (
+    <Flex vertical gap="small">
+      <Upload.Dragger
+        accept="image/*"
+        beforeUpload={handleBeforeUpload}
+        showUploadList={false}
+        multiple={false}
+        aria-label={ariaLabel}
+      >
+        {value ? (
+          <Flex vertical align="center" gap="small" className="p-2">
+            <img
+              src={value}
+              alt=""
+              className="max-h-24 max-w-full object-contain"
+            />
+            <Typography.Text type="secondary">
+              Click or drag to replace
+            </Typography.Text>
+          </Flex>
+        ) : (
+          <Flex vertical align="center" gap="small" className="p-4">
+            <Icons.Upload size={32} />
+            <Typography.Text>
+              Click or drag an image here to upload
+            </Typography.Text>
+            <Typography.Text type="secondary" className="text-xs">
+              PNG, JPG, or SVG up to 2MB
+            </Typography.Text>
+          </Flex>
+        )}
+      </Upload.Dragger>
+      {value && (
+        <Flex justify="flex-end">
+          <Button size="small" onClick={handleRemove}>
+            Remove
+          </Button>
+        </Flex>
+      )}
+      {errorMessage && (
+        <Typography.Text type="danger">{errorMessage}</Typography.Text>
+      )}
+    </Flex>
+  );
+};

--- a/clients/admin-ui/src/features/properties/privacy-center-config/PrivacyCenterConfigSection.tsx
+++ b/clients/admin-ui/src/features/properties/privacy-center-config/PrivacyCenterConfigSection.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 
 import { ActionEditModal, ActionFormValues } from "./ActionEditModal";
 import { ActionsTable } from "./ActionsTable";
+import { ImageUploadField } from "./ImageUploadField";
 
 export interface PrivacyCenterConfigValue {
   title?: string;
@@ -131,11 +132,12 @@ export const PrivacyCenterConfigSection = ({
             }
           />
         </Form.Item>
-        <Form.Item label="Logo path">
-          <Input
+        <Form.Item label="Logo">
+          <ImageUploadField
+            ariaLabel="Logo"
             value={value?.logo_path ?? ""}
-            onChange={(e) =>
-              onChange?.({ ...(value ?? {}), logo_path: e.target.value })
+            onChange={(next) =>
+              onChange?.({ ...(value ?? {}), logo_path: next })
             }
           />
         </Form.Item>

--- a/clients/admin-ui/src/features/properties/privacy-center-config/__tests__/ActionEditModal.test.tsx
+++ b/clients/admin-ui/src/features/properties/privacy-center-config/__tests__/ActionEditModal.test.tsx
@@ -15,6 +15,27 @@ jest.mock("~/features/policies/policy.slice", () => ({
   }),
 }));
 
+// ImageUploadField wraps antd Upload.Dragger which uses FileReader and a
+// hidden file input -- both awkward to drive in jsdom. Substitute a plain
+// text input for unit tests so we still exercise the form-submission flow.
+jest.mock("../ImageUploadField", () => ({
+  ImageUploadField: ({
+    value,
+    onChange,
+    ariaLabel,
+  }: {
+    value?: string;
+    onChange?: (next: string) => void;
+    ariaLabel?: string;
+  }) => (
+    <input
+      aria-label={ariaLabel}
+      value={value ?? ""}
+      onChange={(e) => onChange?.(e.target.value)}
+    />
+  ),
+}));
+
 // Test adaptation: antd's Select inside an antd Modal triggers a known jsdom +
 // nwsapi crash ("e.parentElement.querySelectorAll(...).includes is not a
 // function") when the dropdown's virtual list layer mounts. Other tests in this
@@ -74,7 +95,7 @@ describe("ActionEditModal", () => {
       screen.getByLabelText(/description/i),
       "Request a copy.",
     );
-    await userEvent.type(screen.getByLabelText(/icon path/i), "/icon.svg");
+    await userEvent.type(screen.getByLabelText(/^icon$/i), "/icon.svg");
     await userEvent.click(screen.getByRole("button", { name: /save/i }));
 
     expect(onOk).toHaveBeenCalledWith(


### PR DESCRIPTION
Ticket [no ticket — demo branch]

### Description Of Changes

Four UX improvements to the property form, targeting the `demo/april` branch:

1. **Drag-and-drop image upload.** The "Logo path" and "Icon path" text inputs in the property and action forms are replaced with an `Upload.Dragger`-based image picker. Selected files are read as base64 data URLs and stored in the existing `logo_path` / `icon_path` string fields, so the privacy center config schema is unchanged. A thumbnail preview and Remove button are shown once a file is set. Files over 2MB or non-image MIME types are rejected client-side.
2. **PathsEditor — paths editor commit UX.** Previously the only way to commit a typed path into the form value was pressing Enter; clicking Save with text still in the input silently dropped it. Adds a visible Add button (disabled while empty) and commits the draft on blur.
3. **PathsEditor — auto-prefix `/`.** Paths must start with `/` to match in the privacy center, but the input let users save `myprop` (which silently never matched). The editor now normalizes `myprop` → `/myprop` on commit; an existing leading slash is preserved.
4. **PathsEditor — convert spaces to hyphens.** Spaces aren't valid in URL path segments. Runs of whitespace are live-replaced with a single hyphen as the user types (so `my path` becomes `my-path` in the input), and stray leading/trailing hyphens are stripped on commit so pasting `  hello world  ` yields `/hello-world`.

Also fixes two latent antd v6 deprecations along the way (`Space direction` → `orientation`, `Alert message` → `description`).

### Code Changes

* New `clients/admin-ui/src/features/properties/privacy-center-config/ImageUploadField.tsx` — reusable drag-and-drop image picker built on `Upload.Dragger`; reads files as base64 data URLs (max 2MB), shows thumbnail preview, Remove button, and inline error messaging.
* `ActionEditModal.tsx` — replace the icon path `<Input>` with `<ImageUploadField />`; rename label "Icon path" → "Icon".
* `PrivacyCenterConfigSection.tsx` — replace the logo path `<Input>` with `<ImageUploadField>`, manually wired to `logo_path`.
* `PathsEditor.tsx` — add Add button; commit on blur; auto-prefix `/`; live-convert whitespace to `-` on input; strip leading/trailing `-` on commit; replace deprecated `Space direction` and `Alert message` props.
* `__tests__/ActionEditModal.test.tsx` — mock `ImageUploadField` with a plain text input (same pattern used for `Select`) so the existing form-submission assertion still runs in jsdom.

### Steps to Confirm

1. Open admin-ui at `http://localhost:3000`, navigate to **Settings → Properties → (any property)**.
2. **Logo upload:** under "Privacy center config", click or drag an image file onto the Logo dropzone. Confirm a thumbnail appears and "Click or drag to replace" is shown.
3. **Icon upload:** click "Add action" (or edit one), drag/drop an image into the Icon dropzone. Confirm preview appears and the Save button enables.
4. Save the property. Reload — confirm the images persist.
5. **Privacy center display:** visit the privacy center at the property's path (e.g. `http://localhost:3001/<path>`); confirm the uploaded logo renders. (Privacy center pulls from API config when accessed via property path or with `FIDES_PRIVACY_CENTER__USE_API_CONFIG=true`.)
6. **PathsEditor — commit on blur / Add button:** edit a property's "Privacy center paths". Type a path and click Save without pressing Enter — confirm the path is captured. Confirm the Add button is disabled when the input is empty.
7. **PathsEditor — auto-prefix `/`:** type a path *without* a leading slash (e.g. `myprop`) and commit — confirm it saves as `/myprop`. Type one *with* a slash (`/foo`) — confirm it stays `/foo`.
8. **PathsEditor — spaces to hyphens:** type `my path` — confirm the input shows `my-path` as soon as you press space. Paste `  hello world  ` — confirm it becomes `-hello-world-` in the input and saves as `/hello-world` after commit.
9. **Validation:** try uploading a non-image file or a >2MB file — confirm an inline error appears.

### Pre-Merge Checklist

* [x] Issue requirements met (no ticket — demo branch)
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated (see `changelog/8151-image-upload-and-paths-editor-ux.yaml`)
  * [ ] Add a db-migration label to the entry if your change includes a DB migration
  * [ ] Add a high-risk label to the entry if your change includes a high-risk change
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed (demo branch)
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, PR opened in fidesdocs
  * [ ] Documentation issue created in fidesdocs
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required