### PR TITLE
Build dependencies automatically when running turbo run dev

### DIFF
--- a/changelog/8157-turbo-dev-build-fides-js.yaml
+++ b/changelog/8157-turbo-dev-build-fides-js.yaml
@@ -1,0 +1,4 @@
+type: Developer Experience
+description: Ensured fides-js builds before admin-ui and privacy-center dev servers start under turbo
+pr: 8157
+labels: []

--- a/clients/turbo.json
+++ b/clients/turbo.json
@@ -15,6 +15,7 @@
       "cache": false
     },
     "dev": {
+      "dependsOn": ["^build"],
       "outputs": [".next/**", "!.next/cache/**"],
       "cache": false,
       "persistent": true


### PR DESCRIPTION
Ticket [ENG-3770]

### Description Of Changes

The `dev` task in `clients/turbo.json` had no `dependsOn`, so `turbo run dev` fanned out to every workspace in parallel with no ordering guarantee. Because `fides-js`'s rollup config writes its bundles directly into `clients/privacy-center/public/lib/` and `clients/admin-ui/public/lib/`, this meant that when you switched to a branch with `fides-js` changes and started the dev servers, the Next dev servers could (and did) start serving the **previous branch's** bundles — privacy-center's `/api/fides-js` route reads `public/lib/fides.js` on first request and caches it in memory for the rest of the process lifetime.

Adding `"dependsOn": ["^build"]` to the `dev` task tells turbo: before starting `dev` on any workspace, finish `build` on all of its workspace dependencies first. For admin-ui and privacy-center (both of which declare `"fides-js": "*"`), that means `fides-js`'s rollup build runs and writes fresh bundles into the consumer `public/lib/` directories before the Next dev servers come up.

Notes:

- This matches the pattern already in use on `dev:windows` in the same file.
- Subsequent runs are cached via turbo's `outputs: ["dist/**"]` on the `build` task — if `fides-js` sources haven't changed, the prerequisite is essentially free.
- `fides-js`'s `dev` script (rollup --watch) still runs as part of the `dev` fan-out, so live reloading during the session continues to work.
- This does **not** fix the separate in-memory cache in `clients/privacy-center/pages/api/fides-js.ts` — mid-session edits to `fides-js` still require restarting the Next dev server to pick up. That's a pre-existing issue and out of scope here.

### Code Changes

* Add `"dependsOn": ["^build"]` to the `dev` task in `clients/turbo.json`.

### Steps to Confirm

1. From `clients/`, run `turbo run dev`.
2. Confirm the turbo output shows a `fides-js#build` task running (or cached) **before** `admin-ui#dev` / `privacy-center#dev` start their Next servers.
3. Open `http://localhost:3000` (admin-ui) and `http://localhost:3001` (privacy-center) and confirm both load normally.
4. Stop the dev servers with `Ctrl+C` in the terminal running turbo (one Ctrl+C stops the whole turbo run and all child processes).
5. To validate the ordering actually rebuilds `fides-js` before serving:
   - Add a marker at the top of `clients/fides-js/src/fides.ts`, e.g. `console.log("FIDES_JS_BUILD_TEST_MARKER");` just after the imports.
   - From `clients/`, run `turbo run dev`.
   - Once turbo reports `admin-ui#dev` / `privacy-center#dev` are ready, open `http://localhost:3001/fides.js` in a browser tab (or `curl http://localhost:3001/fides.js | grep FIDES_JS_BUILD_TEST_MARKER`) and confirm the marker string is present in the served bundle on the **first** request — i.e. without waiting for the rollup watcher to pick up a later change.
   - `Ctrl+C` to stop. Revert the marker line before committing.

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-3770]: https://ethyca.atlassian.net/browse/ENG-3770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ