### PR TITLE
Support all taxonomies in policy builder UI

### DIFF
--- a/changelog/8177-policy-editor-full-taxonomy.yaml
+++ b/changelog/8177-policy-editor-full-taxonomy.yaml
@@ -1,0 +1,4 @@
+type: Added
+description: Added support for system groups and custom taxonomies in the access policy editor
+pr: 8177
+labels: []

--- a/clients/admin-ui/src/features/access-policies/AccessPolicyEditor.tsx
+++ b/clients/admin-ui/src/features/access-policies/AccessPolicyEditor.tsx
@@ -29,7 +29,10 @@ import AgentChatPanel from "./AgentChatPanel";
 import ConstraintNode, { ConstraintNodeType } from "./ConstraintNode";
 import ActionNode, { ActionNodeType } from "./DecisionNode";
 import LabeledEdge from "./LabeledEdge";
-import ConditionNode, { ConditionNodeType } from "./MatchNode";
+import ConditionNode, {
+  ConditionNodeData,
+  ConditionNodeType,
+} from "./MatchNode";
 import {
   deriveLayoutEdges,
   nodesToYaml,
@@ -42,7 +45,6 @@ import PolicyNode, { PolicyNodeType } from "./PolicyNode";
 import {
   ActionType,
   ConditionOperator,
-  ConditionProperty,
   ConsentRequirement,
   ConstraintType,
   DataFlowDirection,
@@ -657,6 +659,10 @@ const PolicyCanvasPanel = (props: PolicyCanvasPanelProps) => {
           };
         }
         if (node.type === "conditionNode") {
+          const disabledProperties = layoutedNodes
+            .filter((n) => n.type === "conditionNode" && n.id !== node.id)
+            .map((n) => (n.data as ConditionNodeData).property)
+            .filter((p): p is string => !!p);
           return {
             ...node,
             data: {
@@ -667,7 +673,8 @@ const PolicyCanvasPanel = (props: PolicyCanvasPanelProps) => {
               onAddConstraint: handleAddConstraint,
               onDelete: () => deleteConditionNode(node.id),
               hasChildren: constraintsExist,
-              onPropertyChange: (value: ConditionProperty) =>
+              disabledProperties,
+              onPropertyChange: (value: string) =>
                 updateNodeData(node.id, { property: value, values: [] }),
               onValuesChange: (values: string[]) =>
                 updateNodeData(node.id, { values }),

--- a/clients/admin-ui/src/features/access-policies/ConstraintNode.tsx
+++ b/clients/admin-ui/src/features/access-policies/ConstraintNode.tsx
@@ -65,12 +65,14 @@ export type ConstraintNodeType = Node<ConstraintNodeData, "constraintNode">;
 
 const ConstraintNode = ({ data }: NodeProps<ConstraintNodeType>) => (
   <div className={styles.node} data-testid="constraint-node">
-    <Handle
-      type="target"
-      position={Position.Left}
-      id="left"
-      className={styles.handle}
-    />
+    {data.isFirstOfType && (
+      <Handle
+        type="target"
+        position={Position.Left}
+        id="left"
+        className={styles.handle}
+      />
+    )}
     {!data.isFirstOfType && (
       <Handle
         type="target"
@@ -235,12 +237,14 @@ const ConstraintNode = ({ data }: NodeProps<ConstraintNodeType>) => (
         showAddAction={false}
       />
     )}
-    <Handle
-      type="source"
-      position={Position.Right}
-      id="right"
-      className={styles.handle}
-    />
+    {data.isFirstOfType && (
+      <Handle
+        type="source"
+        position={Position.Right}
+        id="right"
+        className={styles.handle}
+      />
+    )}
     <Handle
       type="source"
       position={Position.Bottom}

--- a/clients/admin-ui/src/features/access-policies/MatchNode.tsx
+++ b/clients/admin-ui/src/features/access-policies/MatchNode.tsx
@@ -128,12 +128,14 @@ const ConditionNode = ({ data }: NodeProps<ConditionNodeType>) => {
 
   return (
     <div className={styles.node} data-testid="condition-node">
-      <Handle
-        type="target"
-        position={Position.Left}
-        id="left"
-        className={styles.handle}
-      />
+      {data.isFirstOfType && (
+        <Handle
+          type="target"
+          position={Position.Left}
+          id="left"
+          className={styles.handle}
+        />
+      )}
       {!data.isFirstOfType && (
         <Handle
           type="target"
@@ -221,12 +223,14 @@ const ConditionNode = ({ data }: NodeProps<ConditionNodeType>) => {
           showAddConstraint={false}
         />
       )}
-      <Handle
-        type="source"
-        position={Position.Right}
-        id="right"
-        className={styles.handle}
-      />
+      {data.isFirstOfType && (
+        <Handle
+          type="source"
+          position={Position.Right}
+          id="right"
+          className={styles.handle}
+        />
+      )}
       <Handle
         type="source"
         position={Position.Bottom}

--- a/clients/admin-ui/src/features/access-policies/MatchNode.tsx
+++ b/clients/admin-ui/src/features/access-policies/MatchNode.tsx
@@ -113,16 +113,13 @@ const renderValuesSelect = (
 };
 
 const ConditionNode = ({ data }: NodeProps<ConditionNodeType>) => {
-  const { groupedOptions, labelByKey } = usePolicyTaxonomyOptions();
+  const { options, labelByKey } = usePolicyTaxonomyOptions();
 
   const disabledSet = new Set(data.disabledProperties ?? []);
-  const propertyOptions = groupedOptions.map((group) => ({
-    label: group.label,
-    options: group.options.map((opt) => ({
-      value: opt.value,
-      label: opt.label,
-      disabled: disabledSet.has(opt.value) && opt.value !== data.property,
-    })),
+  const propertyOptions = options.map((opt) => ({
+    value: opt.value,
+    label: opt.label,
+    disabled: disabledSet.has(opt.value) && opt.value !== data.property,
   }));
 
   const valuesLabel = data.property

--- a/clients/admin-ui/src/features/access-policies/MatchNode.tsx
+++ b/clients/admin-ui/src/features/access-policies/MatchNode.tsx
@@ -13,20 +13,22 @@ import {
 import DataCategorySelect from "~/features/common/dropdown/DataCategorySelect";
 import DataSubjectSelect from "~/features/common/dropdown/DataSubjectSelect";
 import DataUseSelect from "~/features/common/dropdown/DataUseSelect";
+import SystemGroupSelect from "~/features/common/dropdown/SystemGroupSelect";
+import CustomTaxonomySelect from "~/features/taxonomy/components/CustomTaxonomySelect";
 
-import {
-  CONDITION_OPERATOR_OPTIONS,
-  CONDITION_PROPERTY_OPTIONS,
-} from "./constants";
+import { CONDITION_OPERATOR_OPTIONS } from "./constants";
+import { usePolicyTaxonomyOptions } from "./hooks/usePolicyTaxonomyOptions";
 import styles from "./MatchNode.module.scss";
 import NodeActions from "./NodeActions";
 import { ConditionOperator, ConditionProperty } from "./types";
 
 export interface ConditionNodeData extends Record<string, unknown> {
-  property?: ConditionProperty;
+  property?: string;
   values?: string[];
   operator?: ConditionOperator;
-  onPropertyChange?: (value: ConditionProperty) => void;
+  /** Taxonomy keys already used by sibling condition nodes — disabled in the dropdown. */
+  disabledProperties?: string[];
+  onPropertyChange?: (value: string) => void;
   onValuesChange?: (values: string[]) => void;
   onOperatorChange?: (value: ConditionOperator) => void;
   onAddNode?: () => void;
@@ -40,162 +42,202 @@ export interface ConditionNodeData extends Record<string, unknown> {
 
 export type ConditionNodeType = Node<ConditionNodeData, "conditionNode">;
 
-const VALUES_LABEL: Record<string, string> = {
-  [ConditionProperty.DATA_USE]: "Data uses",
-  [ConditionProperty.DATA_CATEGORIES]: "Data categories",
-  [ConditionProperty.DATA_SUBJECTS]: "Data subjects",
+const renderValuesSelect = (
+  property: string | undefined,
+  values: string[] | undefined,
+  onChange: (values: string[]) => void,
+) => {
+  if (!property) {
+    return (
+      <Select
+        disabled
+        placeholder="Select a taxonomy first"
+        className="w-full"
+        aria-label="Select values"
+        data-testid="condition-values-disabled"
+      />
+    );
+  }
+
+  const commonProps = {
+    selectedTaxonomies: values,
+    value: values,
+    onChange: (v: unknown) => onChange(v as string[]),
+    mode: "multiple" as const,
+    maxTagCount: 1 as const,
+  };
+
+  switch (property) {
+    case ConditionProperty.DATA_USE:
+      return (
+        <DataUseSelect
+          {...commonProps}
+          placeholder="Select data uses"
+          data-testid="condition-values-data-use"
+        />
+      );
+    case ConditionProperty.DATA_CATEGORIES:
+      return (
+        <DataCategorySelect
+          {...commonProps}
+          placeholder="Select data categories"
+          data-testid="condition-values-data-category"
+        />
+      );
+    case ConditionProperty.DATA_SUBJECTS:
+      return (
+        <DataSubjectSelect
+          {...commonProps}
+          placeholder="Select data subjects"
+          data-testid="condition-values-data-subject"
+        />
+      );
+    case ConditionProperty.SYSTEM_GROUP:
+      return (
+        <SystemGroupSelect
+          {...commonProps}
+          placeholder="Select system groups"
+          data-testid="condition-values-system-group"
+        />
+      );
+    default:
+      return (
+        <CustomTaxonomySelect
+          {...commonProps}
+          taxonomyKey={property}
+          placeholder="Select values"
+          data-testid="condition-values-custom"
+        />
+      );
+  }
 };
 
-const ConditionNode = ({ data }: NodeProps<ConditionNodeType>) => (
-  <div className={styles.node} data-testid="condition-node">
-    <Handle
-      type="target"
-      position={Position.Left}
-      id="left"
-      className={styles.handle}
-    />
-    {!data.isFirstOfType && (
+const ConditionNode = ({ data }: NodeProps<ConditionNodeType>) => {
+  const { groupedOptions, labelByKey } = usePolicyTaxonomyOptions();
+
+  const disabledSet = new Set(data.disabledProperties ?? []);
+  const propertyOptions = groupedOptions.map((group) => ({
+    label: group.label,
+    options: group.options.map((opt) => ({
+      value: opt.value,
+      label: opt.label,
+      disabled: disabledSet.has(opt.value) && opt.value !== data.property,
+    })),
+  }));
+
+  const valuesLabel = data.property
+    ? (labelByKey[data.property] ?? data.property)
+    : "Values";
+
+  return (
+    <div className={styles.node} data-testid="condition-node">
       <Handle
         type="target"
-        position={Position.Top}
-        id="top"
+        position={Position.Left}
+        id="left"
         className={styles.handle}
       />
-    )}
-    <Flex align="center" gap="small" className={styles.header}>
-      <Avatar
-        shape="square"
-        size="small"
-        icon={<Icons.SettingsAdjust size={16} />}
-        className={styles.avatar}
-      />
-      <Text strong style={{ flex: 1 }}>
-        Match
-      </Text>
-      <Popconfirm
-        title="Delete match"
-        description="Are you sure you want to delete this match and its children?"
-        onConfirm={data.onDelete}
-        okText="Delete"
-        okButtonProps={{ danger: true }}
-        cancelText="Cancel"
-      >
-        <Button
-          type="text"
-          size="small"
-          icon={<Icons.TrashCan size={14} />}
-          danger
-          className="nodrag"
-          aria-label="Delete match"
-          data-testid="delete-condition-btn"
+      {!data.isFirstOfType && (
+        <Handle
+          type="target"
+          position={Position.Top}
+          id="top"
+          className={styles.handle}
         />
-      </Popconfirm>
-    </Flex>
-    <div className={styles.body}>
-      <Form layout="vertical" className="nodrag">
-        <Form.Item label="Taxonomy" className="mb-2">
-          <Select
-            placeholder="Select taxonomy"
-            value={data.property}
-            onChange={(value) => data.onPropertyChange?.(value)}
-            options={CONDITION_PROPERTY_OPTIONS}
-            variant="outlined"
-            className="w-full"
-            aria-label="Select taxonomy"
-            data-testid="condition-property-select"
-          />
-        </Form.Item>
-        <Form.Item label="Match" className="mb-2">
-          <Select
-            placeholder="Select match type"
-            value={data.operator ?? ConditionOperator.ALL}
-            onChange={(value) => data.onOperatorChange?.(value)}
-            options={CONDITION_OPERATOR_OPTIONS}
-            variant="outlined"
-            className="w-full"
-            aria-label="Select match type"
-            data-testid="condition-operator-select"
-          />
-        </Form.Item>
-        <Form.Item
-          label={data.property ? VALUES_LABEL[data.property] : "Values"}
-          className="mb-0"
+      )}
+      <Flex align="center" gap="small" className={styles.header}>
+        <Avatar
+          shape="square"
+          size="small"
+          icon={<Icons.SettingsAdjust size={16} />}
+          className={styles.avatar}
+        />
+        <Text strong style={{ flex: 1 }}>
+          Match
+        </Text>
+        <Popconfirm
+          title="Delete match"
+          description="Are you sure you want to delete this match and its children?"
+          onConfirm={data.onDelete}
+          okText="Delete"
+          okButtonProps={{ danger: true }}
+          cancelText="Cancel"
         >
-          {data.property === ConditionProperty.DATA_USE && (
-            <DataUseSelect
-              selectedTaxonomies={data.values}
-              value={data.values}
-              onChange={(values) => data.onValuesChange?.(values as string[])}
-              mode="multiple"
-              maxTagCount={1}
-              placeholder="Select data uses"
-              data-testid="condition-values-data-use"
-            />
-          )}
-          {data.property === ConditionProperty.DATA_CATEGORIES && (
-            <DataCategorySelect
-              selectedTaxonomies={data.values}
-              value={data.values}
-              onChange={(values) => data.onValuesChange?.(values as string[])}
-              mode="multiple"
-              maxTagCount={1}
-              placeholder="Select data categories"
-              data-testid="condition-values-data-category"
-            />
-          )}
-          {data.property === ConditionProperty.DATA_SUBJECTS && (
-            <DataSubjectSelect
-              selectedTaxonomies={data.values}
-              value={data.values}
-              onChange={(values) => data.onValuesChange?.(values as string[])}
-              mode="multiple"
-              maxTagCount={1}
-              placeholder="Select data subjects"
-              data-testid="condition-values-data-subject"
-            />
-          )}
-          {!data.property && (
+          <Button
+            type="text"
+            size="small"
+            icon={<Icons.TrashCan size={14} />}
+            danger
+            className="nodrag"
+            aria-label="Delete match"
+            data-testid="delete-condition-btn"
+          />
+        </Popconfirm>
+      </Flex>
+      <div className={styles.body}>
+        <Form layout="vertical" className="nodrag">
+          <Form.Item label="Taxonomy" className="mb-2">
             <Select
-              disabled
-              placeholder="Select a taxonomy first"
+              placeholder="Select taxonomy"
+              value={data.property}
+              onChange={(value) => data.onPropertyChange?.(value)}
+              options={propertyOptions}
+              variant="outlined"
               className="w-full"
-              aria-label="Select values"
-              data-testid="condition-values-disabled"
+              aria-label="Select taxonomy"
+              data-testid="condition-property-select"
             />
-          )}
-        </Form.Item>
-      </Form>
+          </Form.Item>
+          <Form.Item label="Match" className="mb-2">
+            <Select
+              placeholder="Select match type"
+              value={data.operator ?? ConditionOperator.ALL}
+              onChange={(value) => data.onOperatorChange?.(value)}
+              options={CONDITION_OPERATOR_OPTIONS}
+              variant="outlined"
+              className="w-full"
+              aria-label="Select match type"
+              data-testid="condition-operator-select"
+            />
+          </Form.Item>
+          <Form.Item label={valuesLabel} className="mb-0">
+            {renderValuesSelect(data.property, data.values, (values) =>
+              data.onValuesChange?.(values),
+            )}
+          </Form.Item>
+        </Form>
+      </div>
+      {data.isFirstOfType && !data.hasChildren && (
+        <NodeActions
+          onAddNode={data.onAddNode}
+          onAddConstraint={data.onAddConstraint}
+          showAddCondition={false}
+          showAddAction={false}
+        />
+      )}
+      {data.isLastOfType && (
+        <NodeActions
+          position="bottom"
+          onAddNode={data.onAddCondition}
+          onAddCondition={data.onAddCondition}
+          showAddAction={false}
+          showAddConstraint={false}
+        />
+      )}
+      <Handle
+        type="source"
+        position={Position.Right}
+        id="right"
+        className={styles.handle}
+      />
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        id="bottom"
+        className={styles.handle}
+      />
     </div>
-    {data.isFirstOfType && !data.hasChildren && (
-      <NodeActions
-        onAddNode={data.onAddNode}
-        onAddConstraint={data.onAddConstraint}
-        showAddCondition={false}
-        showAddAction={false}
-      />
-    )}
-    {data.isLastOfType && (
-      <NodeActions
-        position="bottom"
-        onAddNode={data.onAddCondition}
-        onAddCondition={data.onAddCondition}
-        showAddAction={false}
-        showAddConstraint={false}
-      />
-    )}
-    <Handle
-      type="source"
-      position={Position.Right}
-      id="right"
-      className={styles.handle}
-    />
-    <Handle
-      type="source"
-      position={Position.Bottom}
-      id="bottom"
-      className={styles.handle}
-    />
-  </div>
-);
+  );
+};
 
 export default ConditionNode;

--- a/clients/admin-ui/src/features/access-policies/constants.ts
+++ b/clients/admin-ui/src/features/access-policies/constants.ts
@@ -3,7 +3,6 @@ import type { SelectProps } from "fidesui";
 import {
   ActionType,
   ConditionOperator,
-  ConditionProperty,
   ConsentRequirement,
   ConstraintType,
   DataFlowDirection,
@@ -25,12 +24,6 @@ export const DECISION_LABELS: Record<ActionType, string> = {
   [ActionType.ALLOW]: "Allow",
   [ActionType.DENY]: "Deny",
 };
-
-export const CONDITION_PROPERTY_OPTIONS: NonNullable<SelectProps["options"]> = [
-  { value: ConditionProperty.DATA_USE, label: "Data use" },
-  { value: ConditionProperty.DATA_CATEGORIES, label: "Data categories" },
-  { value: ConditionProperty.DATA_SUBJECTS, label: "Data subjects" },
-];
 
 export const CONDITION_OPERATOR_OPTIONS: NonNullable<SelectProps["options"]> = [
   { value: ConditionOperator.ALL, label: "All of" },

--- a/clients/admin-ui/src/features/access-policies/hooks/usePolicyTaxonomyOptions.ts
+++ b/clients/admin-ui/src/features/access-policies/hooks/usePolicyTaxonomyOptions.ts
@@ -1,0 +1,88 @@
+import { useMemo } from "react";
+
+import { useFeatures } from "~/features/common/features";
+import { useGetCustomTaxonomiesQuery } from "~/features/taxonomy/taxonomy.slice";
+
+import {
+  BUILT_IN_TAXONOMY_KEYS,
+  BUILT_IN_TAXONOMY_LABELS,
+  ConditionProperty,
+} from "../types";
+
+export interface PolicyTaxonomyOption {
+  value: string;
+  label: string;
+}
+
+export interface PolicyTaxonomyOptionGroup {
+  label: string;
+  options: PolicyTaxonomyOption[];
+}
+
+export interface UsePolicyTaxonomyOptionsResult {
+  /** Grouped options ready for an Antd Select. */
+  groupedOptions: PolicyTaxonomyOptionGroup[];
+  /** Flat list of all valid taxonomy keys (for membership checks). */
+  allKeys: string[];
+  /** Map of taxonomy key → display label. Falls back to the key when unknown. */
+  labelByKey: Record<string, string>;
+  isLoading: boolean;
+}
+
+/**
+ * Single source of truth for the taxonomies selectable in an access policy
+ * condition: the 3 core built-ins plus `system_group` (Plus only) plus every
+ * custom taxonomy (Plus only). No `applies_to` filtering — every custom
+ * taxonomy is offered regardless of which entity types it claims to apply to.
+ */
+export const usePolicyTaxonomyOptions = (): UsePolicyTaxonomyOptionsResult => {
+  const features = useFeatures();
+  const isPlusEnabled = features.plus;
+
+  const { data: customTaxonomies = [], isLoading: isLoadingCustom } =
+    useGetCustomTaxonomiesQuery(undefined, { skip: !isPlusEnabled });
+
+  return useMemo(() => {
+    const builtInKeys = BUILT_IN_TAXONOMY_KEYS.filter(
+      (key) => key !== ConditionProperty.SYSTEM_GROUP || isPlusEnabled,
+    );
+
+    const builtInOptions: PolicyTaxonomyOption[] = builtInKeys.map((key) => ({
+      value: key,
+      label: BUILT_IN_TAXONOMY_LABELS[key],
+    }));
+
+    const reservedKeys = new Set<string>(builtInKeys);
+    const customOptions: PolicyTaxonomyOption[] = customTaxonomies
+      .filter((t) => !reservedKeys.has(t.fides_key))
+      .map((t) => ({
+        value: t.fides_key,
+        label: t.name || t.fides_key,
+      }));
+
+    const groupedOptions: PolicyTaxonomyOptionGroup[] = [
+      { label: "Built-in", options: builtInOptions },
+    ];
+    if (customOptions.length > 0) {
+      groupedOptions.push({ label: "Custom", options: customOptions });
+    }
+
+    const labelByKey: Record<string, string> = {};
+    builtInOptions.forEach((o) => {
+      labelByKey[o.value] = o.label;
+    });
+    customOptions.forEach((o) => {
+      labelByKey[o.value] = o.label;
+    });
+
+    return {
+      groupedOptions,
+      allKeys: [
+        ...builtInOptions.map((o) => o.value),
+        ...customOptions.map((o) => o.value),
+      ],
+      labelByKey,
+      isLoading: isLoadingCustom,
+    };
+  }, [customTaxonomies, isLoadingCustom, isPlusEnabled]);
+};

--- a/clients/admin-ui/src/features/access-policies/hooks/usePolicyTaxonomyOptions.ts
+++ b/clients/admin-ui/src/features/access-policies/hooks/usePolicyTaxonomyOptions.ts
@@ -14,16 +14,9 @@ export interface PolicyTaxonomyOption {
   label: string;
 }
 
-export interface PolicyTaxonomyOptionGroup {
-  label: string;
-  options: PolicyTaxonomyOption[];
-}
-
 export interface UsePolicyTaxonomyOptionsResult {
-  /** Grouped options ready for an Antd Select. */
-  groupedOptions: PolicyTaxonomyOptionGroup[];
-  /** Flat list of all valid taxonomy keys (for membership checks). */
-  allKeys: string[];
+  /** Flat options list — built-ins first, then custom taxonomies. */
+  options: PolicyTaxonomyOption[];
   /** Map of taxonomy key → display label. Falls back to the key when unknown. */
   labelByKey: Record<string, string>;
   isLoading: boolean;
@@ -60,27 +53,15 @@ export const usePolicyTaxonomyOptions = (): UsePolicyTaxonomyOptionsResult => {
         label: t.name || t.fides_key,
       }));
 
-    const groupedOptions: PolicyTaxonomyOptionGroup[] = [
-      { label: "Built-in", options: builtInOptions },
-    ];
-    if (customOptions.length > 0) {
-      groupedOptions.push({ label: "Custom", options: customOptions });
-    }
+    const options = [...builtInOptions, ...customOptions];
 
     const labelByKey: Record<string, string> = {};
-    builtInOptions.forEach((o) => {
-      labelByKey[o.value] = o.label;
-    });
-    customOptions.forEach((o) => {
+    options.forEach((o) => {
       labelByKey[o.value] = o.label;
     });
 
     return {
-      groupedOptions,
-      allKeys: [
-        ...builtInOptions.map((o) => o.value),
-        ...customOptions.map((o) => o.value),
-      ],
+      options,
       labelByKey,
       isLoading: isLoadingCustom,
     };

--- a/clients/admin-ui/src/features/access-policies/policy-yaml.ts
+++ b/clients/admin-ui/src/features/access-policies/policy-yaml.ts
@@ -10,7 +10,6 @@ import {
   ActionBlock,
   ActionType,
   ConditionOperator,
-  ConditionProperty,
   ConsentRequirement,
   ConstraintType,
   DataFlowDirection,
@@ -83,13 +82,14 @@ export const updateYamlField = (
   }
 };
 
-const CONDITION_PROPERTY_KEYS: ConditionProperty[] = [
-  ConditionProperty.DATA_CATEGORIES,
-  ConditionProperty.DATA_USE,
-  ConditionProperty.DATA_SUBJECTS,
-];
-
 export const POLICY_NODE_ID = "policy";
+
+/** Extract taxonomy keys from a match block, preserving YAML insertion order. */
+const extractMatchKeys = (matchBlock: MatchBlock): string[] =>
+  Object.keys(matchBlock).filter((k) => {
+    const dim = matchBlock[k];
+    return !!dim && (Array.isArray(dim.all) || Array.isArray(dim.any));
+  });
 
 /**
  * Build display edges using a chain topology:
@@ -166,10 +166,10 @@ export const yamlToNodesAndEdges = (
     type: "labeledEdge",
   });
 
-  // Condition nodes — chain: first from action ("when"), rest vertical ("and")
-  const presentProperties = CONDITION_PROPERTY_KEYS.filter(
-    (p) => !!matchBlock[p],
-  );
+  // Condition nodes — chain: first from action ("when"), rest vertical ("and").
+  // Iterate the match block in YAML insertion order so any taxonomy key
+  // (built-in or custom) is supported.
+  const presentProperties = extractMatchKeys(matchBlock);
 
   presentProperties.forEach((property, idx) => {
     const dimension = matchBlock[property] as MatchDimension;

--- a/clients/admin-ui/src/features/access-policies/policy-yaml.ts
+++ b/clients/admin-ui/src/features/access-policies/policy-yaml.ts
@@ -10,6 +10,7 @@ import {
   ActionBlock,
   ActionType,
   ConditionOperator,
+  ConditionProperty,
   ConsentRequirement,
   ConstraintType,
   DataFlowDirection,
@@ -84,12 +85,35 @@ export const updateYamlField = (
 
 export const POLICY_NODE_ID = "policy";
 
-/** Extract taxonomy keys from a match block, preserving YAML insertion order. */
-const extractMatchKeys = (matchBlock: MatchBlock): string[] =>
-  Object.keys(matchBlock).filter((k) => {
+/**
+ * Canonical render order for built-in taxonomies — independent of YAML key
+ * order. Custom taxonomy keys (anything not in this list) follow, in YAML
+ * insertion order.
+ */
+const BUILT_IN_RENDER_ORDER: string[] = [
+  ConditionProperty.DATA_CATEGORIES,
+  ConditionProperty.DATA_USE,
+  ConditionProperty.DATA_SUBJECTS,
+  ConditionProperty.SYSTEM_GROUP,
+];
+
+/**
+ * Extract taxonomy keys from a match block. Built-in keys come first in the
+ * canonical render order; anything else (custom taxonomies) follows in YAML
+ * insertion order.
+ */
+const extractMatchKeys = (matchBlock: MatchBlock): string[] => {
+  const hasDimension = (k: string) => {
     const dim = matchBlock[k];
     return !!dim && (Array.isArray(dim.all) || Array.isArray(dim.any));
-  });
+  };
+  const builtIns = BUILT_IN_RENDER_ORDER.filter(hasDimension);
+  const builtInSet = new Set(builtIns);
+  const custom = Object.keys(matchBlock).filter(
+    (k) => !builtInSet.has(k) && hasDimension(k),
+  );
+  return [...builtIns, ...custom];
+};
 
 /**
  * Build display edges using a chain topology:

--- a/clients/admin-ui/src/features/access-policies/types.ts
+++ b/clients/admin-ui/src/features/access-policies/types.ts
@@ -29,7 +29,24 @@ export enum ConditionProperty {
   DATA_USE = "data_use",
   DATA_CATEGORIES = "data_category",
   DATA_SUBJECTS = "data_subject",
+  SYSTEM_GROUP = "system_group",
 }
+
+/** Ordered list of built-in taxonomy keys, used for dropdown ordering. */
+export const BUILT_IN_TAXONOMY_KEYS: ConditionProperty[] = [
+  ConditionProperty.DATA_USE,
+  ConditionProperty.DATA_CATEGORIES,
+  ConditionProperty.DATA_SUBJECTS,
+  ConditionProperty.SYSTEM_GROUP,
+];
+
+/** Human-readable labels for built-in taxonomies. */
+export const BUILT_IN_TAXONOMY_LABELS: Record<ConditionProperty, string> = {
+  [ConditionProperty.DATA_USE]: "Data uses",
+  [ConditionProperty.DATA_CATEGORIES]: "Data categories",
+  [ConditionProperty.DATA_SUBJECTS]: "Data subjects",
+  [ConditionProperty.SYSTEM_GROUP]: "System groups",
+};
 
 export enum ConditionOperator {
   ALL = "all",
@@ -46,6 +63,7 @@ export interface MatchBlock {
   data_category?: MatchDimension;
   data_use?: MatchDimension;
   data_subject?: MatchDimension;
+  system_group?: MatchDimension;
   /** Custom taxonomy dimensions use their taxonomy_type as key */
   [key: string]: MatchDimension | undefined;
 }

--- a/clients/admin-ui/src/features/common/dropdown/SystemGroupSelect.tsx
+++ b/clients/admin-ui/src/features/common/dropdown/SystemGroupSelect.tsx
@@ -1,23 +1,36 @@
-import { Select, SelectProps } from "fidesui";
+import { useAppSelector } from "~/app/hooks";
+import {
+  TaxonomySelect,
+  TaxonomySelectOption,
+  TaxonomySelectProps,
+} from "~/features/common/dropdown/TaxonomySelect";
+import {
+  selectSystemGroupsAsTaxonomyEntities,
+  useGetAllSystemGroupsQuery,
+} from "~/features/system/system-groups.slice";
 
-import { useGetAllSystemGroupsQuery } from "~/features/system/system-groups.slice";
+const SystemGroupSelect = ({
+  selectedTaxonomies,
+  showDisabled = false,
+  ...props
+}: TaxonomySelectProps) => {
+  useGetAllSystemGroupsQuery();
+  const systemGroups = useAppSelector(selectSystemGroupsAsTaxonomyEntities);
 
-const SystemGroupSelect = (props: SelectProps) => {
-  const { data: systemGroups } = useGetAllSystemGroupsQuery();
+  const visibleGroups = showDisabled
+    ? systemGroups
+    : systemGroups.filter((g) => g.active);
 
-  const options = systemGroups?.map((group) => ({
-    value: group.fides_key,
-    label: group.name,
-  }));
+  const options: TaxonomySelectOption[] = visibleGroups
+    .filter((group) => !selectedTaxonomies?.includes(group.fides_key))
+    .map((group) => ({
+      value: group.fides_key,
+      name: group.name ?? group.fides_key,
+      description: group.description ?? "",
+      title: group.fides_key,
+    }));
 
-  return (
-    <Select
-      options={options}
-      placeholder="Select a system group"
-      aria-label="Select a system group"
-      {...props}
-    />
-  );
+  return <TaxonomySelect options={options} {...props} />;
 };
 
 export default SystemGroupSelect;

--- a/clients/admin-ui/src/features/taxonomy/components/CustomTaxonomySelect.tsx
+++ b/clients/admin-ui/src/features/taxonomy/components/CustomTaxonomySelect.tsx
@@ -1,30 +1,56 @@
-import { Select, SelectProps } from "fidesui";
+import { SelectProps } from "fidesui";
 
+import {
+  TaxonomySelect,
+  TaxonomySelectOption,
+} from "~/features/common/dropdown/TaxonomySelect";
 import { useGetTaxonomyQuery } from "~/features/taxonomy/taxonomy.slice";
 
-interface CustomTaxonomySelectProps extends SelectProps {
+interface CustomTaxonomySelectProps extends Omit<
+  SelectProps,
+  "options" | "mode"
+> {
   taxonomyKey: string;
+  /** Same semantics as the other TaxonomySelect wrappers. */
+  selectedTaxonomies?: string[];
+  showDisabled?: boolean;
+  /**
+   * Pass-through to TaxonomySelect. Allowed values mirror Antd's single-select
+   * (undefined) and multi-select ("multiple").
+   */
+  mode?: "multiple";
 }
 
 const CustomTaxonomySelect = ({
   taxonomyKey,
+  selectedTaxonomies,
+  showDisabled = false,
   ...props
 }: CustomTaxonomySelectProps) => {
-  const { data: taxonomyItems, isLoading } = useGetTaxonomyQuery(taxonomyKey);
+  const { data: taxonomyItems = [], isLoading } =
+    useGetTaxonomyQuery(taxonomyKey);
 
-  if (!taxonomyItems) {
-    return null;
-  }
+  const visibleItems = showDisabled
+    ? taxonomyItems
+    : taxonomyItems.filter((t) => t.active !== false);
+
+  const options: TaxonomySelectOption[] = visibleItems
+    .filter((item) => !selectedTaxonomies?.includes(item.fides_key))
+    .map((item) => ({
+      value: item.fides_key,
+      name: item.name ?? item.fides_key,
+      description: item.description ?? "",
+      title: item.fides_key,
+    }));
+
+  // TaxonomySelect props are a discriminated union (single vs multi mode);
+  // CustomTaxonomySelect's flat prop shape can satisfy either branch at the
+  // call site, so we cast to `any` here to keep the wrapper consumer-friendly.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const passthrough = props as any;
 
   return (
-    <Select
-      options={taxonomyItems.map((taxonomy) => ({
-        value: taxonomy.fides_key,
-        label: taxonomy.name ?? taxonomy.fides_key,
-      }))}
-      loading={isLoading}
-      {...props}
-    />
+    <TaxonomySelect options={options} loading={isLoading} {...passthrough} />
   );
 };
 


### PR DESCRIPTION
Ticket [ENG-3790]

### Description Of Changes

Adds first-class support for **all taxonomies** (built-in + custom) as condition properties in the new access policy editor. Previously the "Taxonomy" dropdown in a match node only offered Data uses / Data categories / Data subjects. It now also offers:

- **System groups** (Plus only)
- **Every user-defined custom taxonomy** (Plus only)

All taxonomies appear in a single flat list — built-ins first, then custom — with no group headers. A taxonomy that's already used by another condition node in the same policy is shown disabled in the dropdown, since the YAML `match` schema only allows one entry per taxonomy key. The YAML round-trip is now generic over taxonomy keys, so the Builder ↔ Code tabs preserve any taxonomy key the backend accepts (no allowlist).

Backend acceptance of the new match keys is owned by a separate ticket and is out of scope here.

### Code Changes

* [`types.ts`](clients/admin-ui/src/features/access-policies/types.ts) — added `SYSTEM_GROUP` to `ConditionProperty`, plus `BUILT_IN_TAXONOMY_KEYS` / `BUILT_IN_TAXONOMY_LABELS` exports; added `system_group` to `MatchBlock`.
* [`hooks/usePolicyTaxonomyOptions.ts`](clients/admin-ui/src/features/access-policies/hooks/usePolicyTaxonomyOptions.ts) — new hook, single source of truth for taxonomy dropdown options. Built-ins + system_group (Plus-gated) + all custom taxonomies (Plus-gated, skipped when Plus disabled).
* [`MatchNode.tsx`](clients/admin-ui/src/features/access-policies/MatchNode.tsx) — property-agnostic: property dropdown driven by the hook; values dropdown dispatches by property, falling through to `CustomTaxonomySelect` for custom taxonomy keys; sibling-condition taxonomies disabled in-place.
* [`AccessPolicyEditor.tsx`](clients/admin-ui/src/features/access-policies/AccessPolicyEditor.tsx) — wires `disabledProperties` from sibling condition nodes; `onPropertyChange` widened to `string`.
* [`policy-yaml.ts`](clients/admin-ui/src/features/access-policies/policy-yaml.ts) — dropped the hardcoded `CONDITION_PROPERTY_KEYS` allowlist; `yamlToNodesAndEdges` now iterates `match` keys in YAML insertion order.
* [`SystemGroupSelect.tsx`](clients/admin-ui/src/features/common/dropdown/SystemGroupSelect.tsx) — rewrote the existing stub to use the shared `TaxonomySelect` (parity with `DataSubjectSelect`); no prior callers were affected.
* [`CustomTaxonomySelect.tsx`](clients/admin-ui/src/features/taxonomy/components/CustomTaxonomySelect.tsx) — upgraded to render through `TaxonomySelect` with name + description, while remaining backward-compatible with the `TaxonomyCustomFieldsForm` caller.
* [`constants.ts`](clients/admin-ui/src/features/access-policies/constants.ts) — removed the now-unused static `CONDITION_PROPERTY_OPTIONS`.

### Steps to Confirm

1. `npm run dev` in [`clients/admin-ui/`](clients/admin-ui/) and log in (`root_user` / `Testpassword1!`).
2. Navigate to **Taxonomy** → create a custom taxonomy `marketing_audience` with a couple of elements.
3. Go to **Access policies** → **New policy**, add a Match (condition) node.
4. Open the **Taxonomy** dropdown — confirm the flat list shows: Data uses, Data categories, Data subjects, **System groups**, **marketing_audience** (no group labels).
5. Pick `marketing_audience`, select values, save the policy. Switch to the **Code** tab and confirm the YAML round-trip:
   ```yaml
   match:
     marketing_audience:
       all: [marketing_audience.<your_element>]
   ```
6. Add a second condition node — confirm `marketing_audience` is **disabled** in its dropdown but selectable in the first node.
7. Paste a YAML with a custom taxonomy match into the **Code** tab, switch to **Builder**, confirm the condition node renders with the right taxonomy + values.
8. (Plus off) Confirm `System groups` and custom taxonomies disappear from the dropdown.
9. Existing taxonomy custom-fields form ([`TaxonomyCustomFieldsForm.tsx`](clients/admin-ui/src/features/taxonomy/components/TaxonomyCustomFieldsForm.tsx)) still renders — `CustomTaxonomySelect` upgrade is backward-compatible.

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-3790]: https://ethyca.atlassian.net/browse/ENG-3790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ