### PR TITLE
Add markdown support to policy agent UI

### DIFF
--- a/changelog/8174-agent-chat-markdown.yaml
+++ b/changelog/8174-agent-chat-markdown.yaml
@@ -1,0 +1,4 @@
+type: Added
+description: Added markdown rendering for agent responses in the policy builder chat
+pr: 8174
+labels: []

--- a/clients/admin-ui/.eslintignore
+++ b/clients/admin-ui/.eslintignore
@@ -7,6 +7,7 @@ jest.config.js
 cypress.config.ts
 cypress/screenshots
 .eslintrc*
+__mocks__
 postcss.config.js
 tailwind.config.js
 src/types/api

--- a/clients/admin-ui/__mocks__/fileMock.js
+++ b/clients/admin-ui/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = "test-file-stub";

--- a/clients/admin-ui/__mocks__/styleMock.js
+++ b/clients/admin-ui/__mocks__/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/clients/admin-ui/jest.config.js
+++ b/clients/admin-ui/jest.config.js
@@ -49,7 +49,7 @@ module.exports = {
     ],
   },
   transformIgnorePatterns: [
-    "/node_modules/(?!(react-hotkeys-hook)/)",
+    "/node_modules/(?!(react-hotkeys-hook|@ant-design/x-markdown)/)",
     "^.+\\.module\\.(css|sass|scss)$",
   ],
   watchPathIgnorePatterns: ["node_modules"],

--- a/clients/admin-ui/src/features/access-policies/AccessPolicyEditor.module.scss
+++ b/clients/admin-ui/src/features/access-policies/AccessPolicyEditor.module.scss
@@ -17,12 +17,12 @@
 }
 
 .chatWrapper {
-  width: 350px;
+  width: 400px;
   flex-shrink: 0;
   position: relative;
   z-index: 100;
 
   @media (max-width: 1280px) {
-    width: 300px;
+    width: 350px;
   }
 }

--- a/clients/admin-ui/src/features/access-policies/AgentChatPanel.module.scss
+++ b/clients/admin-ui/src/features/access-policies/AgentChatPanel.module.scss
@@ -3,8 +3,7 @@
   overflow: hidden;
   border-left: 1px solid var(--fidesui-color-border);
 
-
-  & :global(.x-markdown){
+  & :global(.x-markdown) {
     --padding-ul-ol: 0 !important;
     --margin-ul-ol: 0 !important;
 

--- a/clients/admin-ui/src/features/access-policies/AgentChatPanel.module.scss
+++ b/clients/admin-ui/src/features/access-policies/AgentChatPanel.module.scss
@@ -2,6 +2,20 @@
   height: 100%;
   overflow: hidden;
   border-left: 1px solid var(--fidesui-color-border);
+
+
+  & :global(.x-markdown){
+    --padding-ul-ol: 0 !important;
+    --margin-ul-ol: 0 !important;
+
+    // Keep cells single-line so the table grows to its natural width and the
+    // package's `overflow: auto` can show a horizontal scrollbar. Otherwise
+    // Tailwind's `:where(*) { word-wrap: break-word }` shrinks cells to fit.
+    th,
+    td {
+      white-space: nowrap;
+    }
+  }
 }
 
 .header {

--- a/clients/admin-ui/src/features/access-policies/AgentChatPanel.module.scss
+++ b/clients/admin-ui/src/features/access-policies/AgentChatPanel.module.scss
@@ -8,12 +8,16 @@
     --padding-ul-ol: 0 !important;
     --margin-ul-ol: 0 !important;
 
-    // Keep cells single-line so the table grows to its natural width and the
-    // package's `overflow: auto` can show a horizontal scrollbar. Otherwise
-    // Tailwind's `:where(*) { word-wrap: break-word }` shrinks cells to fit.
+    // Let cells wrap at spaces but never break mid-word. The package inherits
+    // `word-break: break-word` onto cell descendants via `.x-markdown div/span`,
+    // and Tailwind's `:where(*)` reapplies `word-wrap: break-word`, so both
+    // need overriding on cells and their children.
     th,
-    td {
-      white-space: nowrap;
+    td,
+    :is(th, td) * {
+      word-break: normal;
+      overflow-wrap: normal;
+      word-wrap: normal;
     }
   }
 }

--- a/clients/admin-ui/src/features/access-policies/AgentChatPanel.tsx
+++ b/clients/admin-ui/src/features/access-policies/AgentChatPanel.tsx
@@ -7,6 +7,7 @@ import {
   Sender,
   Typography,
   useMessage,
+  XMarkdown,
 } from "fidesui";
 import { useCallback, useMemo, useRef, useState } from "react";
 
@@ -45,6 +46,12 @@ const AgentAvatar = () => (
     className={styles.agentAvatar}
     icon={<AgentLogoMark size={15} />}
   />
+);
+
+const renderAgentMarkdown = (content: string) => (
+  <Typography>
+    <XMarkdown escapeRawHtml openLinksInNewTab content={content} />
+  </Typography>
 );
 
 const AgentChatPanel = ({
@@ -157,6 +164,7 @@ const AgentChatPanel = ({
         placement: "start" as const,
         variant: "outlined" as const,
         avatar: <AgentAvatar />,
+        contentRender: renderAgentMarkdown,
       },
     }),
     [],

--- a/clients/fidesui/package.json
+++ b/clients/fidesui/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@ant-design/x": "^2.5.0",
+    "@ant-design/x-markdown": "^2.7.0",
     "@carbon/icons-react": "^11.51.0",
     "@chakra-ui/icons": "^2.1.1",
     "@chakra-ui/react": "^2.8.2",

--- a/clients/fidesui/src/index.ts
+++ b/clients/fidesui/src/index.ts
@@ -449,6 +449,10 @@ export { theme as antTheme } from "antd/lib";
 export type { BubbleItemType } from "@ant-design/x/lib/bubble";
 export { default as Bubble } from "@ant-design/x/lib/bubble";
 export { default as Sender } from "@ant-design/x/lib/sender";
+// Use the ESM entry (es/) — Turbopack's CJS path errors on the package's
+// deep `require("./*.css")` calls with "module factory is not available".
+// Jest's transformIgnorePatterns must allow this package through babel-jest.
+export { default as XMarkdown } from "@ant-design/x-markdown/es";
 
 /**
  * Custom ChakraUI Components (deprecated)

--- a/clients/package-lock.json
+++ b/clients/package-lock.json
@@ -1284,6 +1284,7 @@
     "fidesui": {
       "dependencies": {
         "@ant-design/x": "^2.5.0",
+        "@ant-design/x-markdown": "^2.7.0",
         "@carbon/icons-react": "^11.51.0",
         "@chakra-ui/icons": "^2.1.1",
         "@chakra-ui/react": "^2.8.2",
@@ -2608,6 +2609,44 @@
         "antd": "^6.1.1",
         "react": ">=18.0.0",
         "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@ant-design/x-markdown": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/x-markdown/-/x-markdown-2.7.0.tgz",
+      "integrity": "sha512-tmuwbeulTD5nfO15VCb3mN13iCTT106626dVFxGjhj1tWnmLL+fIngyv3U8SOTq94+Baor6QdSWtPZluVKCIbw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1",
+        "dompurify": "^3.2.6",
+        "html-react-parser": "^5.2.13",
+        "katex": "^0.16.22",
+        "marked": "^15.0.12"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@ant-design/x-markdown/node_modules/dompurify": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.3.tgz",
+      "integrity": "sha512-VVwJidIJcp1hpg2OMXML3ZVRPYSZiq4aX7qBh83BSIpOaRDqI+qxhXjjIWnpzkOXhmp0L81lnoME1mnCc9H48A==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/@ant-design/x-markdown/node_modules/marked": {
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/@ant-design/x/node_modules/@types/hast": {
@@ -6662,7 +6701,6 @@
       "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
       "hasInstallScript": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "detect-libc": "^1.0.3",
         "is-glob": "^4.0.3",
@@ -6703,7 +6741,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -6723,7 +6760,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -6743,7 +6779,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -6763,7 +6798,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -6783,7 +6817,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -6803,7 +6836,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -6823,7 +6855,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -6843,7 +6874,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -6863,7 +6893,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -6883,7 +6912,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -6903,7 +6931,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -6923,7 +6950,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -6943,7 +6969,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -7959,7 +7984,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -7972,7 +7996,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -7985,7 +8008,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -7998,7 +8020,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -8011,7 +8032,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -8024,7 +8044,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -8037,7 +8056,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -8050,7 +8068,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -8063,7 +8080,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -8076,7 +8092,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -8089,7 +8104,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -8102,7 +8116,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -8115,7 +8128,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -8128,7 +8140,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -8141,7 +8152,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -8154,7 +8164,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -8167,7 +8176,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -8180,7 +8188,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -8193,7 +8200,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -8206,7 +8212,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
@@ -8219,7 +8224,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "openharmony"
@@ -8232,7 +8236,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -8245,7 +8248,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -8258,7 +8260,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -8271,7 +8272,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -14339,7 +14339,6 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
       "optional": true,
-      "peer": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
       },
@@ -14727,7 +14726,6 @@
       "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "prr": "~1.0.1"
       },
@@ -16843,7 +16841,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -17463,6 +17460,108 @@
         "node": ">=12"
       }
     },
+    "node_modules/html-dom-parser": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-5.1.8.tgz",
+      "integrity": "sha512-MCIUng//mF2qTtGHXJWr6OLfHWmg3Pm8ezpfiltF83tizPWY17JxT4dRLE8lykJ5bChJELoY3onQKPbufJHxYA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/remarkablemark"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "5.0.3",
+        "htmlparser2": "10.1.0"
+      }
+    },
+    "node_modules/html-dom-parser/node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/html-dom-parser/node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/html-dom-parser/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/html-dom-parser/node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/html-dom-parser/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/html-dom-parser/node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
@@ -17480,6 +17579,52 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "node_modules/html-react-parser": {
+      "version": "5.2.17",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-5.2.17.tgz",
+      "integrity": "sha512-m+K/7Moq1jodAB4VL0RXSOmtwLUYoAsikZhwd+hGQe5Vtw2dbWfpFd60poxojMU0Tsh9w59mN1QLEcoHz0Dx9w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/remarkablemark"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/html-react-parser"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "5.0.3",
+        "html-dom-parser": "5.1.8",
+        "react-property": "2.0.2",
+        "style-to-js": "1.1.21"
+      },
+      "peerDependencies": {
+        "@types/react": "0.14 || 15 || 16 || 17 || 18 || 19",
+        "react": "0.14 || 15 || 16 || 17 || 18 || 19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/html-react-parser/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
     },
     "node_modules/htmlparser2": {
       "version": "8.0.2",
@@ -17731,7 +17876,6 @@
       "integrity": "sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "bin": {
         "image-size": "bin/image-size.js"
       },
@@ -17866,6 +18010,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
     },
     "node_modules/input-format": {
       "version": "0.3.14",
@@ -20162,7 +20312,6 @@
       "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "pify": "^4.0.1",
         "semver": "^5.6.0"
@@ -20177,7 +20326,6 @@
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -20188,7 +20336,6 @@
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -20199,7 +20346,6 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -21928,7 +22074,6 @@
       "integrity": "sha512-6k0YULvhpw+RoLNiQCRKOl09Rv1dPLr8hHnVjHqdolKwDrdNyk+Hmrthi4lIGPPz3r39dLx0hsF5s40sZ3Us4Q==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "iconv-lite": "^0.6.3",
         "sax": "^1.2.4"
@@ -21946,7 +22091,6 @@
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -22059,8 +22203,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
@@ -24334,8 +24477,7 @@
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
       "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/psl": {
       "version": "1.15.0",
@@ -24745,6 +24887,12 @@
         "react": ">=16.8",
         "react-dom": ">=16.8"
       }
+    },
+    "node_modules/react-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.2.tgz",
+      "integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==",
+      "license": "MIT"
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
@@ -25904,8 +26052,7 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
       "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -26954,6 +27101,24 @@
       "resolved": "https://registry.npmjs.org/style-inject/-/style-inject-0.3.0.tgz",
       "integrity": "sha512-IezA2qp+vcdlhJaVm5SOdPPTUu0FCEqfNSli2vRuSIBbu5Nq5UvygTk/VzeCqfLz2Atj3dVII5QBKGZRZ0edzw==",
       "dev": true
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
+      }
     },
     "node_modules/styled-jsx": {
       "version": "5.1.6",


### PR DESCRIPTION
Ticket [ENG-3782]

### Description Of Changes

Adds markdown rendering to agent responses in the policy builder agent chat. Until now the agent's replies rendered as plain text, so anything the LLM emitted with structure — headings, bullet/numbered lists, inline code, bold, links, fenced code blocks, tables — showed up as raw characters. This PR routes agent (AI-role) bubble content through `@ant-design/x-markdown`'s `XMarkdown` component, wrapped in antd `Typography` so rendered elements inherit the design system's text styles.

User-role bubbles are unchanged — rendering user input as markdown would mangle accidental special characters in their prompts.

Notable details:

- **Why a new dep.** Admin-ui had no markdown renderer, and `@ant-design/x` (already in `fidesui`) doesn't ship one — `@ant-design/x-markdown` is a separate package by the same authors. It bundles `marked` + `dompurify`, so output is sanitized by default.
- **ESM entry, not CJS.** `fidesui` re-exports `XMarkdown` from `@ant-design/x-markdown/es`. The `/lib` (CJS) build does deep `require("./*.css")` calls that Turbopack errors on with "module factory is not available". The ESM build's `import "./*.css"` goes through Next's CSS pipeline cleanly. To keep Jest happy with raw ESM in node_modules, the package is added to `jest.config.js` `transformIgnorePatterns` so babel-jest transforms it.
- **`escapeRawHtml` enabled.** Raw HTML in markdown is rendered as plain text rather than parsed — defense in depth against the agent emitting `<script>` or other unintended tags, on top of the package's built-in DOMPurify sanitization.
- **Table styling.** The package renders markdown tables with `display: block; width: max-content; max-width: 100%; overflow: auto` so they can scroll horizontally. Tailwind's preflight (`:where(*) { word-wrap: break-word }`) and the package's own `.x-markdown div/span/li { word-break: break-word }` were collapsing cell content (including inline `<strong>`) so the table never grew wide enough to trigger overflow. A small override on table cells + descendants restores natural wrapping (`word-break: normal; overflow-wrap: normal`), so prose cells wrap at word boundaries and long unbreakable runs (URLs, identifiers) force the horizontal scroll the package already supports.
- **Chat panel widened** from 350px → 400px (and 300px → 350px at the `<1280px` breakpoint) so rendered lists, code blocks, and tables have a bit more breathing room.

### Code Changes

- Added `@ant-design/x-markdown` to `clients/fidesui/package.json` and re-exported `XMarkdown` from `clients/fidesui/src/index.ts` via the ESM (`/es`) entry.
- Updated `clients/admin-ui/jest.config.js` `transformIgnorePatterns` to allow babel-jest to transform `@ant-design/x-markdown`.
- Wired `XMarkdown` into `AgentChatPanel.tsx` via the `ai` role's `contentRender`. The renderer is hoisted to module scope to satisfy `react/no-unstable-nested-components`. Passes `escapeRawHtml` for safety.
- Added scoped `.x-markdown` styles in `AgentChatPanel.module.scss` to zero out the default list padding/margin and to fix table-cell wrapping so horizontal scroll triggers when needed.
- Widened the chat wrapper in `AccessPolicyEditor.module.scss` to fit richer content.

### Steps to Confirm

1. Open the access-policy editor and start a conversation with the policy builder agent.
2. Send a prompt that nudges the agent to produce structured output — e.g. "Write a policy that denies third party uses. Explain everything in detail using lots of markdown."
3. Verify in the agent bubble:
   - Headings, bold, italics, and inline `code` render as styled elements (not raw `**...**` etc.).
   - Bullet/numbered lists render with markers.
   - Links are clickable.
   - Fenced code blocks render with monospace/background.
   - Tables render with borders, and if the table is wider than the bubble, a horizontal scrollbar appears inside the bubble (the table doesn't blow out the panel width).
4. Ask the agent to include `<script>alert(1)</script>` in its reply. Confirm it renders as visible text rather than executing.
5. Resize the window narrow (≤1280px) and confirm the chat panel reflows to 350px and content still renders correctly.

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [x] No migrations
* Documentation:
  * [x] No documentation updates required


[ENG-3782]: https://ethyca.atlassian.net/browse/ENG-3782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ