### PR TITLE
ENG-3178: Migrate vendor / configure-consent forms to antd

### DIFF
--- a/changelog/8156-vendor-forms-antd-migration.yaml
+++ b/changelog/8156-vendor-forms-antd-migration.yaml
@@ -1,0 +1,4 @@
+type: Changed
+description: Migrated the configure-consent "Add a vendor" form from Formik to antd
+pr: 8156
+labels: []

--- a/clients/admin-ui/cypress/e2e/consent-configuration.cy.ts
+++ b/clients/admin-ui/cypress/e2e/consent-configuration.cy.ts
@@ -61,7 +61,7 @@ describe("Consent configuration", () => {
     });
   });
 
-  describe.skip("adding a vendor", () => {
+  describe("adding a vendor", () => {
     beforeEach(() => {
       stubSystemCrud();
       stubTaxonomyEntities();
@@ -99,12 +99,9 @@ describe("Consent configuration", () => {
       it("can add a vendor from the modal without the dictionary", () => {
         cy.getByTestId("add-vendor-btn").click();
         cy.getByTestId("input-name").type("test vendor");
-        cy.selectOption(
-          "input-privacy_declarations.0.consent_use",
-          "analytics",
-        );
-        cy.getByTestId("input-privacy_declarations.0.cookieNames")
-          .find(".custom-creatable-select__input-container")
+        cy.getByTestId("select-consent-use-0").antSelect("Analytics");
+        cy.getByTestId("select-cookies-0")
+          .find("input")
           .type("test{enter}cookie{enter}");
         cy.getByTestId("save-btn").click();
         cy.wait("@postSystem").then((interception) => {
@@ -138,24 +135,15 @@ describe("Consent configuration", () => {
         cy.getByTestId("add-vendor-btn").click();
         cy.getByTestId("add-data-use-btn").should("be.disabled");
         cy.getByTestId("input-name").type("test vendor");
-        cy.selectOption(
-          "input-privacy_declarations.0.consent_use",
-          "analytics",
-        );
-        cy.getByTestId("input-privacy_declarations.0.cookieNames")
-          .find(".custom-creatable-select__input-container")
-          .type("one{enter}");
+        cy.getByTestId("select-consent-use-0").antSelect("Analytics");
+        cy.getByTestId("select-cookies-0").find("input").type("one{enter}");
+        // Close the tags dropdown so it doesn't overlap the add-data-use button.
+        cy.getByTestId("select-cookies-0").find("input").blur();
 
         // Add another use
         cy.getByTestId("add-data-use-btn").click();
-        // TODO: this select fails when trying to select "essential" or "functional", but accepts "analytics" or "marketing"
-        cy.selectOption(
-          "input-privacy_declarations.1.consent_use",
-          "marketing",
-        );
-        cy.getByTestId("input-privacy_declarations.1.cookieNames")
-          .find(".custom-creatable-select__input-container")
-          .type("two{enter}");
+        cy.getByTestId("select-consent-use-1").antSelect("Marketing");
+        cy.getByTestId("select-cookies-1").find("input").type("two{enter}");
         cy.getByTestId("save-btn").click();
         cy.wait("@postSystem").then((interception) => {
           const { body } = interception.request;
@@ -232,29 +220,20 @@ describe("Consent configuration", () => {
       it("can add a vendor with dictionary suggestions from the modal", () => {
         cy.visit(ADD_MULTIPLE_VENDORS_ROUTE);
         cy.getByTestId("add-vendor-btn").click();
-        cy.getByTestId("input-name").type("Aniview LTD{enter}");
+        cy.wait("@getDictionaryEntries");
+        cy.getByTestId("vendor-name-select").antSelect("Aniview LTD");
         cy.wait("@getDictionaryDeclarations");
-        cy.getByTestId(
-          "controlled-select-privacy_declarations.0.consent_use",
-        ).contains("Marketing");
-        cy.getByTestId(
-          "controlled-select-privacy_declarations.0.data_use",
-        ).contains("Profiling for Advertising");
+        cy.getByTestId("select-consent-use-0").contains("Marketing");
+        cy.getByTestId("select-data-use-0").contains("Profiling for Advertising");
         ["av_*", "aniC", "2_C_*"].forEach((cookieName) => {
-          cy.getByTestId("input-privacy_declarations.0.cookieNames").contains(
-            cookieName,
-          );
+          cy.getByTestId("select-cookies-0").contains(cookieName);
         });
 
         // Also check one that shouldn't have any cookies
-        cy.getByTestId(
-          "controlled-select-privacy_declarations.1.data_use",
-        ).contains("Analytics for Insights");
-        cy.getByTestId("input-privacy_declarations.1.cookieNames").contains(
-          "Select...",
-        );
+        cy.getByTestId("select-data-use-1").contains("Analytics for Insights");
+        cy.getByTestId("select-cookies-1").contains("Select...");
         // There should be 13 declarations (but start from 0, so 12)
-        cy.getByTestId("input-privacy_declarations.12.cookieNames");
+        cy.getByTestId("select-cookies-12");
         cy.getByTestId("save-btn").click();
         cy.wait("@postSystem").then((interception) => {
           const { body } = interception.request;
@@ -681,14 +660,11 @@ describe("Consent configuration", () => {
       it("can create a vendor that is not in the dictionary", () => {
         cy.visit(ADD_MULTIPLE_VENDORS_ROUTE);
         cy.getByTestId("add-vendor-btn").click();
-        cy.getByTestId("input-name").type("custom vendor{enter}");
-        cy.selectOption(
-          "input-privacy_declarations.0.consent_use",
-          "analytics",
-        );
-        cy.getByTestId("input-privacy_declarations.0.cookieNames")
-          .find(".custom-creatable-select__input-container")
-          .type("test{enter}");
+        cy.getByTestId("vendor-name-select")
+          .find("input")
+          .type("custom vendor{enter}");
+        cy.getByTestId("select-consent-use-0").antSelect("Analytics");
+        cy.getByTestId("select-cookies-0").find("input").type("test{enter}");
         cy.getByTestId("save-btn").click();
         cy.wait("@postSystem").then((interception) => {
           const { body } = interception.request;

--- a/clients/admin-ui/cypress/e2e/consent-configuration.cy.ts
+++ b/clients/admin-ui/cypress/e2e/consent-configuration.cy.ts
@@ -224,7 +224,9 @@ describe("Consent configuration", () => {
         cy.getByTestId("vendor-name-select").antSelect("Aniview LTD");
         cy.wait("@getDictionaryDeclarations");
         cy.getByTestId("select-consent-use-0").contains("Marketing");
-        cy.getByTestId("select-data-use-0").contains("Profiling for Advertising");
+        cy.getByTestId("select-data-use-0").contains(
+          "Profiling for Advertising",
+        );
         ["av_*", "aniC", "2_C_*"].forEach((cookieName) => {
           cy.getByTestId("select-cookies-0").contains(cookieName);
         });

--- a/clients/admin-ui/src/features/configure-consent/AddVendor.tsx
+++ b/clients/admin-ui/src/features/configure-consent/AddVendor.tsx
@@ -1,19 +1,17 @@
 import {
   Button,
   ButtonProps,
-  ChakraBox as Box,
-  ChakraVStack as VStack,
+  Flex,
+  Form,
+  FormRule,
+  Input,
   Modal,
-  useChakraDisclosure as useDisclosure,
   useMessage,
 } from "fidesui";
-import { Form, Formik, FormikHelpers } from "formik";
-import { useMemo, useRef } from "react";
-import * as Yup from "yup";
+import { useEffect, useMemo, useState } from "react";
 
 import { useAppDispatch, useAppSelector } from "~/app/hooks";
 import { useFeatures } from "~/features/common/features";
-import { CustomTextInput } from "~/features/common/form/inputs";
 import { formatKey } from "~/features/datastore-connections/system_portal_config/helpers";
 import {
   selectAllDictEntries,
@@ -31,7 +29,7 @@ import {
   setSuggestions,
 } from "~/features/system/dictionary-form/dict-suggestion.slice";
 import GVLNotice from "~/features/system/GVLNotice";
-import VendorSelector from "~/features/system/VendorSelector";
+import VendorSelectorAnt from "~/features/system/VendorSelectorAnt";
 import { System } from "~/types/api";
 
 import {
@@ -59,35 +57,11 @@ const AddVendor = ({
   buttonProps?: ButtonProps;
 }) => {
   const message = useMessage();
-  const { isOpen, onOpen, onClose } = useDisclosure();
-
+  const [isOpen, setIsOpen] = useState(false);
+  const [form] = Form.useForm<FormValues>();
   const dispatch = useAppDispatch();
 
   const [getSystemQueryTrigger] = useLazyGetSystemsQuery();
-
-  const ValidationSchema = useMemo(
-    () =>
-      Yup.object().shape({
-        name: Yup.string()
-          .required()
-          .label("Vendor name")
-          .test("is-unique", "", async (value, context) => {
-            const { data } = await getSystemQueryTrigger({
-              page: 1,
-              size: 10,
-              search: value,
-            });
-            const similarSystemNames = data?.items || [];
-            if (similarSystemNames.some((s) => s.name === value)) {
-              return context.createError({
-                message: `You already have a vendor called "${value}". Please specify a unique name for this vendor.`,
-              });
-            }
-            return true;
-          }),
-      }),
-    [getSystemQueryTrigger],
-  );
 
   // Subscribe and get dictionary values
   const { tcf, dictionaryService } = useFeatures();
@@ -100,27 +74,73 @@ const AddVendor = ({
   const [createSystemMutationTrigger] = useCreateSystemMutation();
   const suggestionsState = useAppSelector(selectSuggestions);
 
+  // Track form state for the Save button enable/disable.
+  const watchedValues = Form.useWatch([], form);
+  const [submittable, setSubmittable] = useState(false);
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    form
+      .validateFields({ validateOnly: true })
+      .then(() => setSubmittable(true))
+      .catch(() => setSubmittable(false));
+  }, [form, watchedValues, isOpen]);
+
+  const watchedVendorId = Form.useWatch<string | undefined>("vendor_id", form);
+  const dictEntry = useAppSelector(selectDictEntry(watchedVendorId || ""));
+
+  const nameRules: FormRule[] = useMemo(
+    () => [
+      { required: true, message: "Vendor name is a required field" },
+      {
+        async validator(_, value: string) {
+          if (!value) {
+            return;
+          }
+          const { data } = await getSystemQueryTrigger({
+            page: 1,
+            size: 10,
+            search: value,
+          });
+          const similarSystemNames = data?.items || [];
+          if (similarSystemNames.some((s) => s.name === value)) {
+            throw new Error(
+              `You already have a vendor called "${value}". Please specify a unique name for this vendor.`,
+            );
+          }
+        },
+      },
+    ],
+    [getSystemQueryTrigger],
+  );
+
   const handleCloseModal = () => {
-    onClose();
+    setIsOpen(false);
+    form.resetFields();
     dispatch(setSuggestions("initial"));
     dispatch(setLockedForGVL(false));
   };
 
-  const formRef = useRef(null);
-  const selectedVendorId = formRef.current
-    ? (formRef.current as { values: FormValues }).values.vendor_id
-    : undefined;
-  const dictEntry = useAppSelector(selectDictEntry(selectedVendorId || ""));
-
-  const handleSubmit = async (
-    values: FormValues,
-    helpers: FormikHelpers<FormValues>,
-  ) => {
+  const handleSubmit = async () => {
+    // Read the full form store, not just registered Form.Item fields. Each
+    // privacy declaration carries `name` and `data_categories` that aren't
+    // bound to a visible Form.Item but are required by the backend.
+    const values = form.getFieldsValue(true) as FormValues;
     const transformedDeclarations = values.privacy_declarations
       .filter((dec) => dec.consent_use !== EMPTY_DECLARATION.consent_use)
       .flatMap((dec) => {
+        // Convert the UI's cookieNames (string[]) into the API's cookies
+        // shape. If the dictionary populated full cookie objects, keep the
+        // match so domain/path survive; for user-typed names, default
+        // `path: "/"`.
         // eslint-disable-next-line @typescript-eslint/naming-convention
-        const { consent_use, ...rest } = dec;
+        const { consent_use, cookieNames, cookies, ...rest } = dec;
+        const cookiesByName = new Map((cookies ?? []).map((c) => [c.name, c]));
+        const transformedCookies = (cookieNames ?? []).map(
+          (name) => cookiesByName.get(name) ?? { name, path: "/" },
+        );
+        const base = { ...rest, cookies: transformedCookies };
 
         // for "marketing", we create two data uses on the backend
         if (dec.consent_use === "marketing" && !dec.data_use) {
@@ -128,12 +148,12 @@ const AddVendor = ({
             "marketing.advertising.first_party.targeted",
             "marketing.advertising.third_party.targeted",
           ].map((dataUse) => ({
-            ...rest,
+            ...base,
             data_use: dataUse,
           }));
         }
         return {
-          ...rest,
+          ...base,
           data_use: dec.data_use ? dec.data_use : dec.consent_use!,
         };
       });
@@ -153,7 +173,6 @@ const AddVendor = ({
       return;
     }
     message.success("Vendor successfully created!");
-    helpers.resetForm();
     handleCloseModal();
   };
 
@@ -178,7 +197,7 @@ const AddVendor = ({
     if (onButtonClick) {
       onButtonClick();
     } else {
-      onOpen();
+      setIsOpen(true);
     }
   };
 
@@ -191,75 +210,67 @@ const AddVendor = ({
       >
         {buttonLabel}
       </Button>
-      <Formik
-        initialValues={defaultInitialValues}
-        enableReinitialize
-        onSubmit={handleSubmit}
-        validationSchema={ValidationSchema}
-        innerRef={formRef}
+      <Modal
+        open={isOpen}
+        onCancel={handleCloseModal}
+        centered
+        destroyOnHidden
+        title="Add a vendor"
+        footer={
+          <Flex justify="space-between">
+            <Button onClick={handleCloseModal}>Cancel</Button>
+            <Button
+              type="primary"
+              onClick={() => form.submit()}
+              disabled={isLoading || !submittable}
+              loading={isLoading}
+              data-testid="save-btn"
+            >
+              Save vendor
+            </Button>
+          </Flex>
+        }
       >
-        {({ dirty, isValid, resetForm }) => (
-          <Modal
-            open={isOpen}
-            onCancel={handleCloseModal}
-            centered
-            destroyOnHidden
-            title="Add a vendor"
-            footer={null}
+        <div data-testid="add-vendor-modal-content">
+          {lockedForGVL ? <GVLNotice /> : null}
+          <Form<FormValues>
+            form={form}
+            initialValues={defaultInitialValues}
+            layout="vertical"
+            onFinish={handleSubmit}
           >
-            <Box data-testid="add-vendor-modal-content" my={4}>
-              {lockedForGVL ? <GVLNotice /> : null}
-              <Form>
-                <VStack alignItems="start" spacing={6}>
-                  {dictionaryService ? (
-                    <VendorSelector
-                      label="Vendor name"
-                      options={dictionaryOptions}
-                      isLoading={isLoading}
-                      onVendorSelected={handleVendorSelected}
-                      isCreate
-                      lockedForGVL={lockedForGVL}
-                    />
-                  ) : (
-                    <CustomTextInput
-                      id="name"
-                      name="name"
-                      isRequired
-                      label="Vendor name"
-                      tooltip='Give the system a unique, and relevant name for reporting purposes. e.g. "Email Data Warehouse"'
-                      variant="stacked"
-                    />
-                  )}
-                  <DataUsesForm
-                    showSuggestions={suggestionsState === "showing"}
-                    isCreate
-                    disabled={lockedForGVL}
-                  />
-                  <div className="flex w-full justify-between">
-                    <Button
-                      onClick={() => {
-                        handleCloseModal();
-                        resetForm();
-                      }}
-                    >
-                      Cancel
-                    </Button>
-                    <Button
-                      type="primary"
-                      htmlType="submit"
-                      disabled={isLoading || !dirty || !isValid}
-                      loading={isLoading}
-                      data-testid="save-btn"
-                    >
-                      Save vendor
-                    </Button>
-                  </div>
-                </VStack>
-              </Form>
-            </Box>
-          </Modal>
-        )}
-      </Formik>
+            <Flex vertical gap="middle" align="stretch">
+              {dictionaryService ? (
+                <VendorSelectorAnt
+                  label="Vendor name"
+                  options={dictionaryOptions}
+                  isLoading={isLoading}
+                  onVendorSelected={handleVendorSelected}
+                  isCreate
+                  lockedForGVL={lockedForGVL}
+                  nameRules={nameRules}
+                />
+              ) : (
+                <Form.Item
+                  name="name"
+                  label="Vendor name"
+                  required
+                  tooltip='Give the system a unique, and relevant name for reporting purposes. e.g. "Email Data Warehouse"'
+                  rules={nameRules}
+                  className="mb-0"
+                >
+                  <Input data-testid="input-name" />
+                </Form.Item>
+              )}
+              <DataUsesForm
+                showSuggestions={suggestionsState === "showing"}
+                isCreate
+                disabled={lockedForGVL}
+              />
+            </Flex>
+          </Form>
+        </div>
+      </Modal>
     </>
   );
 };

--- a/clients/admin-ui/src/features/configure-consent/DataUsesForm.tsx
+++ b/clients/admin-ui/src/features/configure-consent/DataUsesForm.tsx
@@ -1,5 +1,4 @@
-import { Button, ChakraVStack as VStack, Spin } from "fidesui";
-import { FieldArray, useFormikContext } from "formik";
+import { Button, Card, Flex, Form, Icons, Select, Spin } from "fidesui";
 import { useEffect } from "react";
 
 import { useAppSelector } from "~/app/hooks";
@@ -14,7 +13,6 @@ import {
 } from "~/features/plus/plus.slice";
 import { transformDictDataUseToDeclaration } from "~/features/system/dictionary-form/helpers";
 
-import { ControlledSelect } from "../common/form/ControlledSelect";
 import {
   CONSENT_USE_OPTIONS,
   EMPTY_DECLARATION,
@@ -22,74 +20,94 @@ import {
   MinimalPrivacyDeclaration,
 } from "./constants";
 
-const DataUseBlock = ({
-  index,
-  disabled,
-}: {
+interface DataUseBlockProps {
   index: number;
   disabled?: boolean;
-}) => {
+}
+
+const DataUseBlock = ({ index, disabled }: DataUseBlockProps) => {
   useGetAllDataUsesQuery();
   const allDataUseOptions = useAppSelector(selectDataUseOptions);
 
-  const { values } = useFormikContext<FormValues>();
+  const consentUse = Form.useWatch<string | undefined>([
+    "privacy_declarations",
+    index,
+    "consent_use",
+  ]);
 
   const detailedDataUseOptions = allDataUseOptions.filter(
-    (o) =>
-      o.value.split(".")[0] === values.privacy_declarations[index].consent_use,
+    (o) => o.value.split(".")[0] === consentUse,
   );
 
   return (
-    <VStack
-      width="100%"
-      borderRadius="4px"
-      border="1px solid"
-      borderColor="gray.200"
-      spacing={4}
-      p={4}
-    >
-      <ControlledSelect
-        label="Consent category"
-        tooltip="What is the system using the data for. For example, is it for third party advertising or perhaps simply providing system operations."
-        name={`privacy_declarations.${index}.consent_use`}
-        options={CONSENT_USE_OPTIONS}
-        layout="stacked"
-        isRequired
-        disabled={disabled}
-      />
-      <ControlledSelect
-        allowClear
-        label="Detailed consent category (optional)"
-        tooltip="Select a more specific consent category"
-        name={`privacy_declarations.${index}.data_use`}
-        options={detailedDataUseOptions}
-        layout="stacked"
-        disabled={!values.privacy_declarations[index].consent_use || disabled}
-      />
-      <ControlledSelect
-        mode="tags"
-        label="Cookie names"
-        name={`privacy_declarations.${index}.cookieNames`}
-        options={[]}
-        layout="stacked"
-        disabled={disabled}
-        className="w-full"
-      />
-    </VStack>
+    <Card size="small">
+      <Flex vertical gap="middle">
+        <Form.Item
+          label="Consent category"
+          tooltip="What is the system using the data for. For example, is it for third party advertising or perhaps simply providing system operations."
+          name={[index, "consent_use"]}
+          required
+          rules={[{ required: true, message: "Consent category is required" }]}
+          className="mb-0"
+        >
+          <Select
+            options={CONSENT_USE_OPTIONS}
+            disabled={disabled}
+            aria-label="Consent category"
+            data-testid={`select-consent-use-${index}`}
+          />
+        </Form.Item>
+        <Form.Item
+          label="Detailed consent category (optional)"
+          tooltip="Select a more specific consent category"
+          name={[index, "data_use"]}
+          className="mb-0"
+        >
+          <Select
+            allowClear
+            options={detailedDataUseOptions}
+            disabled={!consentUse || disabled}
+            aria-label="Detailed consent category"
+            data-testid={`select-data-use-${index}`}
+          />
+        </Form.Item>
+        <Form.Item
+          label="Cookie names"
+          name={[index, "cookieNames"]}
+          className="mb-0"
+        >
+          <Select
+            mode="tags"
+            options={[]}
+            disabled={disabled}
+            placeholder="Select..."
+            className="w-full"
+            aria-label="Cookie names"
+            data-testid={`select-cookies-${index}`}
+          />
+        </Form.Item>
+      </Flex>
+    </Card>
   );
 };
+
+interface DataUsesFormProps {
+  showSuggestions: boolean;
+  isCreate: boolean;
+  disabled?: boolean;
+}
 
 const DataUsesForm = ({
   showSuggestions,
   isCreate,
   disabled,
-}: {
-  showSuggestions: boolean;
-  isCreate: boolean;
-  disabled?: boolean;
-}) => {
-  const { values, setFieldValue } = useFormikContext<FormValues>();
-  const { vendor_id: vendorId } = values;
+}: DataUsesFormProps) => {
+  const form = Form.useFormInstance<FormValues>();
+  const vendorId = Form.useWatch<string | undefined>("vendor_id", form);
+  const privacyDeclarations = Form.useWatch<
+    MinimalPrivacyDeclaration[] | undefined
+  >("privacy_declarations", form);
+
   const { isLoading } = useGetDictionaryDataUsesQuery(
     { vendor_id: vendorId as string },
     { skip: !showSuggestions || vendorId === null || vendorId === undefined },
@@ -97,62 +115,65 @@ const DataUsesForm = ({
   const dictDataUses = useAppSelector(selectDictDataUses(vendorId || ""));
 
   useEffect(() => {
-    if (showSuggestions && values.vendor_id && dictDataUses?.length) {
+    if (showSuggestions && vendorId && dictDataUses?.length) {
       const declarations: MinimalPrivacyDeclaration[] = dictDataUses
         .filter((du) => dataUseIsConsentUse(du.data_use))
-        .map((d) => transformDictDataUseToDeclaration(d))
-        .map((d) => ({
-          name: d.name ?? "",
-          consent_use: d.data_use.split(".")[0],
-          data_use: d.data_use,
-          data_categories: d.data_categories,
-        }));
-      setFieldValue("privacy_declarations", declarations);
+        .map((d) => {
+          const transformed = transformDictDataUseToDeclaration(d);
+          const cookies = (d.cookies ?? []).map((c) => ({
+            name: c.name,
+            domain: c.domain,
+            path: c.path ?? null,
+          }));
+          return {
+            name: transformed.name ?? "",
+            consent_use: transformed.data_use.split(".")[0],
+            data_use: transformed.data_use,
+            data_categories: transformed.data_categories,
+            cookies,
+            cookieNames: cookies.map((c) => c.name),
+          };
+        });
+      form.setFieldValue("privacy_declarations", declarations);
     } else if (isCreate) {
-      setFieldValue("privacy_declarations", [EMPTY_DECLARATION]);
+      form.setFieldValue("privacy_declarations", [EMPTY_DECLARATION]);
     }
-  }, [
-    showSuggestions,
-    isCreate,
-    values.vendor_id,
-    dictDataUses,
-    setFieldValue,
-  ]);
+  }, [showSuggestions, isCreate, vendorId, dictDataUses, form]);
 
+  const lastDeclaration = privacyDeclarations?.[privacyDeclarations.length - 1];
   const lastDataUseIsEmpty =
-    values.privacy_declarations[values.privacy_declarations.length - 1]
-      ?.data_use === EMPTY_DECLARATION.data_use &&
-    values.privacy_declarations[values.privacy_declarations.length - 1]
-      ?.consent_use === EMPTY_DECLARATION.consent_use;
+    lastDeclaration?.data_use === EMPTY_DECLARATION.data_use &&
+    lastDeclaration?.consent_use === EMPTY_DECLARATION.consent_use;
 
   if (isLoading) {
     return <Spin size="small" />;
   }
 
   return (
-    <FieldArray
-      name="privacy_declarations"
-      render={(arrayHelpers) => (
-        <>
-          {values.privacy_declarations.map((declaration, idx) => (
+    <Form.List name="privacy_declarations">
+      {(fields, { add }) => (
+        <Flex vertical gap="middle" align="stretch">
+          {fields.map((field) => (
             <DataUseBlock
-              key={declaration.data_use || idx}
-              index={idx}
+              key={field.key}
+              index={field.name}
               disabled={disabled}
             />
           ))}
-          <Button
-            onClick={() => arrayHelpers.push(EMPTY_DECLARATION)}
-            size="small"
-            type="text"
-            disabled={disabled || lastDataUseIsEmpty}
-            data-testid="add-data-use-btn"
-          >
-            Add data use +
-          </Button>
-        </>
+          <Flex justify="flex-start">
+            <Button
+              onClick={() => add(EMPTY_DECLARATION)}
+              size="small"
+              icon={<Icons.Add />}
+              disabled={disabled || lastDataUseIsEmpty}
+              data-testid="add-data-use-btn"
+            >
+              Add data use
+            </Button>
+          </Flex>
+        </Flex>
       )}
-    />
+    </Form.List>
   );
 };
 

--- a/clients/admin-ui/src/features/configure-consent/constants.ts
+++ b/clients/admin-ui/src/features/configure-consent/constants.ts
@@ -1,5 +1,11 @@
 import { PrivacyDeclaration } from "~/types/api";
 
+export interface MinimalCookie {
+  name: string;
+  path?: string | null;
+  domain?: string | null;
+}
+
 export interface MinimalPrivacyDeclaration {
   name: string;
   consent_use?: string;
@@ -11,6 +17,8 @@ export interface MinimalPrivacyDeclaration {
    * object because the dictionary could potentially give us more than just the names
    * and we want a place to keep that information.
    */
+  cookieNames?: string[];
+  cookies?: MinimalCookie[];
 }
 
 export interface FormValues {
@@ -25,6 +33,8 @@ export const EMPTY_DECLARATION: MinimalPrivacyDeclaration = {
   data_use: "",
   // TODO(fides#4059): data categories will eventually be optional
   data_categories: ["user"],
+  cookieNames: [],
+  cookies: [],
 };
 
 export const CONSENT_USE_OPTIONS = [

--- a/clients/admin-ui/src/features/system/VendorSelectorAnt.tsx
+++ b/clients/admin-ui/src/features/system/VendorSelectorAnt.tsx
@@ -1,0 +1,289 @@
+import {
+  Button,
+  CompassIcon,
+  Dropdown,
+  Flex,
+  Form,
+  FormRule,
+  Icons,
+  Input,
+  MenuProps,
+  Select,
+} from "fidesui";
+import { KeyboardEvent, useEffect, useMemo, useState } from "react";
+
+import { useAppSelector } from "~/app/hooks";
+import { AutosuggestSuffix } from "~/features/common/AutosuggestSuffix";
+import { DictOption as VendorOption } from "~/features/plus/plus.slice";
+import { selectSuggestions } from "~/features/system/dictionary-form/dict-suggestion.slice";
+
+const NEW_SYSTEM_PREFIX = "Create new system";
+
+const CompassButton = ({
+  active,
+  disabled,
+  onRefreshSuggestions,
+}: {
+  active: boolean;
+  disabled: boolean;
+  onRefreshSuggestions: () => void;
+}) => {
+  const items: MenuProps["items"] = useMemo(
+    () => [
+      {
+        key: "reset",
+        label: "Reset to Compass defaults",
+        onClick: onRefreshSuggestions,
+      },
+    ],
+    [onRefreshSuggestions],
+  );
+
+  return (
+    <Dropdown menu={{ items }} disabled={disabled}>
+      <Button
+        icon={<CompassIcon />}
+        aria-label="Update information from Compass"
+        data-testid="refresh-suggestions-btn"
+        disabled={disabled}
+        type={active ? "primary" : undefined}
+      />
+    </Dropdown>
+  );
+};
+
+export interface VendorSelectorAntProps {
+  label: string;
+  isCreate: boolean;
+  lockedForGVL: boolean;
+  options: VendorOption[];
+  isLoading?: boolean;
+  onVendorSelected: (vendorId?: string | null) => void;
+  /**
+   * Validation rules applied to the `name` field (e.g. uniqueness check).
+   * Forwarded to the wrapped `Form.Item`.
+   */
+  nameRules?: FormRule[];
+}
+
+/**
+ * antd-Form-native vendor name typeahead. Drop-in inside any antd `Form`
+ * that exposes `name: string` and `vendor_id?: string` on its values.
+ *
+ * Forked from `VendorSelector.tsx`, which is still consumed by the
+ * Formik-based `AddNewSystemModal` and `SystemInformationForm`. When those
+ * migrate, swap their imports here and delete the Formik original.
+ */
+const VendorSelectorAnt = ({
+  label,
+  isCreate,
+  lockedForGVL,
+  options,
+  isLoading,
+  onVendorSelected,
+  nameRules,
+}: VendorSelectorAntProps) => {
+  const form = Form.useFormInstance();
+  const dictSuggestionsState = useAppSelector(selectSuggestions);
+  const name = Form.useWatch<string | undefined>("name", form);
+  const vendorId = Form.useWatch<string | undefined>("vendor_id", form);
+
+  const [isTypeahead, setIsTypeahead] = useState(true);
+  const [searchParam, setSearchParam] = useState<string>("");
+
+  const filterFunction = (searchText: string, option?: VendorOption) =>
+    !!option?.label.toLowerCase().startsWith(searchText.toLowerCase());
+
+  const suggestions = useMemo(
+    () => options.filter((o) => filterFunction(searchParam, o)),
+    [options, searchParam],
+  );
+
+  const optionsWithCustom = useMemo(() => {
+    if (isCreate && searchParam) {
+      return [
+        ...options,
+        {
+          label: `${NEW_SYSTEM_PREFIX} "${searchParam}"...`,
+          value: searchParam,
+        },
+      ];
+    }
+    return options;
+  }, [isCreate, options, searchParam]);
+
+  const hasVendorSuggestions = !!searchParam && suggestions.length > 0;
+  const nameFieldLockedForGVL = lockedForGVL && !isCreate;
+
+  useEffect(() => {
+    setIsTypeahead(!name && !vendorId);
+  }, [name, vendorId]);
+
+  const selectedOption = useMemo(() => {
+    const match = options.find((o) => o.value === name);
+    if (match) {
+      return match;
+    }
+    if (!name) {
+      return undefined;
+    }
+    return { label: name, value: name, description: "" } as VendorOption;
+  }, [options, name]);
+
+  const handleClear = () => {
+    setSearchParam("");
+    form.setFieldsValue({ name: "", vendor_id: undefined });
+    form.validateFields(["name"]).catch(() => {});
+    onVendorSelected(undefined);
+  };
+
+  const handleChange = (newValue: VendorOption | undefined) => {
+    if (!newValue) {
+      return;
+    }
+    const newVendorId = options.some((opt) => opt.value === newValue.value)
+      ? newValue.value
+      : undefined;
+    const newName = newValue.label.startsWith(NEW_SYSTEM_PREFIX)
+      ? newValue.value
+      : newValue.label;
+    form.setFieldsValue({ name: newName, vendor_id: newVendorId });
+    form.validateFields(["name"]).catch(() => {});
+    onVendorSelected(newVendorId);
+  };
+
+  // Accept typed value as the name on blur if nothing was picked.
+  const handleBlur = () => {
+    if (searchParam) {
+      form.setFieldValue("name", searchParam);
+    }
+    form.validateFields(["name"]).catch(() => {});
+  };
+
+  // Tab completes the autosuggest.
+  const handleTabPressed = (
+    event: KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) => {
+    if (suggestions.length > 0 && searchParam !== suggestions[0].label) {
+      event.preventDefault();
+      const [topSuggestion] = suggestions;
+      setSearchParam(topSuggestion.label);
+      form.setFieldsValue({
+        name: topSuggestion.label,
+        vendor_id: topSuggestion.value,
+      });
+      onVendorSelected(topSuggestion.value);
+    } else {
+      form.setFieldsValue({ name: searchParam, vendor_id: undefined });
+    }
+  };
+
+  // Standalone typeahead UI — bypasses Form.Item value injection (Select uses
+  // labelInValue, which is shaped { label, value } rather than a plain string).
+  // The hidden Form.Item below registers `name` so rules and validation still
+  // apply.
+  const typeaheadSelect = (
+    <Flex vertical align="stretch" gap="small" className="w-full">
+      <Form.Item
+        label={label}
+        tooltip="Enter the system name"
+        required
+        validateStatus={undefined}
+        htmlFor="vendorName"
+        className="mb-0"
+      >
+        <div className="relative">
+          <Select<VendorOption, VendorOption>
+            id="vendorName"
+            labelInValue
+            autoFocus
+            allowClear
+            options={optionsWithCustom}
+            loading={isLoading}
+            filterOption={(value, option) =>
+              filterFunction(value, option) ||
+              !!option?.label.startsWith(NEW_SYSTEM_PREFIX)
+            }
+            optionFilterProp="label"
+            value={selectedOption}
+            placeholder="Enter system name..."
+            aria-label="Select a system"
+            disabled={nameFieldLockedForGVL}
+            onChange={handleChange}
+            onSearch={setSearchParam}
+            onClear={handleClear}
+            onBlur={handleBlur}
+            onInputKeyDown={(e) => {
+              if (searchParam && e.key === "Tab") {
+                handleTabPressed(e);
+              }
+            }}
+            data-testid="vendor-name-select"
+          />
+          <AutosuggestSuffix
+            searchText={searchParam}
+            suggestion={suggestions.length ? suggestions[0].label : ""}
+          />
+        </div>
+      </Form.Item>
+    </Flex>
+  );
+
+  const textInput = (
+    <Form.Item
+      label="System name"
+      tooltip="Enter the system name"
+      required
+      htmlFor="vendorNameInput"
+      className="mb-0 w-full"
+    >
+      <Input
+        id="vendorNameInput"
+        value={name ?? ""}
+        onChange={(e) => form.setFieldValue("name", e.target.value)}
+        autoFocus
+        disabled={nameFieldLockedForGVL}
+        suffix={
+          !nameFieldLockedForGVL ? (
+            <Button
+              type="text"
+              size="small"
+              icon={<Icons.Close />}
+              onClick={handleClear}
+              aria-label="Clear vendor name"
+              data-testid="clear-btn"
+            />
+          ) : undefined
+        }
+      />
+    </Form.Item>
+  );
+
+  return (
+    <>
+      {/*
+        Always-mounted hidden fields so Form.useWatch stays reactive across
+        both the typeahead and text-input branches above. Without these, the
+        registered Form.Item for "name" would unmount when the user picks an
+        option and the UI flips from Select → Input, and "vendor_id" has no
+        visible Form.Item at all.
+      */}
+      <Form.Item name="name" rules={nameRules} noStyle>
+        <Input type="hidden" />
+      </Form.Item>
+      <Form.Item name="vendor_id" noStyle>
+        <Input type="hidden" />
+      </Form.Item>
+      <Flex align="flex-end" gap="small" className="w-full">
+        {isTypeahead ? typeaheadSelect : textInput}
+        <CompassButton
+          active={!!vendorId || hasVendorSuggestions}
+          disabled={!vendorId || dictSuggestionsState === "showing"}
+          onRefreshSuggestions={() => onVendorSelected(vendorId)}
+        />
+      </Flex>
+    </>
+  );
+};
+
+export default VendorSelectorAnt;


### PR DESCRIPTION
Ticket [ENG-3178]

### Description Of Changes

Replaces Formik + Chakra in the configure-consent "Add a vendor" modal with antd `Form`. The migration covers `AddVendor.tsx` and `DataUsesForm.tsx`, plus a forked `VendorSelectorAnt.tsx` placed next to the legacy `features/system/VendorSelector.tsx` — that legacy component is intentionally left in place because `AddNewSystemModal` and `SystemInformationForm` still consume it on Formik. A follow-up ticket will retire it when those two callers migrate.

Two behavior fixes ride along with the migration:

- **`cookieNames` → `cookies` payload transform** in `handleSubmit`. The backend expects each privacy declaration to ship `cookies: [{ name, path, domain? }]`, not the UI's `cookieNames: string[]`. This was a pre-existing bug (the Cypress spec for this flow was `describe.skip`-ed on `main` and failing). Dictionary-sourced cookies keep their domain/path; user-typed names default to `{ name, path: "/" }`.
- **Always-mounted hidden `Form.Item`s for `name` and `vendor_id`** in `VendorSelectorAnt`. Without them, `Form.useWatch` loses reactivity when the typeahead Select flips to the text-input branch (because the registered `Form.Item` for `name` unmounts, and `vendor_id` was never registered at all — so the dictionary auto-populate query never fires).

`cypress/e2e/consent-configuration.cy.ts` is un-skipped and re-targeted at the new DOM (8/8 passing), so the dictionary-off path is fully covered by CI — the manual steps below only walk the dictionary-on path that matches a standard local dev setup.

### Code Changes

* `clients/admin-ui/src/features/configure-consent/AddVendor.tsx` — `Formik` → antd `Form` (`useForm`, `onFinish`, async name-uniqueness rule, dirty/valid via `Form.useWatch` + `validateFields({ validateOnly: true })`). `ChakraVStack` / `ChakraBox` / `useChakraDisclosure` → `Flex` + `useState`. Cancel + Save moved into Modal `footer` prop. Added `cookieNames` → `cookies` payload transform.
* `clients/admin-ui/src/features/configure-consent/DataUsesForm.tsx` — `FieldArray` → `Form.List`, `ControlledSelect` → `Form.Item` + antd `Select`, `useFormikContext` → `Form.useFormInstance` + `Form.useWatch`. Each data-use block is now wrapped in an antd `Card` (theme-token border). Dictionary auto-populate carries `cookies` + `cookieNames` onto each declaration.
* `clients/admin-ui/src/features/configure-consent/constants.ts` — added `cookieNames?: string[]` and `cookies?: MinimalCookie[]` to `MinimalPrivacyDeclaration`; new local `MinimalCookie` type.
* `clients/admin-ui/src/features/system/VendorSelectorAnt.tsx` — **new** antd-Form-native fork of `VendorSelector.tsx`. Same external prop signature (`label`, `isCreate`, `lockedForGVL`, `options`, `isLoading`, `onVendorSelected`) plus optional `nameRules`. Always-mounted hidden `Form.Item`s for `name` + `vendor_id` keep `Form.useWatch` reactive across the typeahead → text-input UI flip.
* `clients/admin-ui/src/features/system/VendorSelector.tsx` — **unchanged**. Still consumed by `AddNewSystemModal.tsx` and `SystemInformationForm.tsx` (both still Formik).
* `clients/admin-ui/cypress/e2e/consent-configuration.cy.ts` — un-skipped `describe("adding a vendor", …)`; swapped legacy selectors (`selectOption`, `controlled-select-…`, `input-privacy_declarations.N.…`) for antd equivalents (`antSelect` helper, `select-consent-use-N` / `select-data-use-N` / `select-cookies-N`, `vendor-name-select`); cookie typing through `find("input").type("…{enter}")`.

### Steps to Confirm

1. Visit `/consent/configure/add-vendors` and click **Add custom vendor**.
2. **Dictionary typeahead.** Start typing a known vendor name (e.g. *Aniview LTD*) in the **Vendor name** field and pick the dictionary suggestion. The data-use blocks below should auto-populate with that vendor's data uses, and each block's **Cookie names** should already be filled in with tags from the dictionary.
3. **Custom (off-dictionary) entry.** Open the modal again, type a name that isn't in the dictionary, and pick the *Create new system "…"* option. In the data-use block, pick a **Consent category** (e.g. *Analytics*) and type a couple of cookie names into **Cookie names** (each Enter creates a tag). Click **Save vendor**. In Network → look at the `POST /api/v1/system` request body: each `privacy_declarations` entry should have a `cookies: [{ name, path: "/" }]` array (not `cookieNames`).
4. **Marketing expansion.** Add another vendor where the only data-use block has **Consent category** set to *Marketing* and **Detailed consent category** left empty. Save. The `POST` body's `privacy_declarations` should contain **two** entries instead of one: one with `data_use: "marketing.advertising.first_party.targeted"` and one with `data_use: "marketing.advertising.third_party.targeted"`.
5. **Add data use button.** In a fresh modal, confirm the **Add data use** button is disabled before any consent category is picked. Pick *Analytics*, the button enables; click it — a new block appears. **Cancel** dismisses the modal and clears state for the next open.

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [x] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required

---

**Follow-ups not in this PR (file as separate tickets):**

- Migrate `AddNewSystemModal.tsx` and `SystemInformationForm.tsx` off Formik, then retire the legacy `features/system/VendorSelector.tsx`.
- Replace the shared `CustomTextInput` wrapper (15+ consumers) with `Form.Item` + antd `Input`.

[ENG-3178]: https://ethyca.atlassian.net/browse/ENG-3178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ