### PR TITLE
Clean up remaining DSR storage 

### DIFF
--- a/src/fides/api/models/privacy_request/privacy_request.py
+++ b/src/fides/api/models/privacy_request/privacy_request.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple, Union, cast
 
 from celery.result import AsyncResult
 from loguru import logger
@@ -106,7 +106,6 @@ from fides.api.schemas.redis_cache import Identity, LabeledIdentity, MultiValue
 from fides.api.tasks import celery_app
 from fides.api.util.cache import (
     FidesopsRedis,
-    get_cache,
     get_dsr_cache_store,
 )
 from fides.api.util.collection_util import Row
@@ -837,13 +836,11 @@ class PrivacyRequest(
         self, step: CurrentStep, dataset: str
     ) -> List[CheckpointActionRequired]:
         """Retrieve the raw details to populate an email template for collections on a given dataset."""
-        cache: FidesopsRedis = get_cache()
-        email_contents: Dict[str, Optional[Any]] = cache.get_encoded_objects_by_prefix(
-            f"EMAIL_INFORMATION__{self.id}__{step.value}__{dataset}"
-        )
+        store = get_dsr_cache_store(self.id)
+        email_contents = store.list_decoded_email_info_for_dataset(step.value, dataset)
 
         actions: List[CheckpointActionRequired] = []
-        for email_content in email_contents.values():
+        for email_content in email_contents:
             if email_content:
                 actions.append(
                     _parse_cache_to_checkpoint_action_required(email_content)
@@ -909,12 +906,12 @@ class PrivacyRequest(
 
         Dynamically creates a Pydantic model from the manual_webhook to use to validate the input_data
         """
-        cache: FidesopsRedis = get_cache()
         parsed_data = manual_webhook.fields_schema.model_validate(input_data)
 
-        cache.set_encoded_object(
-            f"WEBHOOK_MANUAL_ACCESS_INPUT__{self.id}__{manual_webhook.id}",
+        get_dsr_cache_store(self.id).write_encoded_webhook_manual_access(
+            str(manual_webhook.id),
             parsed_data.model_dump(mode="json"),
+            CONFIG.redis.default_ttl_seconds,
         )
 
     def cache_manual_webhook_erasure_input(
@@ -925,12 +922,12 @@ class PrivacyRequest(
 
         Dynamically creates a Pydantic model from the manual_webhook to use to validate the input_data
         """
-        cache: FidesopsRedis = get_cache()
         parsed_data = manual_webhook.erasure_fields_schema.model_validate(input_data)
 
-        cache.set_encoded_object(
-            f"WEBHOOK_MANUAL_ERASURE_INPUT__{self.id}__{manual_webhook.id}",
+        get_dsr_cache_store(self.id).write_encoded_webhook_manual_erasure(
+            str(manual_webhook.id),
             parsed_data.model_dump(mode="json"),
+            CONFIG.redis.default_ttl_seconds,
         )
 
     def get_manual_webhook_access_input_strict(
@@ -1030,18 +1027,20 @@ class PrivacyRequest(
         Cache a dict of collections traversed in the privacy request
         mapped to their associated data uses
         """
-        cache: FidesopsRedis = get_cache()
-        cache.set_encoded_object(f"DATA_USE_MAP__{self.id}", value)
+        get_dsr_cache_store(self.id).write_encoded_data_use_map(
+            value, CONFIG.redis.default_ttl_seconds
+        )
 
     def get_cached_data_use_map(self) -> Optional[Dict[str, Set[str]]]:
         """
         Fetch the collection -> data use map cached for this privacy request
         """
-        cache: FidesopsRedis = get_cache()
-        value_dict: Optional[Dict[str, Optional[Dict[str, Set[str]]]]] = (
-            cache.get_encoded_objects_by_prefix(f"DATA_USE_MAP__{self.id}")
-        )
-        return list(value_dict.values())[0] if value_dict else None
+        raw = get_dsr_cache_store(self.id).read_encoded_data_use_map()
+        if raw is None:
+            return None
+        if isinstance(raw, dict):
+            return cast(Dict[str, Set[str]], raw)
+        return None
 
     def trigger_pre_approval_webhook(
         self,
@@ -1666,14 +1665,13 @@ def _get_manual_access_input_from_cache(
 ) -> Optional[Dict[str, Any]]:
     """Get raw manual input uploaded to the privacy request for the given webhook
     from the cache without attempting to coerce into a Pydantic schema"""
-    cache: FidesopsRedis = get_cache()
-    cached_results: Optional[Optional[Dict[str, Any]]] = (
-        cache.get_encoded_objects_by_prefix(
-            f"WEBHOOK_MANUAL_ACCESS_INPUT__{privacy_request.id}__{manual_webhook.id}"
-        )
+    raw = get_dsr_cache_store(privacy_request.id).read_encoded_webhook_manual_access(
+        str(manual_webhook.id)
     )
-    if cached_results:
-        return list(cached_results.values())[0]
+    if raw is None:
+        return None
+    if isinstance(raw, dict):
+        return raw
     return None
 
 
@@ -1682,14 +1680,13 @@ def _get_manual_erasure_input_from_cache(
 ) -> Optional[Dict[str, Any]]:
     """Get raw manual input uploaded to the privacy request for the given webhook
     from the cache without attempting to coerce into a Pydantic schema"""
-    cache: FidesopsRedis = get_cache()
-    cached_results: Optional[Optional[Dict[str, Any]]] = (
-        cache.get_encoded_objects_by_prefix(
-            f"WEBHOOK_MANUAL_ERASURE_INPUT__{privacy_request.id}__{manual_webhook.id}"
-        )
+    raw = get_dsr_cache_store(privacy_request.id).read_encoded_webhook_manual_erasure(
+        str(manual_webhook.id)
     )
-    if cached_results:
-        return list(cached_results.values())[0]
+    if raw is None:
+        return None
+    if isinstance(raw, dict):
+        return raw
     return None
 
 
@@ -1806,17 +1803,32 @@ def cache_action_required(
 
     The "step" describes whether action is needed in the access or the erasure portion of the request.
     """
-    cache: FidesopsRedis = get_cache()
     action_required: Optional[CheckpointActionRequired] = None
     if step:
         action_required = CheckpointActionRequired(
             step=step, collection=collection, action_needed=action_needed
         )
 
-    cache.set_encoded_object(
-        cache_key,
-        action_required.model_dump() if action_required else None,
-    )
+    action_dict = action_required.model_dump() if action_required else None
+    ttl = CONFIG.redis.default_ttl_seconds
+
+    if cache_key.startswith("EMAIL_INFORMATION__"):
+        rest = cache_key[len("EMAIL_INFORMATION__") :]
+        pr_id, step_v, ds, coll = rest.rsplit("__", 3)
+        get_dsr_cache_store(pr_id).write_encoded_email_info(
+            step_v, ds, coll, action_dict, ttl
+        )
+        return
+    if cache_key.startswith("PAUSED_LOCATION__"):
+        pr_id = cache_key[len("PAUSED_LOCATION__") :]
+        get_dsr_cache_store(pr_id).write_encoded_paused_location(action_dict, ttl)
+        return
+    if cache_key.startswith("FAILED_LOCATION__"):
+        pr_id = cache_key[len("FAILED_LOCATION__") :]
+        get_dsr_cache_store(pr_id).write_encoded_failed_location(action_dict, ttl)
+        return
+
+    raise ValueError(f"Unsupported cache_action_required cache_key={cache_key!r}")
 
 
 def get_action_required_details(
@@ -1828,9 +1840,19 @@ def get_action_required_details(
     The "collection" is the node in question, and the "action_needed" describes actions that must be manually
     performed to complete the request.
     """
-    cache: FidesopsRedis = get_cache()
-    cached_stopped: Optional[dict[str, Any]] = cache.get_encoded_by_key(cached_key)
-    if cached_stopped:
+    if not cached_key.startswith("EN_"):
+        return None
+    logical = cached_key[len("EN_") :]
+    if logical.startswith("PAUSED_LOCATION__"):
+        pr_id = logical[len("PAUSED_LOCATION__") :]
+        cached_stopped = get_dsr_cache_store(pr_id).read_encoded_paused_location()
+    elif logical.startswith("FAILED_LOCATION__"):
+        pr_id = logical[len("FAILED_LOCATION__") :]
+        cached_stopped = get_dsr_cache_store(pr_id).read_encoded_failed_location()
+    else:
+        return None
+
+    if cached_stopped and isinstance(cached_stopped, dict):
         return _parse_cache_to_checkpoint_action_required(cached_stopped)
 
     return None

--- a/src/fides/api/models/privacy_request/privacy_request.py
+++ b/src/fides/api/models/privacy_request/privacy_request.py
@@ -1828,7 +1828,11 @@ def cache_action_required(
         get_dsr_cache_store(pr_id).write_encoded_failed_location(action_dict, ttl)
         return
 
-    raise ValueError(f"Unsupported cache_action_required cache_key={cache_key!r}")
+    logger.warning(
+        "cache_action_required: unsupported cache_key={!r}; skipping write (no-op)",
+        cache_key,
+    )
+    return
 
 
 def get_action_required_details(

--- a/src/fides/api/service/privacy_request/request_runner_service.py
+++ b/src/fides/api/service/privacy_request/request_runner_service.py
@@ -88,7 +88,7 @@ from fides.api.task.manual.manual_task_utils import (
 )
 from fides.api.tasks import DatabaseTask, celery_app
 from fides.api.tasks.scheduled.scheduler import scheduler
-from fides.api.util.cache import get_all_masking_secret_keys
+from fides.api.util.cache import get_cache, get_masking_secret_cache_key
 from fides.api.util.collection_util import Row
 from fides.api.util.consent_util import (
     filter_privacy_preferences_for_propagation,
@@ -1397,12 +1397,21 @@ def _verify_masking_secrets(
     if resume_step is None:
         return
 
-    # if masking can be performed without any masking secrets, we skip the cache check
-    if (
-        policy.generate_masking_secrets()
-        and not get_all_masking_secret_keys(privacy_request.id)
-        and not privacy_request.masking_secrets
-    ):
-        raise MaskingSecretsExpired(
-            f"The masking secrets for privacy request ID '{privacy_request.id}' have expired. Please submit a new erasure request."
+    needed = policy.generate_masking_secrets()
+    if not needed:
+        return
+
+    if privacy_request.masking_secrets:
+        return
+
+    cache = get_cache()
+    for meta in needed:
+        key = get_masking_secret_cache_key(
+            privacy_request.id, meta.masking_strategy, meta.secret_type
         )
+        if cache.get(key):
+            return
+
+    raise MaskingSecretsExpired(
+        f"The masking secrets for privacy request ID '{privacy_request.id}' have expired. Please submit a new erasure request."
+    )

--- a/src/fides/api/util/cache.py
+++ b/src/fides/api/util/cache.py
@@ -488,9 +488,12 @@ def get_masking_secret_cache_key(
 
 
 def get_all_cache_keys_for_privacy_request(privacy_request_id: str) -> List[Any]:
-    """Returns all cache keys related to this privacy request's cached identities"""
-    cache: FidesopsRedis = get_cache()
-    return cache.get_keys_by_prefix(f"id-{privacy_request_id}-")
+    """Return DSR cache keys registered in the per-request index (no keyspace SCAN).
+
+    Legacy keys that were never added to the index are not included.
+    """
+    manager = get_redis_cache_manager()
+    return manager.get_keys_by_index(f"dsr:{privacy_request_id}")
 
 
 def get_async_task_tracking_cache_key(privacy_request_id: str) -> str:
@@ -642,8 +645,3 @@ def get_queue_counts() -> Dict[str, int]:
         logger.critical(exception)
         queue_counts = {}
     return queue_counts
-
-
-def get_all_masking_secret_keys(privacy_request_id: str) -> List[str]:
-    cache: FidesopsRedis = get_cache()
-    return cache.get_keys_by_prefix(f"id-{privacy_request_id}-masking-secret-")

--- a/src/fides/common/cache/dsr_store.py
+++ b/src/fides/common/cache/dsr_store.py
@@ -14,12 +14,15 @@ later if we want to avoid index consistency concerns.
 """
 
 import re
-from typing import Any, Callable, Dict, Optional, Set, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Union
 
+from loguru import logger
 from redis import Redis
 
 from fides.common.cache.key_mapping import DSR_KEY_PREFIX, KeyMapper
 from fides.common.cache.manager import RedisCacheManager, RedisValue
+from fides.common.cache.redis_json_codec import decode_cache_obj, encode_cache_obj
+from fides.config import CONFIG
 
 __all__ = [
     "DSR_KEY_PREFIX",
@@ -434,27 +437,166 @@ class DSRCacheStore:
         part = "retry_count"
         return self.get_with_legacy(part, KeyMapper.retry_count(self._dsr_id)[1])
 
+    # --- Encoded JSON blobs (legacy EN_{logical} + indexed dsr:{id}:…) ---
+
+    @staticmethod
+    def _redis_str(val: Optional[Union[str, bytes]]) -> Optional[str]:
+        if val is None:
+            return None
+        if isinstance(val, bytes):
+            return val.decode("utf-8", errors="replace")
+        return str(val)
+
+    def _legacy_en_key(self, legacy_logical: str) -> str:
+        return f"EN_{legacy_logical}"
+
+    def _get_decoded_encoded_with_legacy(
+        self, part: str, legacy_logical: str
+    ) -> Optional[Any]:
+        """Read JSON-encoded object from new key, else legacy EN_{logical}; optionally migrate."""
+        new_key = _dsr_key(self._dsr_id, part)
+        raw = self._redis.get(new_key)
+        s = self._redis_str(raw)
+        if s is not None:
+            return decode_cache_obj(s)
+
+        legacy_key = self._legacy_en_key(legacy_logical)
+        raw = self._redis.get(legacy_key)
+        if raw is None:
+            return decode_cache_obj(self._redis_str(self._redis.get(new_key)))
+
+        payload = self._redis_str(raw)
+        decoded = decode_cache_obj(payload)
+        if self._migrate_on_read and payload is not None:
+            ttl = self._redis.ttl(legacy_key)
+            expire = ttl if ttl > 0 else self._default_ttl
+            self.set(part, payload, expire)
+            self._redis.delete(legacy_key)
+        return decoded
+
+    def _set_encoded_json(
+        self,
+        part: str,
+        legacy_logical: str,
+        obj: Any,
+        expire_seconds: int,
+    ) -> None:
+        """Write JSON-encoded object to indexed new key and remove legacy EN_* if present."""
+        payload = encode_cache_obj(obj)
+        self.set(part, payload, expire_seconds)
+        legacy_key = self._legacy_en_key(legacy_logical)
+        if self._redis.get(legacy_key) is not None:
+            self._redis.delete(legacy_key)
+
+    def write_encoded_email_info(
+        self,
+        step: str,
+        dataset: str,
+        collection: str,
+        obj: Any,
+        expire_seconds: int,
+    ) -> None:
+        _, legacy_logical = KeyMapper.email_info(
+            self._dsr_id, step, dataset, collection
+        )
+        part = f"email_info:{step}:{dataset}:{collection}"
+        self._set_encoded_json(part, legacy_logical, obj, expire_seconds)
+
+    def list_decoded_email_info_for_dataset(self, step: str, dataset: str) -> List[Any]:
+        """Return decoded email checkpoint payloads for a dataset without prefix SCAN."""
+        index_prefix = _dsr_index_prefix(self._dsr_id)
+        dsr_full_prefix = f"{DSR_KEY_PREFIX}{self._dsr_id}:"
+        part_prefix = f"email_info:{step}:{dataset}:"
+        items: List[tuple[str, Any]] = []
+        for full_key in self._manager.get_keys_by_index(index_prefix):
+            if not full_key.startswith(dsr_full_prefix):
+                continue
+            part = full_key[len(dsr_full_prefix) :]
+            if not part.startswith(part_prefix):
+                continue
+            collection = part[len(part_prefix) :]
+            _, legacy_logical = KeyMapper.email_info(
+                self._dsr_id, step, dataset, collection
+            )
+            decoded = self._get_decoded_encoded_with_legacy(part, legacy_logical)
+            if decoded is not None:
+                items.append((part, decoded))
+        items.sort(key=lambda t: t[0])
+        return [d for _, d in items]
+
+    def write_encoded_data_use_map(self, obj: Any, expire_seconds: int) -> None:
+        _, legacy_logical = KeyMapper.data_use_map(self._dsr_id)
+        self._set_encoded_json("data_use_map", legacy_logical, obj, expire_seconds)
+
+    def read_encoded_data_use_map(self) -> Optional[Any]:
+        _, legacy_logical = KeyMapper.data_use_map(self._dsr_id)
+        return self._get_decoded_encoded_with_legacy("data_use_map", legacy_logical)
+
+    def write_encoded_webhook_manual_access(
+        self, webhook_id: str, obj: Any, expire_seconds: int
+    ) -> None:
+        _, legacy_logical = KeyMapper.webhook_manual_access(self._dsr_id, webhook_id)
+        part = f"webhook_manual_access:{webhook_id}"
+        self._set_encoded_json(part, legacy_logical, obj, expire_seconds)
+
+    def read_encoded_webhook_manual_access(self, webhook_id: str) -> Optional[Any]:
+        _, legacy_logical = KeyMapper.webhook_manual_access(self._dsr_id, webhook_id)
+        part = f"webhook_manual_access:{webhook_id}"
+        return self._get_decoded_encoded_with_legacy(part, legacy_logical)
+
+    def write_encoded_webhook_manual_erasure(
+        self, webhook_id: str, obj: Any, expire_seconds: int
+    ) -> None:
+        _, legacy_logical = KeyMapper.webhook_manual_erasure(self._dsr_id, webhook_id)
+        part = f"webhook_manual_erasure:{webhook_id}"
+        self._set_encoded_json(part, legacy_logical, obj, expire_seconds)
+
+    def read_encoded_webhook_manual_erasure(self, webhook_id: str) -> Optional[Any]:
+        _, legacy_logical = KeyMapper.webhook_manual_erasure(self._dsr_id, webhook_id)
+        part = f"webhook_manual_erasure:{webhook_id}"
+        return self._get_decoded_encoded_with_legacy(part, legacy_logical)
+
+    def write_encoded_paused_location(self, obj: Any, expire_seconds: int) -> None:
+        _, legacy_logical = KeyMapper.paused_location(self._dsr_id)
+        self._set_encoded_json("paused_location", legacy_logical, obj, expire_seconds)
+
+    def read_encoded_paused_location(self) -> Optional[Any]:
+        _, legacy_logical = KeyMapper.paused_location(self._dsr_id)
+        return self._get_decoded_encoded_with_legacy("paused_location", legacy_logical)
+
+    def write_encoded_failed_location(self, obj: Any, expire_seconds: int) -> None:
+        _, legacy_logical = KeyMapper.failed_location(self._dsr_id)
+        self._set_encoded_json("failed_location", legacy_logical, obj, expire_seconds)
+
+    def read_encoded_failed_location(self) -> Optional[Any]:
+        _, legacy_logical = KeyMapper.failed_location(self._dsr_id)
+        return self._get_decoded_encoded_with_legacy("failed_location", legacy_logical)
+
     # --- List / clear ---
 
     def get_all_keys(self) -> list[str]:
         """
         Return all cache keys for this DSR.
 
-        Uses the index first. If a migration flag confirms no legacy keys remain,
-        returns index contents directly. Otherwise, does a one-time SCAN to find
-        legacy stragglers, backfills them into the index, and sets the migration
-        flag so future calls skip the SCAN.
+        Prefers the DSR index (``SMEMBERS`` on ``__idx:dsr:{id}``). When
+        ``CONFIG.redis.dsr_cache_strict_index`` is True, never scans. Otherwise,
+        performs at most one keyspace ``SCAN`` per DSR until the migration marker
+        shows the index is complete, backfilling discovered keys into the index.
         """
         index_prefix = _dsr_index_prefix(self._dsr_id)
         keys = self._manager.get_keys_by_index(index_prefix)
-
-        # If we've already confirmed no legacy keys remain, index is authoritative
         migration_key = f"__migrated:{self._dsr_id}"
+
+        if CONFIG.redis.dsr_cache_strict_index:
+            return keys
+
         if keys and self._redis.exists(migration_key):
             return keys
 
-        # SCAN for all keys (one-time per DSR until migration confirmed)
-        # Filter out internal keys (__migrated:, __idx:) that match the SCAN pattern
+        logger.warning(
+            "DSR cache: get_all_keys SCAN for dsr_id={} (set redis.dsr_cache_strict_index to skip)",
+            self._dsr_id,
+        )
         scanned_keys = [
             k
             for k in self._redis.scan_iter(match=f"*{self._dsr_id}*", count=500)
@@ -472,7 +614,6 @@ class DSRCacheStore:
                 if k not in indexed:
                     self._manager.add_key_to_index(index_prefix, k)
 
-        # If index existed and no scanned keys found outside it, mark as migrated
         if keys and not (scanned_set - indexed):
             self._redis.setex(migration_key, 86400, "1")  # 24h TTL
 
@@ -480,21 +621,11 @@ class DSRCacheStore:
 
     def clear(self) -> None:
         """
-        Delete all cache keys for this DSR and remove the index.
+        Delete all indexed cache keys for this DSR and remove the index.
 
-        Always uses SCAN to find all keys (both indexed and legacy) to ensure
-        complete cleanup in mixed-key scenarios. Does a second SCAN pass to
-        catch keys written by concurrent migrations between the first SCAN
-        and DELETE.
+        Does not scan the keyspace. Legacy keys that were never registered in the
+        index may remain until TTL expiry or the DSR cache sweeper removes them.
         """
-        all_keys = list(self._redis.scan_iter(match=f"*{self._dsr_id}*", count=500))
         index_prefix = _dsr_index_prefix(self._dsr_id)
-        if all_keys:
-            self._redis.delete(*all_keys)
-        self._manager.delete_index(index_prefix)
-        # Invalidate migration flag so future reads re-scan
+        self._manager.delete_keys_by_index(index_prefix)
         self._redis.delete(f"__migrated:{self._dsr_id}")
-        # Second pass: catch keys written by concurrent migrations
-        stragglers = list(self._redis.scan_iter(match=f"*{self._dsr_id}*", count=500))
-        if stragglers:
-            self._redis.delete(*stragglers)

--- a/src/fides/common/cache/dsr_store.py
+++ b/src/fides/common/cache/dsr_store.py
@@ -404,31 +404,6 @@ class DSRCacheStore:
         """
         return self._has_cached_by_type(":drp:", "-drp-")
 
-    # --- Convenience: masking secret ---
-
-    def write_masking_secret(
-        self,
-        strategy: str,
-        secret_type: str,
-        value: RedisValue,
-        expire_seconds: int,
-    ) -> Optional[bool]:
-        """Write masking secret. New key: dsr:{id}:masking_secret:{strategy}:{secret_type}."""
-        part = f"masking_secret:{strategy}:{secret_type}"
-        return self.set(part, value, expire_seconds)
-
-    def get_masking_secret(
-        self,
-        strategy: str,
-        secret_type: str,
-    ) -> Optional[Union[str, bytes]]:
-        """Get masking secret; reads from legacy id-{id}-masking-secret-{strategy}-{type} if needed."""
-        part = f"masking_secret:{strategy}:{secret_type}"
-        return self.get_with_legacy(
-            part,
-            KeyMapper.masking_secret(self._dsr_id, strategy, secret_type)[1],
-        )
-
     # --- Convenience: async execution (single value per DSR) ---
 
     def write_async_execution(

--- a/src/fides/common/cache/dsr_store.py
+++ b/src/fides/common/cache/dsr_store.py
@@ -536,7 +536,9 @@ class DSRCacheStore:
             en_match_prefix = (
                 f"EN_EMAIL_INFORMATION__{self._dsr_id}__{step}__{dataset}__"
             )
-            for raw_key in self._redis.scan_iter(match=f"{en_match_prefix}*", count=500):
+            for raw_key in self._redis.scan_iter(
+                match=f"{en_match_prefix}*", count=500
+            ):
                 redis_key = decode_dsr_redis_key(raw_key)
                 if not redis_key.startswith("EN_"):
                     continue

--- a/src/fides/common/cache/dsr_store.py
+++ b/src/fides/common/cache/dsr_store.py
@@ -463,7 +463,7 @@ class DSRCacheStore:
         legacy_key = self._legacy_en_key(legacy_logical)
         raw = self._redis.get(legacy_key)
         if raw is None:
-            return decode_cache_obj(self._redis_str(self._redis.get(new_key)))
+            return None
 
         payload = self._redis_str(raw)
         decoded = decode_cache_obj(payload)
@@ -503,7 +503,15 @@ class DSRCacheStore:
         self._set_encoded_json(part, legacy_logical, obj, expire_seconds)
 
     def list_decoded_email_info_for_dataset(self, step: str, dataset: str) -> List[Any]:
-        """Return decoded email checkpoint payloads for a dataset without prefix SCAN."""
+        """Return decoded email checkpoint payloads for a dataset.
+
+        Always reads ``dsr:{id}:email_info:…`` keys registered in the per-DSR index.
+
+        When ``CONFIG.redis.dsr_cache_strict_index`` is False, also runs a **narrow**
+        ``SCAN … MATCH EN_EMAIL_INFORMATION__{id}__{step}__{dataset}__*`` to discover
+        legacy encoded keys not yet represented under ``dsr:`` parts. When strict
+        mode is True, legacy ``EN_*`` keys are ignored here (index-only listing).
+        """
         index_prefix = _dsr_index_prefix(self._dsr_id)
         dsr_full_prefix = f"{DSR_KEY_PREFIX}{self._dsr_id}:"
         part_prefix = f"email_info:{step}:{dataset}:"
@@ -521,6 +529,41 @@ class DSRCacheStore:
             decoded = self._get_decoded_encoded_with_legacy(part, legacy_logical)
             if decoded is not None:
                 items.append((part, decoded))
+
+        seen_collections = {part[len(part_prefix) :] for part, _ in items}
+
+        if not CONFIG.redis.dsr_cache_strict_index:
+            en_match_prefix = (
+                f"EN_EMAIL_INFORMATION__{self._dsr_id}__{step}__{dataset}__"
+            )
+            for raw_key in self._redis.scan_iter(match=f"{en_match_prefix}*", count=500):
+                redis_key = decode_dsr_redis_key(raw_key)
+                if not redis_key.startswith("EN_"):
+                    continue
+                logical = redis_key[len("EN_") :]
+                em_pfx = "EMAIL_INFORMATION__"
+                if not logical.startswith(em_pfx):
+                    continue
+                rest = logical[len(em_pfx) :]
+                try:
+                    pr_id, step_v, ds, coll = rest.rsplit("__", 3)
+                except ValueError:
+                    continue
+                if pr_id != self._dsr_id or step_v != step or ds != dataset:
+                    continue
+                if coll in seen_collections:
+                    continue
+                raw_val = self._redis.get(redis_key)
+                payload = self._redis_str(raw_val)
+                if not payload:
+                    continue
+                decoded = decode_cache_obj(payload)
+                if decoded is None:
+                    continue
+                part = f"email_info:{step}:{dataset}:{coll}"
+                items.append((part, decoded))
+                seen_collections.add(coll)
+
         items.sort(key=lambda t: t[0])
         return [d for _, d in items]
 
@@ -623,8 +666,12 @@ class DSRCacheStore:
         """
         Delete all indexed cache keys for this DSR and remove the index.
 
-        Does not scan the keyspace. Legacy keys that were never registered in the
-        index may remain until TTL expiry or the DSR cache sweeper removes them.
+        Intentionally **does not** scan Redis: only keys registered in
+        ``__idx:dsr:{id}`` are removed (via ``delete_keys_by_index``). Legacy
+        ``EN_*`` or ``id-{id}-*`` values that never entered that index can remain
+        until TTL expiry or until the **DSR cache sweeper** (and related hygiene)
+        deletes them. Prefer running index backfill / migration before relying on
+        ``clear()`` alone for compliance-sensitive teardown.
         """
         index_prefix = _dsr_index_prefix(self._dsr_id)
         self._manager.delete_keys_by_index(index_prefix)

--- a/src/fides/common/cache/key_mapping.py
+++ b/src/fides/common/cache/key_mapping.py
@@ -61,14 +61,6 @@ class KeyMapper:
         return _new_key(dsr_id, part), f"id-{dsr_id}-encryption-{attr}"
 
     @staticmethod
-    def masking_secret(dsr_id: str, strategy: str, secret_type: str) -> Tuple[str, str]:
-        """New: dsr:{id}:masking_secret:{strategy}:{secret_type}. Legacy: id-{id}-masking-secret-{strategy}-{secret_type}."""
-        part = f"masking_secret:{strategy}:{secret_type}"
-        return _new_key(
-            dsr_id, part
-        ), f"id-{dsr_id}-masking-secret-{strategy}-{secret_type}"
-
-    @staticmethod
     def async_execution(dsr_id: str) -> Tuple[str, str]:
         """New: dsr:{id}:async_execution. Legacy: id-{id}-async-execution."""
         part = "async_execution"

--- a/src/fides/common/cache/redis_json_codec.py
+++ b/src/fides/common/cache/redis_json_codec.py
@@ -1,14 +1,21 @@
 """JSON encode/decode for Redis-cached objects (matches FidesopsRedis semantics).
 
-Kept in ``fides.common.cache`` so DSRCacheStore can serialize consistently with
-``FidesopsRedis.set_encoded_object`` / ``get_encoded_by_key`` without importing
-``fides.api.util.cache`` (circular import).
+DSRCacheStore uses this module so it does not import ``fides.api.util.cache``
+(which would cycle back into ``fides.common.cache``).
+
+**Encoder location:** ``CustomJSONEncoder`` / ``_custom_decoder`` still live under
+``fides.api.util.custom_json_encoder`` so payloads stay byte-for-byte compatible
+with ``FidesopsRedis.encode_obj`` / ``decode_obj``. That creates a deliberate
+``fides.common`` → ``fides.api.util`` dependency (``fidesplus`` and others also
+import the encoder from ``fides.api.util``). Moving the encoder into a neutral
+``fides.common.*`` module is deferred to a dedicated refactor to avoid churn
+across repos in this change set.
 """
 
 from __future__ import annotations
 
 import json
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 from urllib.parse import unquote_to_bytes
 
 from loguru import logger

--- a/src/fides/common/cache/redis_json_codec.py
+++ b/src/fides/common/cache/redis_json_codec.py
@@ -1,0 +1,38 @@
+"""JSON encode/decode for Redis-cached objects (matches FidesopsRedis semantics).
+
+Kept in ``fides.common.cache`` so DSRCacheStore can serialize consistently with
+``FidesopsRedis.set_encoded_object`` / ``get_encoded_by_key`` without importing
+``fides.api.util.cache`` (circular import).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Optional
+from urllib.parse import unquote_to_bytes
+
+from loguru import logger
+
+from fides.api.util.custom_json_encoder import CustomJSONEncoder, _custom_decoder
+
+
+def encode_cache_obj(obj: Any) -> str:
+    """Encode a Python object to the same JSON string used by ``FidesopsRedis.encode_obj``."""
+    return json.dumps(obj, cls=CustomJSONEncoder)  # type: ignore[arg-type]
+
+
+def decode_cache_obj(bs: Optional[str]) -> Optional[Any]:
+    """Decode JSON cached by ``encode_cache_obj`` (same rules as ``FidesopsRedis.decode_obj``)."""
+    if not bs:
+        return None
+    try:
+        result = json.loads(bs, object_hook=_custom_decoder)
+    except json.JSONDecodeError:
+        logger.info(
+            "Error decoding cache. If you are coming from a version of fides prior to 2.8 "
+            "this could be an issue with cache format and the request needs to be reprocessed."
+        )
+        return None
+    if isinstance(result, str) and result.startswith("quote_encoded"):
+        result = unquote_to_bytes(result)[14:]
+    return result

--- a/src/fides/config/redis_settings.py
+++ b/src/fides/config/redis_settings.py
@@ -49,6 +49,14 @@ class RedisSettings(FidesSettings):
         default=600,
         description="Sets TTL for cached identity verification code as part of subject requests.",
     )
+    dsr_cache_strict_index: bool = Field(
+        default=False,
+        description=(
+            "When True, DSRCacheStore.get_all_keys() returns only keys registered in the "
+            "per-DSR Redis index (no SCAN). Enable only after migration burn-in; otherwise "
+            "legacy keys not yet backfilled into the index may be omitted from listings."
+        ),
+    )
     password: str = Field(
         default="testpassword",
         description="The password with which to login to the Redis cache.",

--- a/tests/api/models/test_masking_secret.py
+++ b/tests/api/models/test_masking_secret.py
@@ -1,6 +1,6 @@
 """Tests for the MaskingSecret model and related functionality."""
 
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from sqlalchemy.orm import Session
@@ -147,15 +147,14 @@ class TestMaskingSecretFallback:
     TODO: Remove these tests once we fully move to the new DB based approach.
     """
 
-    @patch(
-        "fides.api.service.privacy_request.request_runner_service.get_all_masking_secret_keys"
-    )
+    @patch("fides.api.service.privacy_request.request_runner_service.get_cache")
     def test_verify_masking_secrets_expired(
-        self, mock_get_all_keys, db: Session, privacy_request
+        self, mock_get_cache, db: Session, privacy_request
     ):
         """Test that _verify_masking_secrets raises appropriate exception."""
-        # Mock to return empty list of keys
-        mock_get_all_keys.return_value = []
+        mock_cache = MagicMock()
+        mock_cache.get.return_value = None
+        mock_get_cache.return_value = mock_cache
 
         # Create a policy that requires masking secrets
         policy_mock = Mock(spec=Policy)
@@ -198,13 +197,21 @@ class TestMaskingSecretFallback:
         # Should not raise an exception
         _verify_masking_secrets(policy_mock, privacy_request, CurrentStep.erasure)
 
-    @patch(
-        "fides.api.service.privacy_request.request_runner_service.get_all_masking_secret_keys"
-    )
+    @patch("fides.api.service.privacy_request.request_runner_service.get_cache")
     def test_verify_masking_secrets_success_cache(
-        self, mock_get_all_keys, db: Session, privacy_request
+        self, mock_get_cache, db: Session, privacy_request
     ):
         """Test that _verify_masking_secrets succeeds when secrets are in cache."""
+        mock_cache = MagicMock()
+
+        def fake_get(key: str):
+            if f"id-{privacy_request.id}-masking-secret-test-strategy-key" == key:
+                return "present"
+            return None
+
+        mock_cache.get.side_effect = fake_get
+        mock_get_cache.return_value = mock_cache
+
         # Create a policy that requires masking secrets
         policy_mock = Mock(spec=Policy)
         policy_mock.generate_masking_secrets.return_value = [
@@ -213,11 +220,6 @@ class TestMaskingSecretFallback:
                 masking_strategy="test-strategy",
                 secret_type=SecretType.key,
             )
-        ]
-
-        # Mock cache keys to return a non-empty list
-        mock_get_all_keys.return_value = [
-            f"id-{privacy_request.id}-masking-secret-test-strategy-key"
         ]
 
         # Should not raise an exception

--- a/tests/common/cache/test_dsr_store.py
+++ b/tests/common/cache/test_dsr_store.py
@@ -6,7 +6,9 @@ No real Redis required.
 import pytest
 
 from fides.common.cache.dsr_store import DSRCacheStore
+from fides.common.cache.key_mapping import KeyMapper
 from fides.common.cache.manager import RedisCacheManager
+from fides.common.cache.redis_json_codec import encode_cache_obj
 
 _TTL = 3600  # Test TTL
 
@@ -115,3 +117,16 @@ class TestDSRCacheStoreWithInMemoryManager:
         store2 = DSRCacheStore("pr-2", manager)
         assert store2.get_encryption("key") == "legacy-enc"
         assert mock_redis.get("id-pr-2-encryption-key") is None
+
+    def test_encoded_data_use_map_round_trip(self, dsr_store: DSRCacheStore) -> None:
+        payload = {"ds": ["marketing"]}
+        dsr_store.write_encoded_data_use_map(payload, _TTL)
+        assert dsr_store.read_encoded_data_use_map() == payload
+
+    def test_encoded_data_use_map_migrates_legacy_en_key(
+        self, dsr_store: DSRCacheStore, mock_redis
+    ) -> None:
+        _, logical = KeyMapper.data_use_map("pr-1")
+        mock_redis.set(f"EN_{logical}", encode_cache_obj({"k": ["v"]}))
+        assert dsr_store.read_encoded_data_use_map() == {"k": ["v"]}
+        assert mock_redis.get(f"EN_{logical}") is None

--- a/tests/common/cache/test_dsr_store.py
+++ b/tests/common/cache/test_dsr_store.py
@@ -115,18 +115,3 @@ class TestDSRCacheStoreWithInMemoryManager:
         store2 = DSRCacheStore("pr-2", manager)
         assert store2.get_encryption("key") == "legacy-enc"
         assert mock_redis.get("id-pr-2-encryption-key") is None
-
-    def test_masking_secret(
-        self, dsr_store: DSRCacheStore, mock_redis, manager
-    ) -> None:
-        """Mirrors secrets_util.get_masking_secret cache read (and write path)."""
-        dsr_store.write_masking_secret(
-            "hash", "salt", "encoded-secret", expire_seconds=600
-        )
-        assert dsr_store.get_masking_secret("hash", "salt") == "encoded-secret"
-        assert dsr_store.get_masking_secret("hash", "other") is None
-        # Legacy key migration (different DSR)
-        mock_redis.set("id-pr-2-masking-secret-hash-pepper", "legacy-masking")
-        store2 = DSRCacheStore("pr-2", manager)
-        assert store2.get_masking_secret("hash", "pepper") == "legacy-masking"
-        assert mock_redis.get("id-pr-2-masking-secret-hash-pepper") is None

--- a/tests/common/cache/test_dsr_store_clear_integration.py
+++ b/tests/common/cache/test_dsr_store_clear_integration.py
@@ -22,14 +22,21 @@ class TestPrivacyRequestClearCachedValues:
     """Test clear_cached_values() with DSR store."""
 
     def test_clear_removes_legacy_keys(self):
-        """clear_cached_values removes legacy cache keys."""
+        """clear_cached_values removes legacy cache keys registered in the DSR index."""
         mock_redis = create_mock_redis()
         pr_id = f"test-pr-{uuid.uuid4()}"
+        manager = RedisCacheManager(mock_redis)
+        idx = f"dsr:{pr_id}"
 
-        # Simulate legacy cached data
-        mock_redis.set(f"id-{pr_id}-identity-email", "test@example.com")
-        mock_redis.set(f"id-{pr_id}-identity-phone_number", "+1234567890")
-        mock_redis.set(f"id-{pr_id}-encryption-key", "encryption-key")
+        # Simulate legacy cached data (also registered on the index so clear() can delete)
+        legacy_keys = [
+            f"id-{pr_id}-identity-email",
+            f"id-{pr_id}-identity-phone_number",
+            f"id-{pr_id}-encryption-key",
+        ]
+        for k in legacy_keys:
+            mock_redis.set(k, "x")
+            manager.add_key_to_index(idx, k)
 
         # Mock privacy request
         pr = MagicMock()
@@ -63,15 +70,22 @@ class TestPrivacyRequestClearCachedValues:
         assert len(mock_redis.keys(f"*{pr_id}*")) == 0
 
     def test_clear_removes_mixed_keys(self):
-        """clear_cached_values removes both legacy and new keys."""
+        """clear_cached_values removes both legacy and new keys when indexed."""
         mock_redis = create_mock_redis()
         pr_id = f"test-pr-{uuid.uuid4()}"
 
-        # Mixed: legacy identity, new encryption
-        mock_redis.set(f"id-{pr_id}-identity-email", "legacy@example.com")
-        mock_redis.set(f"id-{pr_id}-custom-privacy-request-field-dept", "Engineering")
-
         manager = RedisCacheManager(mock_redis)
+        idx = f"dsr:{pr_id}"
+
+        # Mixed: legacy identity/custom keys registered on index, plus new-format store keys
+        legacy_keys = [
+            f"id-{pr_id}-identity-email",
+            f"id-{pr_id}-custom-privacy-request-field-dept",
+        ]
+        for k in legacy_keys:
+            mock_redis.set(k, "x")
+            manager.add_key_to_index(idx, k)
+
         store = DSRCacheStore(pr_id, manager)
         store.write_encryption("key", "new-encryption-key", _TTL)
         store.write_async_execution("task-123", _TTL)

--- a/tests/common/cache/test_dsr_store_key_mapping.py
+++ b/tests/common/cache/test_dsr_store_key_mapping.py
@@ -32,11 +32,6 @@ class TestKeyMapper:
         assert new_key == f"{DSR_KEY_PREFIX}pr-abc:encryption:key"
         assert legacy_key == "id-pr-abc-encryption-key"
 
-    def test_masking_secret(self) -> None:
-        new_key, legacy_key = KeyMapper.masking_secret("pr-def", "hash", "salt")
-        assert new_key == f"{DSR_KEY_PREFIX}pr-def:masking_secret:hash:salt"
-        assert legacy_key == "id-pr-def-masking-secret-hash-salt"
-
     def test_async_execution(self) -> None:
         new_key, legacy_key = KeyMapper.async_execution("pr-ghi")
         assert new_key == f"{DSR_KEY_PREFIX}pr-ghi:async_execution"

--- a/tests/common/cache/test_dsr_store_migration.py
+++ b/tests/common/cache/test_dsr_store_migration.py
@@ -100,10 +100,16 @@ class TestLegacyKeyMigration:
         )
 
     def test_clear_removes_mixed_keys(self, mock_redis, manager, dsr_id):
-        """clear() removes both legacy and new keys using SCAN."""
+        """clear() deletes all keys listed in the DSR index (including registered legacy)."""
         store = DSRCacheStore(dsr_id, manager)
-        mock_redis.set(make_legacy_key(dsr_id, "identity", "email"), "legacy@test.com")
-        mock_redis.set(make_legacy_key(dsr_id, "encryption", "key"), "legacy-key")
+        idx = f"dsr:{dsr_id}"
+        legacy_email = make_legacy_key(dsr_id, "identity", "email")
+        legacy_enc = make_legacy_key(dsr_id, "encryption", "key")
+        mock_redis.set(legacy_email, "legacy@test.com")
+        mock_redis.set(legacy_enc, "legacy-key")
+        manager.add_key_to_index(idx, legacy_email)
+        manager.add_key_to_index(idx, legacy_enc)
+
         store.write_identity("phone_number", "+1234567890", _TTL)
         store.write_custom_field("department", "Engineering", _TTL)
 

--- a/tests/common/cache/test_dsr_store_migration.py
+++ b/tests/common/cache/test_dsr_store_migration.py
@@ -45,7 +45,6 @@ class TestLegacyKeyMigration:
             ("async-execution", "get_async_execution", "", "celery-task-123"),
             ("privacy-request-retry-count", "get_retry_count", "", "3"),
             ("drp", "get_drp", "email", "drp@example.com"),
-            ("masking-secret-hash", "get_masking_secret", "salt", "secret-123"),
         ],
     )
     def test_legacy_keys_readable(
@@ -56,10 +55,7 @@ class TestLegacyKeyMigration:
         legacy_key = make_legacy_key(dsr_id, field_type, field_key)
         mock_redis.set(legacy_key, value)
 
-        # Call appropriate getter
-        if getter == "get_masking_secret":
-            result = store.get_masking_secret("hash", field_key)
-        elif field_key:
+        if field_key:
             result = getattr(store, getter)(field_key)
         else:
             result = getattr(store, getter)()

--- a/tests/common/cache/test_dsr_store_strict_index.py
+++ b/tests/common/cache/test_dsr_store_strict_index.py
@@ -15,6 +15,7 @@ import pytest
 from fides.common.cache import dsr_store as dsr_store_module
 from fides.common.cache.dsr_store import DSRCacheStore
 from fides.common.cache.manager import RedisCacheManager
+from fides.common.cache.redis_json_codec import encode_cache_obj
 
 _TTL = 3600
 
@@ -193,3 +194,86 @@ class TestNonStrictLegacyAndScan:
         idx_members = mock_redis.smembers(f"__idx:dsr:{dsr_id}")
         assert _make_legacy_key(dsr_id, "identity", "email") in idx_members
         assert _make_legacy_key(dsr_id, "identity", "phone_number") in idx_members
+
+
+def _en_email_key(dsr_id: str, step: str, dataset: str, collection: str) -> str:
+    return (
+        f"EN_EMAIL_INFORMATION__{dsr_id}__{step}__{dataset}__{collection}"
+    )
+
+
+@pytest.mark.unit
+class TestListEmailInfoLegacyEnScan:
+    """Legacy ``EN_EMAIL_INFORMATION__*`` listing is gated on strict index mode."""
+
+    def test_list_email_strict_index_skips_legacy_en_without_scan(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_redis: Any,
+        manager: RedisCacheManager,
+    ) -> None:
+        monkeypatch.setattr(
+            dsr_store_module.CONFIG.redis, "dsr_cache_strict_index", True, raising=False
+        )
+        scan_calls = _wrap_scan_iter(mock_redis)
+        dsr_id = "pri_test_email_strict"
+        step, dataset, coll = "access", "postgres", "addresses"
+        mock_redis.set(
+            _en_email_key(dsr_id, step, dataset, coll),
+            encode_cache_obj({"step": step, "collection": None, "action_needed": None}),
+        )
+        store = DSRCacheStore(dsr_id, manager)
+        out = store.list_decoded_email_info_for_dataset(step, dataset)
+        assert out == []
+        assert scan_calls == []
+
+    def test_list_email_non_strict_finds_legacy_en_with_scan(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_redis: Any,
+        manager: RedisCacheManager,
+    ) -> None:
+        monkeypatch.setattr(
+            dsr_store_module.CONFIG.redis,
+            "dsr_cache_strict_index",
+            False,
+            raising=False,
+        )
+        scan_calls = _wrap_scan_iter(mock_redis)
+        dsr_id = "pri_test_email_nonstrict"
+        step, dataset, coll = "access", "postgres", "addresses"
+        payload = {"step": step, "collection": None, "action_needed": None}
+        mock_redis.set(_en_email_key(dsr_id, step, dataset, coll), encode_cache_obj(payload))
+
+        store = DSRCacheStore(dsr_id, manager)
+        out = store.list_decoded_email_info_for_dataset(step, dataset)
+
+        assert out == [payload]
+        assert scan_calls, "expected narrow scan_iter for legacy EN email keys"
+
+    def test_list_email_non_strict_prefers_index_over_duplicate_legacy_en(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_redis: Any,
+        manager: RedisCacheManager,
+    ) -> None:
+        monkeypatch.setattr(
+            dsr_store_module.CONFIG.redis,
+            "dsr_cache_strict_index",
+            False,
+            raising=False,
+        )
+        dsr_id = "pri_test_email_dedupe"
+        step, dataset, coll = "access", "crm", "contacts"
+        indexed_payload = {"step": step, "collection": None, "action_needed": None}
+        legacy_payload = {"step": step, "collection": {"dataset": "x"}, "action_needed": None}
+
+        store = DSRCacheStore(dsr_id, manager)
+        store.write_encoded_email_info(step, dataset, coll, indexed_payload, _TTL)
+        mock_redis.set(
+            _en_email_key(dsr_id, step, dataset, coll), encode_cache_obj(legacy_payload)
+        )
+
+        out = store.list_decoded_email_info_for_dataset(step, dataset)
+        assert len(out) == 1
+        assert out[0] == indexed_payload

--- a/tests/common/cache/test_dsr_store_strict_index.py
+++ b/tests/common/cache/test_dsr_store_strict_index.py
@@ -197,9 +197,7 @@ class TestNonStrictLegacyAndScan:
 
 
 def _en_email_key(dsr_id: str, step: str, dataset: str, collection: str) -> str:
-    return (
-        f"EN_EMAIL_INFORMATION__{dsr_id}__{step}__{dataset}__{collection}"
-    )
+    return f"EN_EMAIL_INFORMATION__{dsr_id}__{step}__{dataset}__{collection}"
 
 
 @pytest.mark.unit
@@ -243,7 +241,9 @@ class TestListEmailInfoLegacyEnScan:
         dsr_id = "pri_test_email_nonstrict"
         step, dataset, coll = "access", "postgres", "addresses"
         payload = {"step": step, "collection": None, "action_needed": None}
-        mock_redis.set(_en_email_key(dsr_id, step, dataset, coll), encode_cache_obj(payload))
+        mock_redis.set(
+            _en_email_key(dsr_id, step, dataset, coll), encode_cache_obj(payload)
+        )
 
         store = DSRCacheStore(dsr_id, manager)
         out = store.list_decoded_email_info_for_dataset(step, dataset)
@@ -266,7 +266,11 @@ class TestListEmailInfoLegacyEnScan:
         dsr_id = "pri_test_email_dedupe"
         step, dataset, coll = "access", "crm", "contacts"
         indexed_payload = {"step": step, "collection": None, "action_needed": None}
-        legacy_payload = {"step": step, "collection": {"dataset": "x"}, "action_needed": None}
+        legacy_payload = {
+            "step": step,
+            "collection": {"dataset": "x"},
+            "action_needed": None,
+        }
 
         store = DSRCacheStore(dsr_id, manager)
         store.write_encoded_email_info(step, dataset, coll, indexed_payload, _TTL)

--- a/tests/common/cache/test_dsr_store_strict_index.py
+++ b/tests/common/cache/test_dsr_store_strict_index.py
@@ -1,0 +1,195 @@
+"""
+Tests for ``redis.dsr_cache_strict_index`` (DSRCacheStore listing without keyspace SCAN).
+
+When strict index mode is enabled, ``get_all_keys`` and helpers that depend on it
+must not call ``scan_iter``. Legacy key *reads* still migrate via ``get_*`` paths.
+When strict mode is off, ``get_all_keys`` may SCAN to discover unindexed legacy keys.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Tuple
+
+import pytest
+
+from fides.common.cache import dsr_store as dsr_store_module
+from fides.common.cache.dsr_store import DSRCacheStore
+from fides.common.cache.manager import RedisCacheManager
+
+_TTL = 3600
+
+
+def _make_legacy_key(dsr_id: str, field_type: str, field_name: str = "") -> str:
+    if field_name:
+        return f"id-{dsr_id}-{field_type}-{field_name}"
+    return f"id-{dsr_id}-{field_type}"
+
+
+def _make_new_key(dsr_id: str, part: str) -> str:
+    return f"dsr:{dsr_id}:{part}"
+
+
+def _wrap_scan_iter(mock_redis: Any) -> List[Tuple[tuple, dict]]:
+    """Record each ``scan_iter`` call; chain to the mock's existing ``side_effect``."""
+    inner = mock_redis.scan_iter.side_effect
+    calls: List[Tuple[tuple, dict]] = []
+
+    def wrapped(*args: Any, **kwargs: Any) -> Any:
+        calls.append((args, kwargs))
+        if callable(inner):
+            return inner(*args, **kwargs)
+        raise RuntimeError(
+            "mock_redis.scan_iter.side_effect must be callable for scan tracking tests"
+        )
+
+    mock_redis.scan_iter.side_effect = wrapped
+    return calls
+
+
+@pytest.mark.unit
+class TestStrictIndexNoScan:
+    """``dsr_cache_strict_index=True`` avoids Redis keyspace scans for listings."""
+
+    def test_get_all_keys_empty_index_no_scan(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_redis: Any,
+        manager: RedisCacheManager,
+    ) -> None:
+        monkeypatch.setattr(
+            dsr_store_module.CONFIG.redis, "dsr_cache_strict_index", True, raising=False
+        )
+        scan_calls = _wrap_scan_iter(mock_redis)
+        dsr_id = "test-pr-strict-empty"
+        store = DSRCacheStore(dsr_id, manager)
+
+        assert store.get_all_keys() == []
+        assert scan_calls == []
+
+    def test_get_all_keys_omits_unindexed_legacy_without_scan(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_redis: Any,
+        manager: RedisCacheManager,
+    ) -> None:
+        monkeypatch.setattr(
+            dsr_store_module.CONFIG.redis, "dsr_cache_strict_index", True, raising=False
+        )
+        scan_calls = _wrap_scan_iter(mock_redis)
+        dsr_id = "test-pr-strict-legacy-list"
+        legacy = _make_legacy_key(dsr_id, "identity", "email")
+        mock_redis.set(legacy, "only-legacy@example.com")
+
+        store = DSRCacheStore(dsr_id, manager)
+        assert store.get_all_keys() == []
+        assert scan_calls == []
+
+    def test_legacy_read_still_migrates_without_scan(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_redis: Any,
+        manager: RedisCacheManager,
+    ) -> None:
+        monkeypatch.setattr(
+            dsr_store_module.CONFIG.redis, "dsr_cache_strict_index", True, raising=False
+        )
+        scan_calls = _wrap_scan_iter(mock_redis)
+        dsr_id = "test-pr-strict-migrate-read"
+        mock_redis.set(
+            _make_legacy_key(dsr_id, "identity", "email"), "migrated@example.com"
+        )
+
+        store = DSRCacheStore(dsr_id, manager)
+        assert store.get_identity("email") == "migrated@example.com"
+        assert (
+            mock_redis.get(_make_new_key(dsr_id, "identity:email"))
+            == "migrated@example.com"
+        )
+        assert mock_redis.get(_make_legacy_key(dsr_id, "identity", "email")) is None
+        assert scan_calls == []
+
+    def test_indexed_operations_and_helpers_no_scan(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_redis: Any,
+        manager: RedisCacheManager,
+    ) -> None:
+        monkeypatch.setattr(
+            dsr_store_module.CONFIG.redis, "dsr_cache_strict_index", True, raising=False
+        )
+        scan_calls = _wrap_scan_iter(mock_redis)
+        dsr_id = "test-pr-strict-helpers"
+        store = DSRCacheStore(dsr_id, manager)
+        store.write_identity("email", "indexed@example.com", _TTL)
+        store.write_custom_field("dept", "Eng", _TTL)
+
+        assert store.get_all_keys()
+        assert store.get_cached_identity_data() == {"email": "indexed@example.com"}
+        assert store.has_cached_identity_data() is True
+        assert store.get_cached_custom_fields() == {"dept": "Eng"}
+        assert store.has_cached_custom_fields() is True
+        store.clear()
+        assert store.get_all_keys() == []
+        assert scan_calls == []
+
+
+@pytest.mark.unit
+class TestNonStrictLegacyAndScan:
+    """With strict index off, legacy migration on read still runs; listings may SCAN."""
+
+    def test_legacy_migrated_on_read_when_not_strict(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_redis: Any,
+        manager: RedisCacheManager,
+    ) -> None:
+        monkeypatch.setattr(
+            dsr_store_module.CONFIG.redis,
+            "dsr_cache_strict_index",
+            False,
+            raising=False,
+        )
+        dsr_id = "test-pr-nonstrict-migrate"
+        mock_redis.set(
+            _make_legacy_key(dsr_id, "identity", "email"), "legacy@example.com"
+        )
+
+        store = DSRCacheStore(dsr_id, manager)
+        assert store.get_identity("email") == "legacy@example.com"
+        assert (
+            mock_redis.get(_make_new_key(dsr_id, "identity:email"))
+            == "legacy@example.com"
+        )
+        assert mock_redis.get(_make_legacy_key(dsr_id, "identity", "email")) is None
+
+    def test_get_all_keys_invokes_scan_for_unindexed_legacy_when_not_strict(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_redis: Any,
+        manager: RedisCacheManager,
+    ) -> None:
+        monkeypatch.setattr(
+            dsr_store_module.CONFIG.redis,
+            "dsr_cache_strict_index",
+            False,
+            raising=False,
+        )
+        scan_calls = _wrap_scan_iter(mock_redis)
+        dsr_id = "test-pr-nonstrict-scan"
+        mock_redis.set(
+            _make_legacy_key(dsr_id, "identity", "email"), "scan@example.com"
+        )
+        mock_redis.set(
+            _make_legacy_key(dsr_id, "identity", "phone_number"), "+15555550100"
+        )
+
+        store = DSRCacheStore(dsr_id, manager)
+        keys = store.get_all_keys()
+
+        assert len(keys) == 2
+        assert scan_calls, (
+            "expected keyspace scan_iter when index is empty and strict is off"
+        )
+        idx_members = mock_redis.smembers(f"__idx:dsr:{dsr_id}")
+        assert _make_legacy_key(dsr_id, "identity", "email") in idx_members
+        assert _make_legacy_key(dsr_id, "identity", "phone_number") in idx_members

--- a/tests/ops/service/privacy_request/test_email_batch_send.py
+++ b/tests/ops/service/privacy_request/test_email_batch_send.py
@@ -23,7 +23,7 @@ from fides.api.service.privacy_request.email_batch_service import (
     EmailExitState,
     send_email_batch,
 )
-from fides.api.util.cache import get_all_cache_keys_for_privacy_request, get_cache
+from fides.api.util.cache import get_cache
 from fides.api.util.lock import redis_lock
 from fides.config import get_config
 from fides.system_integration_link.repository import SystemIntegrationLinkRepository


### PR DESCRIPTION
Remove remaining SCANs when strict indexing mode is enabled (off by default to continue legacy migrations if needed)