### PR TITLE
Update the cookie wildcard placeholder

### DIFF
--- a/changelog/8152-update-cookie-wildcard.yaml
+++ b/changelog/8152-update-cookie-wildcard.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Update the cookie wildcard placeholder
+pr: 8152
+labels: []

--- a/clients/fides-js/__tests__/lib/cookie.test.ts
+++ b/clients/fides-js/__tests__/lib/cookie.test.ts
@@ -495,10 +495,10 @@ describe("cookies", () => {
     });
 
     it("returns true for wildcard cookies", () => {
-      expect(isWildcardCookie({ name: "_ga[id]" })).toBeTruthy();
+      expect(isWildcardCookie({ name: "_ga-id-" })).toBeTruthy();
       expect(
         isWildcardCookie({
-          name: "_ga_[id]_[id]",
+          name: "_ga_-id-_-id-",
         }),
       ).toBeTruthy();
     });
@@ -615,7 +615,7 @@ describe("cookies", () => {
           other_cookie: "other_value",
         } as any);
         removeCookiesFromBrowser(
-          [{ name: "_ga[id]", domain: "foo.com", path: "/bar" }],
+          [{ name: "_ga-id-", domain: "foo.com", path: "/bar" }],
           false,
           false,
         );
@@ -629,7 +629,7 @@ describe("cookies", () => {
           other_cookie: "other_value",
         } as any);
         removeCookiesFromBrowser(
-          [{ name: "_ga[id]", domain: "foo.com", path: "/bar" }],
+          [{ name: "_ga-id-", domain: "foo.com", path: "/bar" }],
           true,
           true,
         );
@@ -644,7 +644,7 @@ describe("cookies", () => {
           foo_abc: "test_value_2",
         } as any);
         removeCookiesFromBrowser(
-          [{ name: "_ga[id]" }, { name: "foo_[id]" }],
+          [{ name: "_ga-id-" }, { name: "foo_-id-" }],
           false,
           false,
         );
@@ -659,7 +659,7 @@ describe("cookies", () => {
           cab123: "",
         } as any);
         removeCookiesFromBrowser(
-          [{ name: "x[id]" }, { name: "ab[id]" }, { name: "y[id]" }],
+          [{ name: "x-id-" }, { name: "ab-id-" }, { name: "y-id-" }],
           false,
           false,
         );
@@ -670,7 +670,7 @@ describe("cookies", () => {
           ab: "",
           ab123: "",
         } as any);
-        removeCookiesFromBrowser([{ name: "ab[id]" }], false, false);
+        removeCookiesFromBrowser([{ name: "ab-id-" }], false, false);
         expect(mockRemoveCookie.mock.calls).toEqual([["ab123", { path: "/" }]]);
       });
       it("should handle wildcard cookies with special characters", () => {
@@ -679,7 +679,7 @@ describe("cookies", () => {
           [`${prefix}123`]: "test_value",
           other_cookie: "other_value",
         } as any);
-        removeCookiesFromBrowser([{ name: `${prefix}[id]` }], false, false);
+        removeCookiesFromBrowser([{ name: `${prefix}-id-` }], false, false);
         expect(mockRemoveCookie.mock.calls).toEqual([
           [`${prefix}123`, { path: "/" }],
         ]);
@@ -690,7 +690,7 @@ describe("cookies", () => {
           "_ga_789.101": "test_value_2",
           other_cookie: "other_value",
         } as any);
-        removeCookiesFromBrowser([{ name: "_ga_[id]_[id]" }], false, false);
+        removeCookiesFromBrowser([{ name: "_ga_-id-_-id-" }], false, false);
         expect(mockRemoveCookie.mock.calls).toEqual([
           ["_ga_123_456", { path: "/" }],
         ]);

--- a/clients/fides-js/src/lib/cookie.ts
+++ b/clients/fides-js/src/lib/cookie.ts
@@ -619,13 +619,13 @@ export const makeConsentDefaultsLegacy = (
 };
 
 /**
- * Determine if the provided cookie is a wildcard cookie, i.e., the name contains `[id]`.
+ * Determine if the provided cookie is a wildcard cookie, i.e., the name contains `-id-`.
  * These are used to represent sets of cookies that have some sort of a unique identifier
  * in their name. For example, a site might set multiple cookies like `_ga_12345` and
- * `_ga_67890` and both of these will match a wildcard cookie with the name `_ga_[id]`.
+ * `_ga_67890` and both of these will match a wildcard cookie with the name `_ga_-id-`.
  */
 export const isWildcardCookie = (cookie: CookiesType): boolean => {
-  return cookie.name.includes("[id]");
+  return cookie.name.includes("-id-");
 };
 
 /**
@@ -666,7 +666,7 @@ export const removeCookiesFromBrowser = (
     wildcardCookies.forEach((wCookie) => {
       const namePattern = wCookie.name
         .replace(/[.*+?^${}()|[\]\\]/g, "\\$&") // Escape special regex chars
-        .replace(/\\\[id\\\]/g, ".+?"); // Replace \[id\] with non-greedy wildcard
+        .replace(/-id-/g, ".+?"); // Replace -id- with non-greedy wildcard
       const pattern = new RegExp(`^(${namePattern})$`);
       Object.keys(allCookies).forEach((name) => {
         if (pattern.test(name)) {


### PR DESCRIPTION
Ticket [ENG-3760]

### Description Of Changes

There was a change upstream to consolidate the wildcard placeholders (`[id]` for cookies and paths, `_id_` for domains) into `-id-` which is valid in all of the possible positions and I forgot to update this cookie handling code. Thanks @nrxsmith for catching this. 

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated


[ENG-3760]: https://ethyca.atlassian.net/browse/ENG-3760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ