### PR TITLE
ENG-3566: Add DBCredentialProvider for dynamic credential resolution

### DIFF
--- a/changelog/8175-db-credential-provider.yaml
+++ b/changelog/8175-db-credential-provider.yaml
@@ -1,0 +1,4 @@
+type: Added
+description: Add DBCredentialProvider for dynamic database credential resolution via AWS Secrets Manager
+pr: 8175
+labels: []

--- a/src/fides/common/db_credential_provider.py
+++ b/src/fides/common/db_credential_provider.py
@@ -62,12 +62,18 @@ class DBCredentialProvider:
         For static provider: uses the well-known default keys.
         """
         if self.is_dynamic:
+            credential_secret_id = CONFIG.database.credential_secret_id
+            if credential_secret_id is None:
+                raise ValueError(
+                    "secrets.provider is not 'static' but "
+                    "database.credential_secret_id is not set."
+                )
             if readonly:
                 return (
                     CONFIG.database.readonly_credential_secret_id
-                    or CONFIG.database.credential_secret_id
+                    or credential_secret_id
                 )
-            return CONFIG.database.credential_secret_id
+            return credential_secret_id
         else:
             if readonly and CONFIG.database.readonly_server:
                 return DATABASE_READONLY_CREDENTIALS_KEY

--- a/src/fides/common/db_credential_provider.py
+++ b/src/fides/common/db_credential_provider.py
@@ -1,0 +1,204 @@
+"""Database credential resolution with retry-on-auth-failure and exception sanitization.
+
+DBCredentialProvider sits between SQLAlchemy engine creators and the SecretProvider
+abstraction.  It resolves credentials (from static config or a secret store), wraps
+connection attempts with a single retry on authentication failure during credential
+rotation, and sanitizes all connection exceptions to prevent credential leakage.
+
+Driver-agnostic: does not import psycopg2 or asyncpg.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Callable, Dict, Optional, TypeVar
+
+from loguru import logger as log
+
+from fides.config import CONFIG
+from fides.config.secrets import StaticSecretProvider, get_secret_provider
+from fides.config.secrets.static_provider import (
+    DATABASE_CREDENTIALS_KEY,
+    DATABASE_READONLY_CREDENTIALS_KEY,
+)
+
+T = TypeVar("T")
+
+_AUTH_SQLSTATES = frozenset({"28P01", "28000"})
+_AUTH_RETRY_DELAY = 1.5  # seconds — propagation window for AWS rotation
+
+
+class SanitizedConnectionError(Exception):
+    """Connection error with credentials stripped. Safe to log and report."""
+
+    __slots__ = ("sqlstate",)
+
+    def __init__(self, message: str, sqlstate: Optional[str] = None) -> None:
+        super().__init__(message)
+        self.sqlstate = sqlstate
+
+
+class DBCredentialProvider:
+    """Resolves database credentials and wraps connection attempts
+    with retry-on-auth-failure and exception sanitization.
+    """
+
+    def __init__(self) -> None:
+        self._provider = get_secret_provider()
+
+    # ------------------------------------------------------------------
+    # Credential resolution
+    # ------------------------------------------------------------------
+
+    @property
+    def is_dynamic(self) -> bool:
+        """True when using a non-static provider (credentials can rotate)."""
+        return not isinstance(self._provider, StaticSecretProvider)
+
+    def _get_secret_id(self, readonly: bool) -> str:
+        """Resolve which secret ID to use.
+
+        For dynamic providers: uses configured secret IDs with readonly -> primary fallback.
+        For static provider: uses the well-known default keys.
+        """
+        if self.is_dynamic:
+            if readonly:
+                return (
+                    CONFIG.database.readonly_credential_secret_id
+                    or CONFIG.database.credential_secret_id
+                )
+            return CONFIG.database.credential_secret_id
+        else:
+            if readonly and CONFIG.database.readonly_server:
+                return DATABASE_READONLY_CREDENTIALS_KEY
+            return DATABASE_CREDENTIALS_KEY
+
+    def get_credentials(self, readonly: bool = False) -> Dict[str, Any]:
+        """Return ``{host, port, user, password, dbname}`` for a database connection."""
+        db = CONFIG.database
+
+        # Host, port, dbname always from config
+        creds = {
+            "host": db.server,
+            "port": int(db.port),
+            "dbname": db.test_db if CONFIG.test_mode else db.db,
+        }
+        if readonly and db.readonly_server:
+            creds["host"] = db.readonly_server
+            creds["port"] = int(db.readonly_port or db.port)
+            creds["dbname"] = db.readonly_db or db.db
+
+        # Get credentials (user/password) from the provider
+        secret = self._provider.get_secret(self._get_secret_id(readonly))
+        creds["user"] = secret["username"]
+        creds["password"] = secret["password"]
+
+        return creds
+
+    # ------------------------------------------------------------------
+    # Connection with retry
+    # ------------------------------------------------------------------
+
+    def connect_with_retry(
+        self,
+        connect_fn: Callable[..., T],
+        connect_kwargs: Dict[str, Any],
+        readonly: bool = False,
+    ) -> T:
+        """Attempt a connection; on auth failure with dynamic credentials, retry once.
+
+        Args:
+            connect_fn: Driver connect callable (e.g. ``psycopg2.connect``).
+            connect_kwargs: Non-credential connection kwargs (keepalives, SSL).
+                Credentials are merged in from ``get_credentials()``.
+            readonly: Whether to use readonly credentials.
+
+        Returns:
+            The raw connection object.
+
+        Raises:
+            SanitizedConnectionError: On any connection failure, with
+                connection parameters stripped from the exception message.
+        """
+        creds = self.get_credentials(readonly=readonly)
+        kwargs = {**connect_kwargs, **creds}
+
+        try:
+            return connect_fn(**kwargs)
+        except Exception as exc:
+            if self.is_dynamic and self._is_auth_error(exc):
+                return self._retry_with_fresh_credentials(
+                    connect_fn, connect_kwargs, readonly, exc
+                )
+            raise self._sanitize_exception(exc) from None
+
+    def _retry_with_fresh_credentials(
+        self,
+        connect_fn: Callable[..., T],
+        connect_kwargs: Dict[str, Any],
+        readonly: bool,
+        original_exc: Exception,
+    ) -> T:
+        """Invalidate the cached secret, wait for propagation, retry once."""
+        secret_id = self._get_secret_id(readonly)
+
+        log.warning(
+            "Auth failure (SQLSTATE {}), invalidating secret {!r} and retrying",
+            self._extract_sqlstate(original_exc),
+            secret_id,
+        )
+        self._provider.invalidate(secret_id)
+
+        time.sleep(_AUTH_RETRY_DELAY)
+
+        fresh_creds = self.get_credentials(readonly=readonly)
+        kwargs = {**connect_kwargs, **fresh_creds}
+
+        try:
+            return connect_fn(**kwargs)
+        except Exception as exc:
+            log.error(
+                "Retry also failed (SQLSTATE {}), credentials may be wrong",
+                self._extract_sqlstate(exc),
+            )
+            raise self._sanitize_exception(exc) from None
+
+    # ------------------------------------------------------------------
+    # Error detection and sanitization
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _is_auth_error(exc: Exception) -> bool:
+        """Detect PostgreSQL authentication errors.
+
+        Checks SQLSTATE codes first (asyncpg always provides these).
+        Falls back to message matching for psycopg2, which does not
+        populate pgcode on connection-time errors.  The fallback string
+        comes from PostgreSQL's auth handshake, which is always English
+        (sent before any locale is configured).
+        """
+        if DBCredentialProvider._extract_sqlstate(exc) in _AUTH_SQLSTATES:
+            return True
+        return "password authentication failed" in str(exc).lower()
+
+    @staticmethod
+    def _extract_sqlstate(exc: Exception) -> Optional[str]:
+        """Extract SQLSTATE from a driver exception for logging."""
+        return getattr(exc, "pgcode", None) or getattr(exc, "sqlstate", None)
+
+    @staticmethod
+    def _sanitize_exception(exc: Exception) -> SanitizedConnectionError:
+        """Replace a driver exception with a sanitized version.
+
+        Constructs a new exception containing only the exception type name
+        and SQLSTATE code.  Raised with ``from None`` by callers to break
+        the exception chain and prevent credential leakage through error
+        reporters that serialize ``__cause__``.
+        """
+        sqlstate = DBCredentialProvider._extract_sqlstate(exc)
+        exc_type = type(exc).__name__
+        if sqlstate:
+            msg = f"Database connection failed: {exc_type} (SQLSTATE {sqlstate})"
+        else:
+            msg = f"Database connection failed: {exc_type}"
+        return SanitizedConnectionError(msg, sqlstate=sqlstate)

--- a/src/fides/common/db_credential_provider.py
+++ b/src/fides/common/db_credential_provider.py
@@ -22,6 +22,8 @@ from fides.config.secrets.static_provider import (
     DATABASE_READONLY_CREDENTIALS_KEY,
 )
 
+__all__ = ["DBCredentialProvider", "SanitizedConnectionError"]
+
 T = TypeVar("T")
 
 _AUTH_SQLSTATES = frozenset({"28P01", "28000"})
@@ -155,6 +157,9 @@ class DBCredentialProvider:
         )
         self._provider.invalidate(secret_id)
 
+        # Safe in both sync and async paths: async engine creators run inside
+        # SQLAlchemy's greenlet bridge, so time.sleep blocks the greenlet, not
+        # the event loop (same mechanism as await_only(asyncpg.connect(...))).
         time.sleep(_AUTH_RETRY_DELAY)
 
         fresh_creds = self.get_credentials(readonly=readonly)

--- a/src/fides/config/__init__.py
+++ b/src/fides/config/__init__.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, Optional, Tuple, Type, Union
 
 import toml
 from loguru import logger as log
-from pydantic import ConfigDict, Field
+from pydantic import ConfigDict, Field, model_validator
 from pydantic_settings import (
     BaseSettings,
     PydanticBaseSettingsSource,
@@ -92,6 +92,31 @@ class FidesConfig(FidesSettings):
     user: UserSettings
 
     model_config = SettingsConfigDict(case_sensitive=True)
+
+    @model_validator(mode="after")
+    def _validate_database_credential_secret_ids(self) -> "FidesConfig":
+        """Validate database credential secret IDs against the secrets provider."""
+        if self.secrets.provider == "static":
+            if self.database.credential_secret_id:
+                raise ValueError(
+                    f"database.credential_secret_id is set ({self.database.credential_secret_id!r}) "
+                    "but secrets.provider is 'static'. Either remove the secret ID "
+                    "or set secrets.provider to 'aws_secrets_manager'."
+                )
+            if self.database.readonly_credential_secret_id:
+                raise ValueError(
+                    f"database.readonly_credential_secret_id is set ({self.database.readonly_credential_secret_id!r}) "
+                    "but secrets.provider is 'static'. Either remove the secret ID "
+                    "or set secrets.provider to 'aws_secrets_manager'."
+                )
+        else:
+            if not self.database.credential_secret_id:
+                raise ValueError(
+                    f"secrets.provider is {self.secrets.provider!r} but "
+                    "database.credential_secret_id is not set. "
+                    "Provide the secret name/ARN containing database credentials."
+                )
+        return self
 
     @classmethod
     def settings_customise_sources(

--- a/src/fides/config/create.py
+++ b/src/fides/config/create.py
@@ -74,6 +74,7 @@ def build_field_documentation(field_name: str, field_info: Dict) -> Optional[str
                 if "$ref" in type_annotation:
                     continue
                 if type_annotation.get("type") != "null":
+                    # Getting first non-null
                     field_type = type_annotation["type"]
                     break
 

--- a/src/fides/config/create.py
+++ b/src/fides/config/create.py
@@ -71,8 +71,9 @@ def build_field_documentation(field_name: str, field_info: Dict) -> Optional[str
             # Union field types are under "anyOf"
             any_of: List[Dict[str, str]] = field_info.get("anyOf") or []
             for type_annotation in any_of:
-                if type_annotation["type"] != "null":
-                    # Getting first non-null
+                if "$ref" in type_annotation:
+                    continue
+                if type_annotation.get("type") != "null":
                     field_type = type_annotation["type"]
                     break
 

--- a/src/fides/config/database_settings.py
+++ b/src/fides/config/database_settings.py
@@ -118,6 +118,15 @@ class DatabaseSettings(FidesSettings):
         description="Additional connection parameters for read-only database connections. If not provided and readonly_server is set, uses 'params'.",
     )
 
+    credential_secret_id: Optional[str] = Field(
+        default=None,
+        description="Secrets Manager secret name or ARN containing DB credentials (JSON with 'username' and 'password' keys). Used when secrets.provider is 'aws_secrets_manager'.",
+    )
+    readonly_credential_secret_id: Optional[str] = Field(
+        default=None,
+        description="Secrets Manager secret name or ARN for read-only DB credentials. Falls back to credential_secret_id if not set.",
+    )
+
     task_engine_pool_size: int = Field(
         default=50,
         description="Number of concurrent database connections Fides will use for executing privacy request tasks, either locally or on each worker. Note that the pool begins with no connections, but as they are requested the connections are maintained and reused up to this limit.",

--- a/src/fides/config/secrets/__init__.py
+++ b/src/fides/config/secrets/__init__.py
@@ -25,6 +25,15 @@ def get_secret_provider() -> SecretProvider:
     return _provider
 
 
+def reset_secret_provider() -> None:
+    """Reset the singleton to ``None``, forcing re-creation on next access.
+
+    Intended for testing only.
+    """
+    global _provider
+    _provider = None
+
+
 __all__ = [
     "AWSSecretsManagerProvider",
     "SecretProvider",
@@ -33,4 +42,5 @@ __all__ = [
     "StaticSecretProvider",
     "create_secret_provider",
     "get_secret_provider",
+    "reset_secret_provider",
 ]

--- a/src/fides/config/secrets/__init__.py
+++ b/src/fides/config/secrets/__init__.py
@@ -1,11 +1,29 @@
 """Secret provider abstraction for dynamically-resolved credentials."""
 
+from typing import Optional
+
+from fides.config import CONFIG
 from fides.config.secrets.aws_secrets_manager_provider import (
     AWSSecretsManagerProvider,
 )
 from fides.config.secrets.base import SecretProvider, SecretProviderError, SecretValue
 from fides.config.secrets.factory import create_secret_provider
 from fides.config.secrets.static_provider import StaticSecretProvider
+
+_provider: Optional[SecretProvider] = None
+
+
+def get_secret_provider() -> SecretProvider:
+    """Return the application-wide SecretProvider singleton.
+
+    Created lazily on first access from ``CONFIG.secrets``.  All consumers
+    share one instance so the credential cache is coherent.
+    """
+    global _provider
+    if _provider is None:
+        _provider = create_secret_provider(CONFIG.secrets)
+    return _provider
+
 
 __all__ = [
     "AWSSecretsManagerProvider",
@@ -14,4 +32,5 @@ __all__ = [
     "SecretValue",
     "StaticSecretProvider",
     "create_secret_provider",
+    "get_secret_provider",
 ]

--- a/src/fides/config/secrets/aws_secrets_manager_provider.py
+++ b/src/fides/config/secrets/aws_secrets_manager_provider.py
@@ -147,7 +147,7 @@ class AWSSecretsManagerProvider(SecretProvider):
 
     def _fetch(self, secret_id: str) -> SecretValue:
         """Call AWS Secrets Manager and parse the response."""
-        log.info("Fetching secret {!r} from AWS Secrets Manager", secret_id)
+        log.debug("Fetching secret {!r} from AWS Secrets Manager", secret_id)
         response = self._client.get_secret_value(
             SecretId=secret_id,
             VersionStage="AWSCURRENT",

--- a/src/fides/config/secrets/aws_secrets_manager_provider.py
+++ b/src/fides/config/secrets/aws_secrets_manager_provider.py
@@ -142,10 +142,12 @@ class AWSSecretsManagerProvider(SecretProvider):
         entry.value = new_value
         entry.fetched_at = time.monotonic()
         entry.last_failed_at = 0.0
+        log.info("Successfully fetched and cached secret {!r}", secret_id)
         return new_value
 
     def _fetch(self, secret_id: str) -> SecretValue:
         """Call AWS Secrets Manager and parse the response."""
+        log.info("Fetching secret {!r} from AWS Secrets Manager", secret_id)
         response = self._client.get_secret_value(
             SecretId=secret_id,
             VersionStage="AWSCURRENT",

--- a/src/fides/config/secrets/factory.py
+++ b/src/fides/config/secrets/factory.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict
+from typing import TYPE_CHECKING
 
 from loguru import logger as log
 
@@ -18,20 +18,17 @@ if TYPE_CHECKING:
 
 def create_secret_provider(
     secrets_settings: SecretsSettings,
-    static_secrets: Dict[str, Dict[str, Any]] | None = None,
 ) -> SecretProvider:
     """Instantiate the configured secret provider.
 
     Args:
         secrets_settings: The ``[secrets]`` config section.
-        static_secrets: Secret ID → key/value mapping for the static provider.
-            Ignored when the provider is not ``"static"``.
     """
     provider_type = secrets_settings.provider
 
     if provider_type == "static":
         log.info("Using static secret provider")
-        return StaticSecretProvider(secrets=static_secrets or {})
+        return StaticSecretProvider()
 
     if provider_type == "aws_secrets_manager":
         aws = secrets_settings.aws_secrets_manager

--- a/src/fides/config/secrets/factory.py
+++ b/src/fides/config/secrets/factory.py
@@ -32,6 +32,11 @@ def create_secret_provider(
 
     if provider_type == "aws_secrets_manager":
         aws = secrets_settings.aws_secrets_manager
+        if aws is None:
+            raise SecretProviderError(
+                "secrets.provider is 'aws_secrets_manager' but "
+                "secrets.aws_secrets_manager is not configured."
+            )
         log.info(
             "Using AWS Secrets Manager provider (region={})",
             aws.region,

--- a/src/fides/config/secrets/static_provider.py
+++ b/src/fides/config/secrets/static_provider.py
@@ -1,23 +1,42 @@
-"""Static secret provider — returns fixed values from config."""
+"""Static secret provider — caches credentials from config at construction time."""
 
 from typing import Any, Dict
 
 from loguru import logger as log
 
+from fides.config import CONFIG
 from fides.config.secrets.base import SecretProvider, SecretProviderError, SecretValue
+
+DATABASE_CREDENTIALS_KEY = "_db_credentials"
+DATABASE_READONLY_CREDENTIALS_KEY = "_db_readonly_credentials"
 
 
 class StaticSecretProvider(SecretProvider):
-    """Returns pre-configured secret values. Used for static credentials
-    (environment variables / TOML config) where rotation is not needed.
+    """Returns credentials read from config at construction time.
+
+    Used for static credentials (environment variables / TOML config)
+    where rotation is not needed.  Reads ``CONFIG.database`` once and
+    caches the values as ``SecretValue`` objects under well-known keys.
     """
 
-    def __init__(self, secrets: Dict[str, Dict[str, Any]]) -> None:
-        self._secrets = secrets
+    def __init__(self) -> None:
+        db = CONFIG.database
+        self._secrets: Dict[str, SecretValue] = {
+            DATABASE_CREDENTIALS_KEY: SecretValue(
+                {"username": db.user, "password": db.raw_password}
+            ),
+        }
+        if db.readonly_server:
+            self._secrets[DATABASE_READONLY_CREDENTIALS_KEY] = SecretValue(
+                {
+                    "username": db.readonly_user,
+                    "password": db.raw_readonly_password,
+                }
+            )
 
     def get_secret(self, secret_id: str) -> SecretValue:
         try:
-            return SecretValue(self._secrets[secret_id])
+            return self._secrets[secret_id]
         except KeyError:
             raise SecretProviderError(f"Unknown secret_id: {secret_id!r}") from None
 

--- a/src/fides/config/secrets/static_provider.py
+++ b/src/fides/config/secrets/static_provider.py
@@ -1,6 +1,6 @@
 """Static secret provider — caches credentials from config at construction time."""
 
-from typing import Any, Dict
+from typing import Dict
 
 from loguru import logger as log
 

--- a/src/fides/config/secrets_settings.py
+++ b/src/fides/config/secrets_settings.py
@@ -14,7 +14,6 @@ class AWSSecretsManagerSettings(FidesSettings):
     """Configuration for the AWS Secrets Manager provider."""
 
     region: str = Field(
-        default="us-east-1",
         description="AWS region for Secrets Manager.",
     )
     cache_ttl_seconds: float = Field(
@@ -53,12 +52,20 @@ class SecretsSettings(FidesSettings):
 
     model_config = SettingsConfigDict(env_prefix=ENV_PREFIX)
 
-    @model_validator(mode="after")
-    def _validate_aws_config(self) -> "SecretsSettings":
-        """Require aws_secrets_manager settings when provider is 'aws_secrets_manager'."""
-        if self.provider == "aws_secrets_manager" and not self.aws_secrets_manager:
-            raise ValueError(
-                "secrets.provider is 'aws_secrets_manager' but "
-                "secrets.aws_secrets_manager is not configured."
-            )
-        return self
+    @model_validator(mode="before")
+    @classmethod
+    def _build_aws_settings_if_needed(cls, values: dict) -> dict:
+        """Construct AWS settings from env vars when provider is aws but no config was provided."""
+        if values.get("provider") == "aws_secrets_manager" and not values.get(
+            "aws_secrets_manager"
+        ):
+            try:
+                values["aws_secrets_manager"] = AWSSecretsManagerSettings()
+            except Exception:
+                raise ValueError(
+                    "secrets.provider is 'aws_secrets_manager' but "
+                    "secrets.aws_secrets_manager is not configured. "
+                    "Provide the configuration via TOML or environment variables "
+                    "(e.g. FIDES__SECRETS__AWS_SECRETS_MANAGER__REGION)."
+                )
+        return values

--- a/src/fides/config/secrets_settings.py
+++ b/src/fides/config/secrets_settings.py
@@ -2,7 +2,7 @@
 
 from typing import Literal, Optional
 
-from pydantic import Field
+from pydantic import Field, model_validator
 from pydantic_settings import SettingsConfigDict
 
 from .fides_settings import FidesSettings
@@ -46,8 +46,19 @@ class SecretsSettings(FidesSettings):
         default="static",
         description="Which secret provider to use: 'static' or 'aws_secrets_manager'.",
     )
-    aws_secrets_manager: AWSSecretsManagerSettings = Field(
-        default_factory=AWSSecretsManagerSettings,
+    aws_secrets_manager: Optional[AWSSecretsManagerSettings] = Field(
+        default=None,
+        description="AWS Secrets Manager configuration. Required when provider is 'aws_secrets_manager'.",
     )
 
     model_config = SettingsConfigDict(env_prefix=ENV_PREFIX)
+
+    @model_validator(mode="after")
+    def _validate_aws_config(self) -> "SecretsSettings":
+        """Require aws_secrets_manager settings when provider is 'aws_secrets_manager'."""
+        if self.provider == "aws_secrets_manager" and not self.aws_secrets_manager:
+            raise ValueError(
+                "secrets.provider is 'aws_secrets_manager' but "
+                "secrets.aws_secrets_manager is not configured."
+            )
+        return self

--- a/src/fides/config/secrets_settings.py
+++ b/src/fides/config/secrets_settings.py
@@ -17,7 +17,7 @@ class AWSSecretsManagerSettings(FidesSettings):
         description="AWS region for Secrets Manager.",
     )
     cache_ttl_seconds: float = Field(
-        default=300.0,
+        default=900.0,
         description="TTL for cached secret values.",
     )
     cache_stale_ttl_seconds: float = Field(
@@ -61,11 +61,11 @@ class SecretsSettings(FidesSettings):
         ):
             try:
                 values["aws_secrets_manager"] = AWSSecretsManagerSettings()
-            except Exception:
+            except Exception as exc:
                 raise ValueError(
                     "secrets.provider is 'aws_secrets_manager' but "
                     "secrets.aws_secrets_manager is not configured. "
                     "Provide the configuration via TOML or environment variables "
                     "(e.g. FIDES__SECRETS__AWS_SECRETS_MANAGER__REGION)."
-                )
+                ) from exc
         return values

--- a/tests/common/test_db_credential_provider.py
+++ b/tests/common/test_db_credential_provider.py
@@ -1,0 +1,378 @@
+"""Tests for DBCredentialProvider.
+
+Covers:
+- Auth error detection (_is_auth_error / _extract_sqlstate)
+- Exception sanitization (credential leakage prevention)
+- Credential resolution (static, readonly, dynamic)
+- Connection retry on auth failure (dynamic only)
+"""
+
+from unittest.mock import MagicMock, patch
+
+import asyncpg
+import psycopg2
+import pytest
+from sqlalchemy.dialects.postgresql.asyncpg import (
+    AsyncAdapt_asyncpg_connection,
+    AsyncAdapt_asyncpg_dbapi,
+)
+from sqlalchemy.util.concurrency import await_only
+
+from fides.common.db_credential_provider import (
+    _AUTH_RETRY_DELAY,
+    DBCredentialProvider,
+    SanitizedConnectionError,
+)
+from fides.config import CONFIG
+from fides.config.database_settings import DatabaseSettings
+from fides.config.secrets.base import SecretValue
+from fides.config.secrets.static_provider import StaticSecretProvider
+
+# --- Helpers ---
+
+
+def _make_auth_error(pgcode=None, sqlstate=None):
+    """Create a mock exception with pgcode/sqlstate attributes."""
+    exc = Exception("connection failed")
+    if pgcode is not None:
+        exc.pgcode = pgcode
+    if sqlstate is not None:
+        exc.sqlstate = sqlstate
+    return exc
+
+
+def _make_password_leaking_error(password):
+    """Create an exception whose message contains the password."""
+    exc = Exception(
+        f'FATAL: password authentication failed for user "myuser" '
+        f"(password={password}, host=db.example.com)"
+    )
+    exc.pgcode = "28P01"
+    return exc
+
+
+# --- Fixtures ---
+
+
+@pytest.fixture()
+def static_provider():
+    """DBCredentialProvider using the real CONFIG with a static provider."""
+    yield DBCredentialProvider()
+
+
+@pytest.fixture()
+def dynamic_provider():
+    """DBCredentialProvider backed by a mock SecretProvider."""
+    with (
+        patch("fides.common.db_credential_provider.get_secret_provider") as mock_get,
+        patch("fides.common.db_credential_provider.CONFIG") as mock_config,
+        patch("fides.common.db_credential_provider.time") as mock_time,
+    ):
+        mock_secret_provider = MagicMock()
+        mock_secret_provider.get_secret.return_value = SecretValue(
+            {"username": "secret_user", "password": "secret_pass"}
+        )
+        mock_get.return_value = mock_secret_provider
+        mock_config.database = CONFIG.database
+        mock_config.database.credential_secret_id = "db-creds"
+        mock_config.database.readonly_credential_secret_id = None
+        mock_config.test_mode = CONFIG.test_mode
+        yield DBCredentialProvider(), mock_config, mock_secret_provider, mock_time
+
+
+# --- Auth error detection ---
+
+
+class TestIsAuthError:
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            _make_auth_error(pgcode="28P01"),
+            _make_auth_error(pgcode="28000"),
+            _make_auth_error(sqlstate="28P01"),
+            _make_auth_error(sqlstate="28000"),
+        ],
+        ids=["pgcode-28P01", "pgcode-28000", "sqlstate-28P01", "sqlstate-28000"],
+    )
+    def test_detects_auth_sqlstates(self, exc):
+        assert DBCredentialProvider._is_auth_error(exc)
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            _make_auth_error(pgcode="42P01"),
+            Exception("generic error"),
+        ],
+        ids=["non-auth-pgcode", "no-code-attributes"],
+    )
+    def test_rejects_non_auth_errors(self, exc):
+        assert not DBCredentialProvider._is_auth_error(exc)
+
+
+# --- Exception sanitization ---
+
+
+class TestSanitizeException:
+    def test_includes_exception_type_and_sqlstate(self):
+        exc = _make_auth_error(pgcode="28P01")
+        sanitized = DBCredentialProvider._sanitize_exception(exc)
+        assert isinstance(sanitized, SanitizedConnectionError)
+        assert "Exception" in str(sanitized)
+        assert "28P01" in str(sanitized)
+        assert sanitized.sqlstate == "28P01"
+
+    def test_without_sqlstate(self):
+        sanitized = DBCredentialProvider._sanitize_exception(RuntimeError("boom"))
+        assert "RuntimeError" in str(sanitized)
+        assert sanitized.sqlstate is None
+
+    def test_password_not_in_sanitized_message(self):
+        password = "s3cret!p@ss"
+        exc = _make_password_leaking_error(password)
+        sanitized = DBCredentialProvider._sanitize_exception(exc)
+        assert password not in str(sanitized)
+        assert password not in repr(sanitized)
+
+    def test_exception_chain_broken_with_from_none(self):
+        exc = _make_auth_error(pgcode="28P01")
+        sanitized = DBCredentialProvider._sanitize_exception(exc)
+        try:
+            raise sanitized from None
+        except SanitizedConnectionError as caught:
+            assert caught.__cause__ is None
+            assert caught.__context__ is None
+
+
+# --- Credential resolution ---
+
+
+class TestGetCredentials:
+    def test_static_returns_config_credentials(self, static_provider):
+        creds = static_provider.get_credentials()
+        assert set(creds.keys()) == {"host", "port", "user", "password", "dbname"}
+        assert creds["host"] == CONFIG.database.server
+        assert creds["port"] == int(CONFIG.database.port)
+        assert creds["user"] == CONFIG.database.user
+        assert isinstance(creds["port"], int)
+
+    def test_static_is_not_dynamic(self, static_provider):
+        assert not static_provider.is_dynamic
+
+    def test_readonly_falls_back_to_primary_when_no_readonly_server(
+        self, static_provider
+    ):
+        creds = static_provider.get_credentials(readonly=True)
+        assert creds["host"] == CONFIG.database.server
+        assert creds["user"] == CONFIG.database.user
+
+    def test_readonly_uses_readonly_fields(self):
+        readonly_settings = DatabaseSettings(
+            readonly_server="replica",
+            readonly_port="5433",
+            readonly_user="ro_user",
+            readonly_password="ro_pass",
+            readonly_db="ro_db",
+        )
+        with (
+            patch("fides.config.secrets.static_provider.CONFIG") as mock_sp_config,
+            patch("fides.common.db_credential_provider.CONFIG") as mock_dcp_config,
+            patch(
+                "fides.common.db_credential_provider.get_secret_provider"
+            ) as mock_get,
+        ):
+            mock_sp_config.database = readonly_settings
+            mock_dcp_config.database = readonly_settings
+            mock_dcp_config.test_mode = False
+            mock_get.return_value = StaticSecretProvider()
+
+            provider = DBCredentialProvider()
+            creds = provider.get_credentials(readonly=True)
+            assert creds == {
+                "host": "replica",
+                "port": 5433,
+                "user": "ro_user",
+                "password": "ro_pass",
+                "dbname": "ro_db",
+            }
+
+    def test_dynamic_fetches_user_password_from_secret(self, dynamic_provider):
+        provider, _, mock_secret_provider, _ = dynamic_provider
+        assert provider.is_dynamic
+        creds = provider.get_credentials()
+        assert creds["user"] == "secret_user"
+        assert creds["password"] == "secret_pass"
+        assert creds["host"] == CONFIG.database.server
+        mock_secret_provider.get_secret.assert_called_once_with("db-creds")
+
+    def test_dynamic_readonly_falls_back_to_primary_secret_id(self, dynamic_provider):
+        provider, _, mock_secret_provider, _ = dynamic_provider
+        provider.get_credentials(readonly=True)
+        mock_secret_provider.get_secret.assert_called_once_with("db-creds")
+
+
+# --- Connection retry ---
+
+
+class TestConnectWithRetry:
+    def test_happy_path_merges_connect_kwargs_and_credentials(self, static_provider):
+        connect_fn = MagicMock(return_value="connection")
+        result = static_provider.connect_with_retry(connect_fn, {"keepalives": 1})
+        assert result == "connection"
+        call_kwargs = connect_fn.call_args[1]
+        assert call_kwargs["host"] == CONFIG.database.server
+        assert call_kwargs["keepalives"] == 1
+
+    def test_non_auth_error_raises_sanitized(self, static_provider):
+        connect_fn = MagicMock(side_effect=RuntimeError("connection refused"))
+        with pytest.raises(SanitizedConnectionError) as exc_info:
+            static_provider.connect_with_retry(connect_fn, {})
+        assert CONFIG.database.raw_password not in str(exc_info.value)
+        assert exc_info.value.__cause__ is None
+
+    def test_static_does_not_retry_auth_error(self, static_provider):
+        connect_fn = MagicMock(side_effect=_make_auth_error(pgcode="28P01"))
+        with pytest.raises(SanitizedConnectionError):
+            static_provider.connect_with_retry(connect_fn, {})
+        connect_fn.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            _make_auth_error(pgcode="28P01"),
+            _make_auth_error(pgcode="28000"),
+            _make_auth_error(sqlstate="28P01"),
+            _make_auth_error(sqlstate="28000"),
+        ],
+        ids=["pgcode-28P01", "pgcode-28000", "sqlstate-28P01", "sqlstate-28000"],
+    )
+    def test_dynamic_retries_on_auth_error_and_succeeds(self, dynamic_provider, exc):
+        provider, _, mock_secret_provider, mock_time = dynamic_provider
+        connect_fn = MagicMock(side_effect=[exc, "connection"])
+        result = provider.connect_with_retry(connect_fn, {})
+
+        assert result == "connection"
+        assert connect_fn.call_count == 2
+        mock_secret_provider.invalidate.assert_called_once_with("db-creds")
+        mock_time.sleep.assert_called_once_with(_AUTH_RETRY_DELAY)
+
+    def test_dynamic_retry_fails_raises_sanitized(self, dynamic_provider):
+        provider, _, _, _ = dynamic_provider
+        connect_fn = MagicMock(
+            side_effect=[
+                _make_auth_error(pgcode="28P01"),
+                _make_auth_error(pgcode="28P01"),
+            ]
+        )
+        with pytest.raises(SanitizedConnectionError) as exc_info:
+            provider.connect_with_retry(connect_fn, {})
+        assert exc_info.value.__cause__ is None
+        assert connect_fn.call_count == 2
+
+    def test_psycopg2_wrong_password_against_real_db(self):
+        """
+        End-to-end: attempts to connect to the test database and
+        checks the real psycopg2 auth failure is caught and sanitized.
+        """
+        wrong_password = "definitely-wrong-password-xyz"
+        db = CONFIG.database
+        wrong_db = DatabaseSettings(
+            server=db.server,
+            port=db.port,
+            user=db.user,
+            password=wrong_password,
+            db=db.db,
+            test_db=db.test_db,
+        )
+        with (
+            patch("fides.config.secrets.static_provider.CONFIG") as mock_sp_config,
+            patch("fides.common.db_credential_provider.CONFIG") as mock_dcp_config,
+            patch(
+                "fides.common.db_credential_provider.get_secret_provider"
+            ) as mock_get,
+        ):
+            mock_sp_config.database = wrong_db
+            mock_dcp_config.database = wrong_db
+            mock_dcp_config.test_mode = CONFIG.test_mode
+            mock_get.return_value = StaticSecretProvider()
+
+            provider = DBCredentialProvider()
+            with pytest.raises(SanitizedConnectionError) as exc_info:
+                provider.connect_with_retry(psycopg2.connect, {})
+            assert wrong_password not in str(exc_info.value)
+            assert exc_info.value.__cause__ is None
+
+    async def test_asyncpg_wrong_password_against_real_db(self):
+        """
+        End-to-end: attempts to connect to the test database and
+        checks the real asyncpg auth failure is caught and sanitized.
+        """
+        _dbapi = AsyncAdapt_asyncpg_dbapi(asyncpg)
+        wrong_password = "definitely-wrong-password-xyz"
+        db = CONFIG.database
+        wrong_db = DatabaseSettings(
+            server=db.server,
+            port=db.port,
+            user=db.user,
+            password=wrong_password,
+            db=db.db,
+            test_db=db.test_db,
+        )
+
+        def _connect_asyncpg(**kwargs):
+            kw = {
+                "host": kwargs.pop("host"),
+                "port": kwargs.pop("port"),
+                "user": kwargs.pop("user"),
+                "password": kwargs.pop("password"),
+                "database": kwargs.pop("dbname"),
+            }
+            kw.update(kwargs)
+            raw_conn = await_only(asyncpg.connect(**kw))
+            return AsyncAdapt_asyncpg_connection(_dbapi, raw_conn)
+
+        with (
+            patch("fides.config.secrets.static_provider.CONFIG") as mock_sp_config,
+            patch("fides.common.db_credential_provider.CONFIG") as mock_dcp_config,
+            patch(
+                "fides.common.db_credential_provider.get_secret_provider"
+            ) as mock_get,
+        ):
+            mock_sp_config.database = wrong_db
+            mock_dcp_config.database = wrong_db
+            mock_dcp_config.test_mode = CONFIG.test_mode
+            mock_get.return_value = StaticSecretProvider()
+
+            provider = DBCredentialProvider()
+            with pytest.raises(SanitizedConnectionError) as exc_info:
+                provider.connect_with_retry(_connect_asyncpg, {})
+            assert wrong_password not in str(exc_info.value)
+            assert exc_info.value.__cause__ is None
+
+
+# --- Credential leakage ---
+
+
+class TestCredentialLeakage:
+    def test_password_not_in_sanitized_exception(self, static_provider):
+        password = "v3ry-s3cret-p@ssw0rd!"
+        connect_fn = MagicMock(side_effect=_make_password_leaking_error(password))
+        with pytest.raises(SanitizedConnectionError) as exc_info:
+            static_provider.connect_with_retry(connect_fn, {})
+        assert password not in str(exc_info.value)
+        assert password not in repr(exc_info.value)
+
+    def test_password_not_in_log_output_during_retry(self, dynamic_provider, caplog):
+        provider, _, mock_secret_provider, _ = dynamic_provider
+        password = "super-secret-123"
+        mock_secret_provider.get_secret.return_value = SecretValue(
+            {"username": "u", "password": password}
+        )
+        connect_fn = MagicMock(
+            side_effect=[
+                _make_auth_error(pgcode="28P01"),
+                _make_auth_error(pgcode="28P01"),
+            ]
+        )
+        with pytest.raises(SanitizedConnectionError):
+            provider.connect_with_retry(connect_fn, {})
+        assert password not in caplog.text

--- a/tests/common/test_db_credential_provider.py
+++ b/tests/common/test_db_credential_provider.py
@@ -204,6 +204,12 @@ class TestGetCredentials:
         assert creds["host"] == CONFIG.database.server
         mock_secret_provider.get_secret.assert_called_once_with("db-creds")
 
+    def test_dynamic_without_credential_secret_id_raises(self, dynamic_provider):
+        provider, mock_config, _, _ = dynamic_provider
+        mock_config.database.credential_secret_id = None
+        with pytest.raises(ValueError, match="credential_secret_id is not set"):
+            provider.get_credentials()
+
     def test_dynamic_readonly_falls_back_to_primary_secret_id(self, dynamic_provider):
         provider, _, mock_secret_provider, _ = dynamic_provider
         provider.get_credentials(readonly=True)

--- a/tests/common/test_db_credential_provider.py
+++ b/tests/common/test_db_credential_provider.py
@@ -108,6 +108,33 @@ class TestIsAuthError:
     def test_rejects_non_auth_errors(self, exc):
         assert not DBCredentialProvider._is_auth_error(exc)
 
+    @pytest.mark.parametrize(
+        "message",
+        [
+            'FATAL:  password authentication failed for user "postgres"',
+            'connection to server failed: FATAL:  Password authentication failed for user "app"',
+        ],
+        ids=["standard-pg", "mixed-case"],
+    )
+    def test_string_fallback_detects_auth_message(self, message):
+        """psycopg2 doesn't set pgcode on connection-time errors,
+        so _is_auth_error falls back to message matching."""
+        exc = Exception(message)
+        assert DBCredentialProvider._is_auth_error(exc)
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "connection refused",
+            "could not connect to server: Connection timed out",
+            'FATAL:  database "nope" does not exist',
+        ],
+        ids=["refused", "timeout", "db-not-found"],
+    )
+    def test_string_fallback_rejects_non_auth_messages(self, message):
+        exc = Exception(message)
+        assert not DBCredentialProvider._is_auth_error(exc)
+
 
 # --- Exception sanitization ---
 

--- a/tests/config/secrets/test_factory.py
+++ b/tests/config/secrets/test_factory.py
@@ -2,6 +2,8 @@ import pytest
 from moto import mock_aws
 from pydantic import ValidationError
 
+import fides.config.secrets as secrets_module
+from fides.config.secrets import get_secret_provider
 from fides.config.secrets.aws_secrets_manager_provider import (
     AWSSecretsManagerProvider,
 )
@@ -11,21 +13,31 @@ from fides.config.secrets.static_provider import StaticSecretProvider
 from fides.config.secrets_settings import SecretsSettings
 
 
+class TestSecretsSettings:
+    def test_aws_provider_without_aws_config_raises(self):
+        with pytest.raises(
+            ValidationError, match="aws_secrets_manager is not configured"
+        ):
+            SecretsSettings(provider="aws_secrets_manager")
+
+    def test_aws_provider_with_aws_config_passes(self):
+        settings = SecretsSettings(
+            provider="aws_secrets_manager",
+            aws_secrets_manager={"region": "us-east-1"},
+        )
+        assert settings.aws_secrets_manager is not None
+        assert settings.aws_secrets_manager.region == "us-east-1"
+
+    def test_static_provider_without_aws_config_passes(self):
+        settings = SecretsSettings(provider="static")
+        assert settings.aws_secrets_manager is None
+
+
 class TestCreateSecretProvider:
     def test_static_provider(self):
         settings = SecretsSettings(provider="static")
-        provider = create_secret_provider(
-            settings, static_secrets={"db": {"user": "admin"}}
-        )
-        assert isinstance(provider, StaticSecretProvider)
-        assert provider.get_secret("db")["user"] == "admin"
-
-    def test_static_provider_default_empty_secrets(self):
-        settings = SecretsSettings(provider="static")
         provider = create_secret_provider(settings)
         assert isinstance(provider, StaticSecretProvider)
-        with pytest.raises(SecretProviderError):
-            provider.get_secret("anything")
 
     @mock_aws
     def test_aws_secrets_manager_provider(self):
@@ -56,3 +68,26 @@ class TestCreateSecretProvider:
         assert settings.provider == "static"
         provider = create_secret_provider(settings)
         assert isinstance(provider, StaticSecretProvider)
+
+
+class TestGetSecretProvider:
+    def test_returns_provider(self):
+        """Reset the singleton, then verify it creates and returns a provider."""
+        original = secrets_module._provider
+        try:
+            secrets_module._provider = None
+            provider = get_secret_provider()
+            assert isinstance(provider, StaticSecretProvider)
+        finally:
+            secrets_module._provider = original
+
+    def test_returns_same_instance(self):
+        """Singleton: second call returns the same object."""
+        original = secrets_module._provider
+        try:
+            secrets_module._provider = None
+            first = get_secret_provider()
+            second = get_secret_provider()
+            assert first is second
+        finally:
+            secrets_module._provider = original

--- a/tests/config/secrets/test_factory.py
+++ b/tests/config/secrets/test_factory.py
@@ -5,8 +5,7 @@ import pytest
 from moto import mock_aws
 from pydantic import ValidationError
 
-import fides.config.secrets as secrets_module
-from fides.config.secrets import get_secret_provider
+from fides.config.secrets import get_secret_provider, reset_secret_provider
 from fides.config.secrets.aws_secrets_manager_provider import (
     AWSSecretsManagerProvider,
 )
@@ -98,23 +97,23 @@ class TestCreateSecretProvider:
 
 
 class TestGetSecretProvider:
+    def setup_method(self):
+        reset_secret_provider()
+
+    def teardown_method(self):
+        reset_secret_provider()
+
     def test_returns_provider(self):
-        """Reset the singleton, then verify it creates and returns a provider."""
-        original = secrets_module._provider
-        try:
-            secrets_module._provider = None
-            provider = get_secret_provider()
-            assert isinstance(provider, StaticSecretProvider)
-        finally:
-            secrets_module._provider = original
+        provider = get_secret_provider()
+        assert isinstance(provider, StaticSecretProvider)
 
     def test_returns_same_instance(self):
-        """Singleton: second call returns the same object."""
-        original = secrets_module._provider
-        try:
-            secrets_module._provider = None
-            first = get_secret_provider()
-            second = get_secret_provider()
-            assert first is second
-        finally:
-            secrets_module._provider = original
+        first = get_secret_provider()
+        second = get_secret_provider()
+        assert first is second
+
+    def test_reset_forces_new_instance(self):
+        first = get_secret_provider()
+        reset_secret_provider()
+        second = get_secret_provider()
+        assert first is not second

--- a/tests/config/secrets/test_factory.py
+++ b/tests/config/secrets/test_factory.py
@@ -10,10 +10,10 @@ from fides.config.secrets import get_secret_provider
 from fides.config.secrets.aws_secrets_manager_provider import (
     AWSSecretsManagerProvider,
 )
-from fides.config.secrets.base import SecretProviderError
+from fides.config.secrets.base import SecretProviderError, SecretValue
 from fides.config.secrets.factory import create_secret_provider
 from fides.config.secrets.static_provider import StaticSecretProvider
-from fides.config.secrets_settings import SecretsSettings
+from fides.config.secrets_settings import AWSSecretsManagerSettings, SecretsSettings
 
 
 class TestSecretsSettings:
@@ -43,10 +43,7 @@ class TestSecretsSettings:
 
     def test_aws_config_requires_region(self):
         with pytest.raises(ValidationError, match="region"):
-            SecretsSettings(
-                provider="aws_secrets_manager",
-                aws_secrets_manager={},
-            )
+            AWSSecretsManagerSettings()
 
     def test_static_provider_without_aws_config_passes(self):
         settings = SecretsSettings(provider="static")
@@ -71,6 +68,16 @@ class TestCreateSecretProvider:
         provider = create_secret_provider(settings)
         assert isinstance(provider, AWSSecretsManagerProvider)
         assert provider._cache_ttl == 120.0
+
+    def test_aws_provider_with_missing_aws_config_raises_in_factory(self):
+        """Bypass Pydantic validation to test the factory's own guard."""
+        settings = SecretsSettings()
+        settings.provider = "aws_secrets_manager"  # type: ignore[assignment]
+        settings.aws_secrets_manager = None
+        with pytest.raises(
+            SecretProviderError, match="aws_secrets_manager is not configured"
+        ):
+            create_secret_provider(settings)
 
     def test_unknown_provider_raises_at_validation(self):
         with pytest.raises(ValidationError, match="literal_error"):

--- a/tests/config/secrets/test_factory.py
+++ b/tests/config/secrets/test_factory.py
@@ -1,3 +1,6 @@
+import os
+from unittest.mock import patch
+
 import pytest
 from moto import mock_aws
 from pydantic import ValidationError
@@ -27,6 +30,23 @@ class TestSecretsSettings:
         )
         assert settings.aws_secrets_manager is not None
         assert settings.aws_secrets_manager.region == "us-east-1"
+
+    def test_aws_provider_from_env_vars(self):
+        with patch.dict(
+            os.environ,
+            {
+                "FIDES__SECRETS__AWS_SECRETS_MANAGER__REGION": "eu-west-1",
+            },
+        ):
+            settings = SecretsSettings(provider="aws_secrets_manager")
+            assert settings.aws_secrets_manager.region == "eu-west-1"
+
+    def test_aws_config_requires_region(self):
+        with pytest.raises(ValidationError, match="region"):
+            SecretsSettings(
+                provider="aws_secrets_manager",
+                aws_secrets_manager={},
+            )
 
     def test_static_provider_without_aws_config_passes(self):
         settings = SecretsSettings(provider="static")

--- a/tests/config/secrets/test_static_provider.py
+++ b/tests/config/secrets/test_static_provider.py
@@ -1,45 +1,42 @@
 import pytest
 
+from fides.config import CONFIG
 from fides.config.secrets.base import SecretProviderError, SecretValue
-from fides.config.secrets.static_provider import StaticSecretProvider
+from fides.config.secrets.static_provider import (
+    DATABASE_CREDENTIALS_KEY,
+    DATABASE_READONLY_CREDENTIALS_KEY,
+    StaticSecretProvider,
+)
 
 
 class TestStaticSecretProvider:
-    def test_get_secret_returns_correct_value(self):
-        provider = StaticSecretProvider(
-            secrets={"db": {"username": "app", "password": "s3cret"}}
-        )
-        secret = provider.get_secret("db")
-        assert secret["username"] == "app"
-        assert secret["password"] == "s3cret"
+    def test_caches_db_credentials_from_config(self):
+        provider = StaticSecretProvider()
+        secret = provider.get_secret(DATABASE_CREDENTIALS_KEY)
+        assert isinstance(secret, SecretValue)
+        assert secret["username"] == CONFIG.database.user
+        assert secret["password"] == CONFIG.database.raw_password
 
-    def test_get_secret_returns_secret_value_type(self):
-        provider = StaticSecretProvider(secrets={"db": {"username": "app"}})
-        assert isinstance(provider.get_secret("db"), SecretValue)
-
-    def test_get_secret_unknown_id_raises(self):
-        provider = StaticSecretProvider(secrets={"db": {"username": "app"}})
+    def test_unknown_id_raises(self):
+        provider = StaticSecretProvider()
         with pytest.raises(SecretProviderError, match="Unknown secret_id"):
             provider.get_secret("nonexistent")
 
     def test_invalidate_is_noop(self):
-        provider = StaticSecretProvider(
-            secrets={"db": {"username": "app", "password": "s3cret"}}
+        provider = StaticSecretProvider()
+        provider.invalidate(DATABASE_CREDENTIALS_KEY)
+        assert (
+            provider.get_secret(DATABASE_CREDENTIALS_KEY)["username"]
+            == CONFIG.database.user
         )
-        provider.invalidate("db")
-        # Still works after invalidation
-        assert provider.get_secret("db")["username"] == "app"
 
     def test_invalidate_unknown_id_does_not_raise(self):
-        provider = StaticSecretProvider(secrets={})
-        provider.invalidate("nonexistent")  # should not raise
+        provider = StaticSecretProvider()
+        provider.invalidate("nonexistent")
 
-    def test_multiple_secrets(self):
-        provider = StaticSecretProvider(
-            secrets={
-                "db": {"username": "dbuser", "password": "dbpass"},
-                "redis": {"password": "redispass"},
-            }
-        )
-        assert provider.get_secret("db")["username"] == "dbuser"
-        assert provider.get_secret("redis")["password"] == "redispass"
+    def test_readonly_credentials_absent_when_no_readonly_server(self):
+        if CONFIG.database.readonly_server:
+            pytest.skip("readonly_server is configured in this environment")
+        provider = StaticSecretProvider()
+        with pytest.raises(SecretProviderError, match="Unknown secret_id"):
+            provider.get_secret(DATABASE_READONLY_CREDENTIALS_KEY)

--- a/tests/ctl/core/config/test_config.py
+++ b/tests/ctl/core/config/test_config.py
@@ -7,7 +7,11 @@ import pytest
 from pydantic import ValidationError
 
 from fides.api.db.database import get_alembic_config
-from fides.config import check_required_webserver_config_values, get_config
+from fides.config import (
+    build_config,
+    check_required_webserver_config_values,
+    get_config,
+)
 from fides.config.database_settings import DatabaseSettings
 from fides.config.redis_settings import RedisSettings
 from fides.config.security_settings import SecuritySettings
@@ -778,3 +782,69 @@ class TestReadOnlyDatabaseConfig:
         assert "ssl=" in parsed.query
         # sslrootcert should be removed from query params
         assert "sslrootcert" not in parsed.query
+
+
+@pytest.mark.unit
+class TestDatabaseCredentialSecretIdValidation:
+    """Validate cross-section coherence between secrets.provider and database.credential_secret_id."""
+
+    def test_static_provider_with_credential_secret_id_raises(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            build_config(
+                {
+                    "secrets": {"provider": "static"},
+                    "database": {
+                        "credential_secret_id": "arn:aws:secretsmanager:us-east-1:123:secret:db-creds"
+                    },
+                }
+            )
+        assert "credential_secret_id" in str(exc.value)
+        assert "static" in str(exc.value)
+
+    def test_static_provider_with_readonly_credential_secret_id_raises(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            build_config(
+                {
+                    "secrets": {"provider": "static"},
+                    "database": {
+                        "readonly_credential_secret_id": "arn:aws:secretsmanager:us-east-1:123:secret:ro-creds"
+                    },
+                }
+            )
+        assert "readonly_credential_secret_id" in str(exc.value)
+        assert "static" in str(exc.value)
+
+    def test_aws_provider_without_credential_secret_id_raises(self) -> None:
+        with pytest.raises(ValidationError) as exc:
+            build_config(
+                {
+                    "secrets": {
+                        "provider": "aws_secrets_manager",
+                        "aws_secrets_manager": {"region": "us-east-1"},
+                    },
+                }
+            )
+        assert "credential_secret_id is not set" in str(exc.value)
+
+    def test_aws_provider_with_credential_secret_id_passes(self) -> None:
+        config = build_config(
+            {
+                "secrets": {
+                    "provider": "aws_secrets_manager",
+                    "aws_secrets_manager": {"region": "us-east-1"},
+                },
+                "database": {
+                    "credential_secret_id": "arn:aws:secretsmanager:us-east-1:123:secret:db-creds"
+                },
+            }
+        )
+        assert (
+            config.database.credential_secret_id
+            == "arn:aws:secretsmanager:us-east-1:123:secret:db-creds"
+        )
+        assert config.database.readonly_credential_secret_id is None
+
+    def test_static_provider_without_secret_ids_passes(self) -> None:
+        config = build_config({})
+        assert config.database.credential_secret_id is None
+        assert config.database.readonly_credential_secret_id is None


### PR DESCRIPTION
Ticket [ENG-3566]

### Description Of Changes

Adds `DBCredentialProvider`, the layer between SQLAlchemy engine creators and the `SecretProvider` abstraction. This is the foundation for dynamic database credentials via AWS Secrets Manager — it resolves credentials, handles auth-failure retry during rotation, and sanitizes connection exceptions to prevent credential leakage.

This PR adds the class and all supporting config/provider changes but does **not** wire it into the engine creators yet. The wiring will follow in a separate PR.

### Code Changes

* `DBCredentialProvider` class with `get_credentials()`, `connect_with_retry()`, auth error detection (SQLSTATE + psycopg2 string fallback), and `SanitizedConnectionError`
* `StaticSecretProvider` refactored to read and cache DB credentials from CONFIG at construction time
* `get_secret_provider()` singleton in `config/secrets/__init__.py` for shared provider cache
* `credential_secret_id` and `readonly_credential_secret_id` fields added to `DatabaseSettings`
* `@model_validator` on `FidesConfig` for cross-section config validation (static + secret_id, aws + missing secret_id)
* `aws_secrets_manager` made `Optional` on `SecretsSettings` with its own validator
* `create_secret_provider` factory simplified (no more `static_secrets` param)
* INFO logs added to `AWSSecretsManagerProvider` for fetch/cache events

### Steps to Confirm

1. Run `nox -s "pytest(misc-unit)"` — all config, secrets, and db_credential_provider tests pass
2. Run `nox -s "pytest(lib)"` — engine creator tests pass
3. Verify static provider behavior unchanged: start Fides normally (no secrets config), confirm `GET /health/database` returns healthy

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
* Database migrations:
  * [x] No migrations
* Documentation:
  * [ ] No documentation updates required

[ENG-3566]: https://ethyca.atlassian.net/browse/ENG-3566