### PR TITLE
Adjust DSR cache sweeper defaults, increase liveness logging, remove per-record eligibilty check

### DIFF
--- a/src/fides/common/cache/dsr_store.py
+++ b/src/fides/common/cache/dsr_store.py
@@ -103,7 +103,7 @@ def redis_key_is_dsr_cache_key_for_id(key: str, dsr_id_lower: str) -> bool:
 
 
 def candidate_privacy_request_ids_for_sweep(key: str) -> Set[str]:
-    """Candidate ids to check with SISMEMBER (normalized lowercase)."""
+    """Candidate ids to check with SMISMEMBER (normalized lowercase)."""
     out: set[str] = set()
     for m in _DSR_REDIS_KEY_SWEEP_UUID_RE.findall(key):
         u = _normalize_uuid_token(m)

--- a/src/fides/config/execution_settings.py
+++ b/src/fides/config/execution_settings.py
@@ -37,10 +37,10 @@ class DsrCacheSweeperSettings(BaseModel):
     )
     batch_size: int = Field(
         default=10000,
-        ge=1000,
+        ge=10,
         description=(
             "Max privacy requests to process per database batch (keyset pagination). "
-            "Minimum 1000; increase for fewer round-trips on large backlogs."
+            "Minimum 10; increase for fewer round-trips on large backlogs."
         ),
     )
     batch_sleep_seconds: float = Field(
@@ -109,6 +109,17 @@ class DsrCacheSweeperSettings(BaseModel):
         ge=1,
         le=10000,
         description="Max keys per pipeline UNLINK/DEL batch in single-pass mode.",
+    )
+    membership_lookup_batch_size: int = Field(
+        default=2048,
+        ge=50,
+        le=20000,
+        description=(
+            "How many staging-set membership checks (SMISMEMBER commands) to send in each "
+            "Redis pipeline round trip while scanning keys in single-pass mode. Default "
+            "2048 balances fewer round trips against predictable latency. Override only if "
+            "you measure a need."
+        ),
     )
 
 

--- a/src/fides/config/execution_settings.py
+++ b/src/fides/config/execution_settings.py
@@ -36,12 +36,20 @@ class DsrCacheSweeperSettings(BaseModel):
         ),
     )
     batch_size: int = Field(
-        default=50,
-        description="Max privacy requests to process per database batch (keyset pagination).",
+        default=1000,
+        ge=1000,
+        description=(
+            "Max privacy requests to process per database batch (keyset pagination). "
+            "Minimum 1000; increase for fewer round-trips on large backlogs."
+        ),
     )
     batch_sleep_seconds: float = Field(
-        default=0.5,
-        description="Base delay between batches; a random jitter up to this value is added.",
+        default=0.05,
+        ge=0.0,
+        description=(
+            "Base delay between database batches (seconds); a random jitter from 0 up to "
+            "this value is added. Default 0.05 (50ms) to yield lightly between pages."
+        ),
     )
     include_denied_and_duplicate: bool = Field(
         default=True,

--- a/src/fides/config/execution_settings.py
+++ b/src/fides/config/execution_settings.py
@@ -36,7 +36,7 @@ class DsrCacheSweeperSettings(BaseModel):
         ),
     )
     batch_size: int = Field(
-        default=1000,
+        default=10000,
         ge=1000,
         description=(
             "Max privacy requests to process per database batch (keyset pagination). "
@@ -44,11 +44,12 @@ class DsrCacheSweeperSettings(BaseModel):
         ),
     )
     batch_sleep_seconds: float = Field(
-        default=0.05,
+        default=0.0,
         ge=0.0,
         description=(
             "Base delay between database batches (seconds); a random jitter from 0 up to "
-            "this value is added. Default 0.05 (50ms) to yield lightly between pages."
+            "this value is added. Default 0 (disabled). Increase to lightly yield between "
+            "pages if needed as a safety valve under load."
         ),
     )
     include_denied_and_duplicate: bool = Field(
@@ -93,7 +94,7 @@ class DsrCacheSweeperSettings(BaseModel):
     maintenance_set_key: str = Field(
         default="__maintenance:dsr_cache_sweeper:eligible_ids",
         description=(
-            "Redis key for the temporary eligible-ID set (SADD/SISMEMBER). Override for "
+            "Redis key for the temporary eligible-ID set (SADD/SMISMEMBER). Override for "
             "multi-tenant or test isolation."
         ),
     )

--- a/src/fides/service/privacy_request/dsr_cache_sweeper.py
+++ b/src/fides/service/privacy_request/dsr_cache_sweeper.py
@@ -245,10 +245,18 @@ def run_dsr_cache_sweeper(
     ttl = int(tc.maintenance_set_ttl_seconds)
     scan_count = int(tc.redis_scan_count)
     del_batch = max(1, int(tc.redis_delete_batch_size))
+    membership_lookup_batch_size = max(1, int(tc.membership_lookup_batch_size))
 
     manager = get_redis_cache_manager()
     redis = manager._redis
     redis.delete(set_key)
+    logger.info(
+        "DSR cache sweeper single-pass: Postgres staging phase starting "
+        "(eligible ids are written to Redis; SCAN/UNLINK runs after this phase). "
+        "maintenance_set_key={} membership_lookup_batch_size={}",
+        set_key,
+        membership_lookup_batch_size,
+    )
     staging_expire_applied = False
     total_staged_members = 0
     staging_first_sadd_s: Optional[float] = None
@@ -258,13 +266,14 @@ def run_dsr_cache_sweeper(
     last_id = ""
     db_phase_started = time.perf_counter()
     db_page_index = 0
+    terminal_status_list = list(terminal_statuses)
 
     while True:
         page_started = time.perf_counter()
         batch_rows = (
             db.query(PrivacyRequest.id, PrivacyRequest.status)
             .filter(
-                PrivacyRequest.status.in_(list(terminal_statuses)),
+                PrivacyRequest.status.in_(terminal_status_list),
                 PrivacyRequest.updated_at < cutoff,
                 PrivacyRequest.id > last_id,
             )
@@ -374,12 +383,14 @@ def run_dsr_cache_sweeper(
     try:
         logger.info(
             "DSR cache sweeper starting Redis SCAN set_key={} eligible_dsr_count={} "
-            "staging_duration_s={:.3f} ttl_seconds={} redis_scan_count={}",
+            "staging_duration_s={:.3f} ttl_seconds={} redis_scan_count={} "
+            "membership_lookup_batch_size={}",
             set_key,
             eligible_dsr_count,
             staging_duration_s,
             ttl,
             scan_count,
+            membership_lookup_batch_size,
         )
 
         pending_delete: list[str] = []
@@ -412,24 +423,32 @@ def run_dsr_cache_sweeper(
 
             present_rows: list[Any] = []
             if keyed:
-                try:
-                    pipe = redis.pipeline(transaction=False)
-                    for _key_str, cand_list in keyed:
-                        pipe.smismember(set_key, *cand_list)
-                    present_rows = pipe.execute()
-                    if len(present_rows) != len(keyed):
-                        raise ValueError(
-                            "SMISMEMBER pipeline length mismatch: "
-                            f"expected {len(keyed)}, got {len(present_rows)}"
-                        )
-                except Exception:  # noqa: BLE001
-                    present_rows = []
-                    for _key_str, cand_list in keyed:
-                        try:
-                            present_rows.append(redis.smismember(set_key, *cand_list))
-                        except Exception:  # noqa: BLE001
-                            redis_errors += 1
-                            present_rows.append(None)
+                for pipe_off in range(0, len(keyed), membership_lookup_batch_size):
+                    pipe_slice = keyed[
+                        pipe_off : pipe_off + membership_lookup_batch_size
+                    ]
+                    sub_present: list[Any] = []
+                    try:
+                        pipe = redis.pipeline(transaction=False)
+                        for _key_str, cand_list in pipe_slice:
+                            pipe.smismember(set_key, *cand_list)
+                        sub_present = pipe.execute()
+                        if len(sub_present) != len(pipe_slice):
+                            raise ValueError(
+                                "SMISMEMBER pipeline length mismatch: "
+                                f"expected {len(pipe_slice)}, got {len(sub_present)}"
+                            )
+                    except Exception:  # noqa: BLE001
+                        sub_present = []
+                        for _key_str, cand_list in pipe_slice:
+                            try:
+                                sub_present.append(
+                                    redis.smismember(set_key, *cand_list)
+                                )
+                            except Exception:  # noqa: BLE001
+                                redis_errors += 1
+                                sub_present.append(None)
+                    present_rows.extend(sub_present)
 
             for (key_str, cand_list), present in zip(keyed, present_rows):
                 if present is None:

--- a/src/fides/service/privacy_request/dsr_cache_sweeper.py
+++ b/src/fides/service/privacy_request/dsr_cache_sweeper.py
@@ -46,7 +46,6 @@ class DsrCacheSweeperResult:
     """Summary of one sweeper run."""
 
     rows_scanned: int
-    rows_skipped_status_mismatch: int
     eligible_dsr_count: int
     redis_keys_scanned: int
     dsr_ids_seen_in_redis: int
@@ -175,17 +174,15 @@ def _run_dsr_cache_sweeper_legacy(
 
     logger.info(
         "DSR cache sweeper DB phase complete (legacy) pages={} rows_scanned={} "
-        "skipped_status_mismatch={} redis_clears={} db_phase_duration_s={:.3f}",
+        "redis_clears={} db_phase_duration_s={:.3f}",
         db_page_index,
         rows_scanned,
-        0,
         redis_keys_deleted,
         time.perf_counter() - db_phase_started,
     )
 
     return DsrCacheSweeperResult(
         rows_scanned=rows_scanned,
-        rows_skipped_status_mismatch=0,
         eligible_dsr_count=redis_keys_deleted,  # best-effort legacy: one clear per eligible row
         redis_keys_scanned=0,
         dsr_ids_seen_in_redis=redis_keys_deleted,
@@ -223,17 +220,15 @@ def run_dsr_cache_sweeper(
         duration = time.perf_counter() - started
         logger.info(
             "DSR cache sweeper (legacy) finished rows_scanned={} "
-            "redis_keys_deleted={} skipped_status_mismatch={} redis_errors={} "
+            "redis_keys_deleted={} redis_errors={} "
             "duration_s={:.3f}",
             res.rows_scanned,
             res.redis_keys_deleted,
-            0,
             res.redis_errors,
             duration,
         )
         return DsrCacheSweeperResult(
             rows_scanned=res.rows_scanned,
-            rows_skipped_status_mismatch=res.rows_skipped_status_mismatch,
             eligible_dsr_count=res.eligible_dsr_count,
             redis_keys_scanned=0,
             dsr_ids_seen_in_redis=res.dsr_ids_seen_in_redis,
@@ -336,12 +331,11 @@ def run_dsr_cache_sweeper(
     )
     logger.info(
         "DSR cache sweeper DB phase complete (single-pass staging) pages={} "
-        "eligible_dsr_count={} rows_scanned={} skipped_status_mismatch={} "
+        "eligible_dsr_count={} rows_scanned={} "
         "db_phase_duration_s={:.3f} redis_staging_stream_s={:.3f}",
         db_page_index,
         eligible_dsr_count,
         rows_scanned,
-        0,
         db_phase_duration_s,
         staging_duration_s,
     )
@@ -357,16 +351,14 @@ def run_dsr_cache_sweeper(
     if eligible_dsr_count == 0:
         logger.info(
             "DSR cache sweeper finished eligible_dsr_count=0 rows_scanned={} "
-            "skipped_status_mismatch={} redis_keys_scanned=0 redis_keys_deleted=0 "
+            "redis_keys_scanned=0 redis_keys_deleted=0 "
             "duration_s={:.3f} db_phase_duration_s={:.3f} maintenance_set_deleted=n/a",
             rows_scanned,
-            0,
             duration,
             db_phase_duration_s,
         )
         return DsrCacheSweeperResult(
             rows_scanned=rows_scanned,
-            rows_skipped_status_mismatch=0,
             eligible_dsr_count=0,
             redis_keys_scanned=0,
             dsr_ids_seen_in_redis=0,
@@ -409,18 +401,46 @@ def run_dsr_cache_sweeper(
         for key_batch in redis.iter_scan_batches(count=scan_count):
             chunk_started = time.perf_counter()
             keys_in_chunk = len(key_batch)
+
+            keyed: list[tuple[str, list[str]]] = []
             for raw_key in key_batch:
                 redis_keys_scanned += 1
                 key_str = decode_dsr_redis_key(raw_key)
                 candidates = candidate_privacy_request_ids_for_sweep(key_str)
+                if candidates:
+                    keyed.append((key_str, sorted(candidates)))
+
+            present_rows: list[Any] = []
+            if keyed:
+                try:
+                    pipe = redis.pipeline(transaction=False)
+                    for _key_str, cand_list in keyed:
+                        pipe.smismember(set_key, *cand_list)
+                    present_rows = pipe.execute()
+                    if len(present_rows) != len(keyed):
+                        raise ValueError(
+                            "SMISMEMBER pipeline length mismatch: "
+                            f"expected {len(keyed)}, got {len(present_rows)}"
+                        )
+                except Exception:  # noqa: BLE001
+                    present_rows = []
+                    for _key_str, cand_list in keyed:
+                        try:
+                            present_rows.append(redis.smismember(set_key, *cand_list))
+                        except Exception:  # noqa: BLE001
+                            redis_errors += 1
+                            present_rows.append(None)
+
+            for (key_str, cand_list), present in zip(keyed, present_rows):
+                if present is None:
+                    continue
+                if isinstance(present, Exception):
+                    redis_errors += 1
+                    continue
                 delete_this_key = False
                 matched_id: Optional[str] = None
-                for uid in candidates:
-                    try:
-                        if not redis.sismember(set_key, uid):
-                            continue
-                    except Exception:  # noqa: BLE001
-                        redis_errors += 1
+                for uid, is_member in zip(cand_list, present):
+                    if not is_member:
                         continue
                     if redis_key_is_dsr_cache_key_for_id(key_str, uid):
                         delete_this_key = True
@@ -473,14 +493,13 @@ def run_dsr_cache_sweeper(
 
     logger.info(
         "DSR cache sweeper finished eligible_dsr_count={} rows_scanned={} "
-        "skipped_status_mismatch={} redis_keys_scanned={} dsr_ids_seen_in_redis={} "
+        "redis_keys_scanned={} dsr_ids_seen_in_redis={} "
         "redis_keys_deleted={} redis_delete_errors={} redis_errors={} "
         "duration_s={:.3f} sweep_s={:.3f} db_phase_duration_s={:.3f} "
         "redis_staging_duration_s={:.3f} redis_scan_phase_duration_s={:.3f} "
         "maintenance_set_deleted={}",
         eligible_dsr_count,
         rows_scanned,
-        0,
         redis_keys_scanned,
         len(dsr_ids_touched),
         redis_keys_deleted,
@@ -496,7 +515,6 @@ def run_dsr_cache_sweeper(
 
     return DsrCacheSweeperResult(
         rows_scanned=rows_scanned,
-        rows_skipped_status_mismatch=0,
         eligible_dsr_count=eligible_dsr_count,
         redis_keys_scanned=redis_keys_scanned,
         dsr_ids_seen_in_redis=len(dsr_ids_touched),

--- a/src/fides/service/privacy_request/dsr_cache_sweeper.py
+++ b/src/fides/service/privacy_request/dsr_cache_sweeper.py
@@ -1,9 +1,9 @@
 """Periodic DSR cache sweeper: clears Redis cache keys for terminal privacy requests.
 
 Eligible rows are selected from Postgres by terminal status and staleness on
-``updated_at``, including soft-deleted requests (``deleted_at`` set). For each
-eligible id we re-read ``status`` while building the work set (same race semantics
-as the legacy per-row path).
+``updated_at``, including soft-deleted requests (``deleted_at`` set). Rows
+returned by the paginated query are treated as eligible without a second
+per-row status read.
 
 **Single-pass mode (default):** eligible string IDs are staged in a Redis set
 with a TTL, the keyspace is scanned once in bounded chunks, and keys matching
@@ -107,12 +107,15 @@ def _run_dsr_cache_sweeper_legacy(
     cutoff = datetime.now(timezone.utc) - timedelta(minutes=staleness_minutes)
 
     rows_scanned = 0
-    rows_skipped_status_mismatch = 0
     redis_errors = 0
     redis_keys_deleted = 0
     last_id = ""
+    db_phase_started = time.perf_counter()
+    db_page_index = 0
 
     while True:
+        page_started = time.perf_counter()
+        cleared_before_page = redis_keys_deleted
         batch_rows = (
             db.query(PrivacyRequest.id, PrivacyRequest.status)
             .filter(
@@ -127,24 +130,8 @@ def _run_dsr_cache_sweeper_legacy(
         if not batch_rows:
             break
 
-        for pr_id, initial_status in batch_rows:
+        for pr_id, status in batch_rows:
             rows_scanned += 1
-
-            current = (
-                db.query(PrivacyRequest.status)
-                .filter(PrivacyRequest.id == pr_id)
-                .scalar()
-            )
-            if current is None or current not in terminal_statuses:
-                rows_skipped_status_mismatch += 1
-                logger.debug(
-                    "Skipping DSR cache sweeper for privacy_request_id={}: "
-                    "status no longer eligible (batch had {}, current={})",
-                    pr_id,
-                    initial_status.value,
-                    getattr(current, "value", current),
-                )
-                continue
 
             store = get_dsr_cache_store(str(pr_id))
             try:
@@ -154,7 +141,7 @@ def _run_dsr_cache_sweeper_legacy(
                     "Cleared Redis DSR cache privacy_request_id={} status={} "
                     "staleness_minutes={}",
                     pr_id,
-                    current.value,
+                    status.value,
                     staleness_minutes,
                 )
             except Exception as exc:  # noqa: BLE001
@@ -162,19 +149,43 @@ def _run_dsr_cache_sweeper_legacy(
                 logger.warning(
                     "Redis clear failed for privacy_request_id={} status={}: {}",
                     pr_id,
-                    current.value,
+                    status.value,
                     exc,
                 )
 
         last_id = batch_rows[-1][0]
+        page_duration_s = time.perf_counter() - page_started
+        clears_in_page = redis_keys_deleted - cleared_before_page
+        logger.info(
+            "DSR cache sweeper DB page (legacy) page_index={} rows_in_page={} "
+            "redis_clear_attempts_in_page={} page_duration_s={:.3f} "
+            "cumulative_rows_scanned={} cumulative_redis_clears={}",
+            db_page_index,
+            len(batch_rows),
+            clears_in_page,
+            page_duration_s,
+            rows_scanned,
+            redis_keys_deleted,
+        )
+        db_page_index += 1
 
         if batch_sleep > 0:
             jitter = random.uniform(0.0, batch_sleep)
             time.sleep(batch_sleep + jitter)
 
+    logger.info(
+        "DSR cache sweeper DB phase complete (legacy) pages={} rows_scanned={} "
+        "skipped_status_mismatch={} redis_clears={} db_phase_duration_s={:.3f}",
+        db_page_index,
+        rows_scanned,
+        0,
+        redis_keys_deleted,
+        time.perf_counter() - db_phase_started,
+    )
+
     return DsrCacheSweeperResult(
         rows_scanned=rows_scanned,
-        rows_skipped_status_mismatch=rows_skipped_status_mismatch,
+        rows_skipped_status_mismatch=0,
         eligible_dsr_count=redis_keys_deleted,  # best-effort legacy: one clear per eligible row
         redis_keys_scanned=0,
         dsr_ids_seen_in_redis=redis_keys_deleted,
@@ -216,7 +227,7 @@ def run_dsr_cache_sweeper(
             "duration_s={:.3f}",
             res.rows_scanned,
             res.redis_keys_deleted,
-            res.rows_skipped_status_mismatch,
+            0,
             res.redis_errors,
             duration,
         )
@@ -235,12 +246,26 @@ def run_dsr_cache_sweeper(
 
     cutoff = datetime.now(timezone.utc) - timedelta(minutes=staleness_minutes)
 
+    set_key = tc.maintenance_set_key
+    ttl = int(tc.maintenance_set_ttl_seconds)
+    scan_count = int(tc.redis_scan_count)
+    del_batch = max(1, int(tc.redis_delete_batch_size))
+
+    manager = get_redis_cache_manager()
+    redis = manager._redis
+    redis.delete(set_key)
+    staging_expire_applied = False
+    total_staged_members = 0
+    staging_first_sadd_s: Optional[float] = None
+    staging_last_sadd_end_s: Optional[float] = None
+
     rows_scanned = 0
-    rows_skipped_status_mismatch = 0
-    eligible_ids: list[str] = []
     last_id = ""
+    db_phase_started = time.perf_counter()
+    db_page_index = 0
 
     while True:
+        page_started = time.perf_counter()
         batch_rows = (
             db.query(PrivacyRequest.id, PrivacyRequest.status)
             .filter(
@@ -255,34 +280,71 @@ def run_dsr_cache_sweeper(
         if not batch_rows:
             break
 
-        for pr_id, initial_status in batch_rows:
-            rows_scanned += 1
-
-            current = (
-                db.query(PrivacyRequest.status)
-                .filter(PrivacyRequest.id == pr_id)
-                .scalar()
-            )
-            if current is None or current not in terminal_statuses:
-                rows_skipped_status_mismatch += 1
-                logger.debug(
-                    "Skipping DSR cache sweeper staging for privacy_request_id={}: "
-                    "status no longer eligible (batch had {}, current={})",
-                    pr_id,
-                    initial_status.value,
-                    getattr(current, "value", current),
-                )
-                continue
-
-            eligible_ids.append(str(pr_id).lower())
+        page_eligible = [str(pr_id).lower() for pr_id, _ in batch_rows]
+        rows_scanned += len(batch_rows)
 
         last_id = batch_rows[-1][0]
+        page_duration_s = time.perf_counter() - page_started
+        eligible_added_in_page = len(page_eligible)
+
+        if page_eligible:
+            sadd_started = time.perf_counter()
+            if staging_first_sadd_s is None:
+                staging_first_sadd_s = sadd_started
+            redis.sadd_members_chunked(set_key, page_eligible)
+            if not staging_expire_applied:
+                redis.expire(set_key, ttl)
+                staging_expire_applied = True
+            sadd_duration_s = time.perf_counter() - sadd_started
+            staging_last_sadd_end_s = time.perf_counter()
+            total_staged_members += len(page_eligible)
+            set_member_count = int(redis.scard(set_key))
+            logger.info(
+                "DSR cache sweeper Redis staging SADD batch page_index={} members_added={} "
+                "sadd_duration_s={:.3f} set_member_count={} ttl_seconds={} ttl_applied={}",
+                db_page_index,
+                len(page_eligible),
+                sadd_duration_s,
+                set_member_count,
+                ttl,
+                staging_expire_applied,
+            )
+
+        logger.info(
+            "DSR cache sweeper DB page (single-pass staging) page_index={} rows_in_page={} "
+            "eligible_added_in_page={} page_duration_s={:.3f} cumulative_rows_scanned={} "
+            "cumulative_staged_members={}",
+            db_page_index,
+            len(batch_rows),
+            eligible_added_in_page,
+            page_duration_s,
+            rows_scanned,
+            total_staged_members,
+        )
+        db_page_index += 1
 
         if batch_sleep > 0:
             jitter = random.uniform(0.0, batch_sleep)
             time.sleep(batch_sleep + jitter)
 
-    eligible_dsr_count = len(eligible_ids)
+    db_phase_duration_s = time.perf_counter() - db_phase_started
+    eligible_dsr_count = int(redis.scard(set_key))
+    staging_duration_s = (
+        (staging_last_sadd_end_s - staging_first_sadd_s)
+        if staging_first_sadd_s is not None and staging_last_sadd_end_s is not None
+        else 0.0
+    )
+    logger.info(
+        "DSR cache sweeper DB phase complete (single-pass staging) pages={} "
+        "eligible_dsr_count={} rows_scanned={} skipped_status_mismatch={} "
+        "db_phase_duration_s={:.3f} redis_staging_stream_s={:.3f}",
+        db_page_index,
+        eligible_dsr_count,
+        rows_scanned,
+        0,
+        db_phase_duration_s,
+        staging_duration_s,
+    )
     redis_keys_scanned = 0
     dsr_ids_touched: set[str] = set()
     redis_keys_deleted = 0
@@ -296,14 +358,15 @@ def run_dsr_cache_sweeper(
         logger.info(
             "DSR cache sweeper finished eligible_dsr_count=0 rows_scanned={} "
             "skipped_status_mismatch={} redis_keys_scanned=0 redis_keys_deleted=0 "
-            "duration_s={:.3f} maintenance_set_deleted=n/a",
+            "duration_s={:.3f} db_phase_duration_s={:.3f} maintenance_set_deleted=n/a",
             rows_scanned,
-            rows_skipped_status_mismatch,
+            0,
             duration,
+            db_phase_duration_s,
         )
         return DsrCacheSweeperResult(
             rows_scanned=rows_scanned,
-            rows_skipped_status_mismatch=rows_skipped_status_mismatch,
+            rows_skipped_status_mismatch=0,
             eligible_dsr_count=0,
             redis_keys_scanned=0,
             dsr_ids_seen_in_redis=0,
@@ -314,19 +377,18 @@ def run_dsr_cache_sweeper(
             maintenance_set_deleted=True,
         )
 
-    manager = get_redis_cache_manager()
-    redis = manager._redis
-    set_key = tc.maintenance_set_key
-    ttl = int(tc.maintenance_set_ttl_seconds)
-    scan_count = int(tc.redis_scan_count)
-    del_batch = max(1, int(tc.redis_delete_batch_size))
-
+    scan_phase_duration_s = 0.0
     sweep_started = time.perf_counter()
     try:
-        # Fresh staging set for this run
-        redis.delete(set_key)
-        redis.sadd_members_chunked(set_key, eligible_ids)
-        redis.expire(set_key, ttl)
+        logger.info(
+            "DSR cache sweeper starting Redis SCAN set_key={} eligible_dsr_count={} "
+            "staging_duration_s={:.3f} ttl_seconds={} redis_scan_count={}",
+            set_key,
+            eligible_dsr_count,
+            staging_duration_s,
+            ttl,
+            scan_count,
+        )
 
         pending_delete: list[str] = []
 
@@ -342,7 +404,11 @@ def run_dsr_cache_sweeper(
                 redis_delete_errors += err
                 redis_errors += err
 
+        scan_started = time.perf_counter()
+        scan_chunk_index = 0
         for key_batch in redis.iter_scan_batches(count=scan_count):
+            chunk_started = time.perf_counter()
+            keys_in_chunk = len(key_batch)
             for raw_key in key_batch:
                 redis_keys_scanned += 1
                 key_str = decode_dsr_redis_key(raw_key)
@@ -366,14 +432,32 @@ def run_dsr_cache_sweeper(
                     if len(pending_delete) >= del_batch:
                         flush_pending()
 
-            logger.debug(
-                "DSR cache sweeper SCAN chunk redis_keys_scanned={} "
-                "pending_delete_queue={}",
+            chunk_duration_s = time.perf_counter() - chunk_started
+            logger.info(
+                "DSR cache sweeper Redis SCAN chunk chunk_index={} keys_in_chunk={} "
+                "chunk_duration_s={:.3f} cumulative_keys_scanned={} pending_delete_queue={} "
+                "redis_keys_deleted_so_far={}",
+                scan_chunk_index,
+                keys_in_chunk,
+                chunk_duration_s,
                 redis_keys_scanned,
                 len(pending_delete),
+                redis_keys_deleted,
             )
+            scan_chunk_index += 1
 
         flush_pending()
+        scan_phase_duration_s = time.perf_counter() - scan_started
+        logger.info(
+            "DSR cache sweeper Redis SCAN phase complete scan_chunks={} "
+            "redis_keys_scanned={} redis_keys_deleted={} dsr_ids_seen_in_redis={} "
+            "scan_phase_duration_s={:.3f}",
+            scan_chunk_index,
+            redis_keys_scanned,
+            redis_keys_deleted,
+            len(dsr_ids_touched),
+            scan_phase_duration_s,
+        )
 
         redis.delete(set_key)
         maintenance_set_deleted = True
@@ -391,10 +475,12 @@ def run_dsr_cache_sweeper(
         "DSR cache sweeper finished eligible_dsr_count={} rows_scanned={} "
         "skipped_status_mismatch={} redis_keys_scanned={} dsr_ids_seen_in_redis={} "
         "redis_keys_deleted={} redis_delete_errors={} redis_errors={} "
-        "duration_s={:.3f} sweep_s={:.3f} maintenance_set_deleted={}",
+        "duration_s={:.3f} sweep_s={:.3f} db_phase_duration_s={:.3f} "
+        "redis_staging_duration_s={:.3f} redis_scan_phase_duration_s={:.3f} "
+        "maintenance_set_deleted={}",
         eligible_dsr_count,
         rows_scanned,
-        rows_skipped_status_mismatch,
+        0,
         redis_keys_scanned,
         len(dsr_ids_touched),
         redis_keys_deleted,
@@ -402,12 +488,15 @@ def run_dsr_cache_sweeper(
         redis_errors,
         total_duration,
         sweep_duration,
+        db_phase_duration_s,
+        staging_duration_s,
+        scan_phase_duration_s,
         maintenance_set_deleted,
     )
 
     return DsrCacheSweeperResult(
         rows_scanned=rows_scanned,
-        rows_skipped_status_mismatch=rows_skipped_status_mismatch,
+        rows_skipped_status_mismatch=0,
         eligible_dsr_count=eligible_dsr_count,
         redis_keys_scanned=redis_keys_scanned,
         dsr_ids_seen_in_redis=len(dsr_ids_touched),

--- a/tests/service/privacy_request/test_dsr_cache_sweeper_functional.py
+++ b/tests/service/privacy_request/test_dsr_cache_sweeper_functional.py
@@ -32,7 +32,7 @@ def _patch_dsr_cache_sweeper_execution(
     nested_updates: dict[str, Any] = {
         "batch_sleep_seconds": 0.0,
         "staleness_minutes": 30,
-        "batch_size": 50,
+        "batch_size": 1000,
     }
     nested_updates.update(overrides)
     tc = CONFIG.execution.dsr_cache_sweeper.model_copy(update=nested_updates)


### PR DESCRIPTION
Adds more liveness logs to the cache sweeper, changes default DB query page size to 1000 and reduces between page sleeps to 50msec default; also removes per-record eligibility check. 