### PR TITLE
ENG-3773: Fix privacy-center build by dropping uuid dep

### DIFF
--- a/changelog/8179-privacy-center-drop-uuid-dep.yaml
+++ b/changelog/8179-privacy-center-drop-uuid-dep.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Fixed privacy-center middleware build error by replacing uuid dependency with native crypto.randomUUID()
+pr: 8179
+labels: []

--- a/clients/package-lock.json
+++ b/clients/package-lock.json
@@ -29812,7 +29812,6 @@
         "react-redux": "^9.2.0",
         "redux-persist": "^6.0.0",
         "sanitize-html": "^2.17.0",
-        "uuid": "^9.0.0",
         "validator": "^13.15.22",
         "yup": "^0.32.11"
       },

--- a/clients/privacy-center/middleware.ts
+++ b/clients/privacy-center/middleware.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from "next/server";
-import { v4 } from "uuid";
 
 import {
   applyRequestContext,
@@ -21,7 +20,7 @@ let geolocationApiHost: string;
 
 export default function middleware(request: NextRequest) {
   const log = createLogger();
-  const requestId = v4();
+  const requestId = crypto.randomUUID();
 
   const logDict = {
     method: request.method,

--- a/clients/privacy-center/package.json
+++ b/clients/privacy-center/package.json
@@ -58,7 +58,6 @@
     "react-redux": "^9.2.0",
     "redux-persist": "^6.0.0",
     "sanitize-html": "^2.17.0",
-    "uuid": "^9.0.0",
     "validator": "^13.15.22",
     "yup": "^0.32.11"
   },


### PR DESCRIPTION
Ticket [ENG-3773]

### Description Of Changes

Follow-up to #8142 (FidesJS bundle size reduction). `clients/privacy-center/middleware.ts` imported `v4` from `uuid@^9`, which ships no bundled types. Combined with the absence of `@types/uuid` in privacy-center devDeps, the Next.js build failed with:

```
Type error: Could not find a declaration file for module 'uuid'.
./middleware.ts:2:20
```

Rather than re-introduce `@types/uuid` or bump `uuid` to v10, this PR drops the dep entirely. The middleware runs in the Next.js Edge Runtime where `crypto.randomUUID()` is a native global and produces the same RFC 4122 v4 UUID format. The value is only used for the `x-request-id` header and log context, so format equivalence is sufficient.

This also aligns with the existing convention — `clients/privacy-center/app/server-utils/recommendedSecurityHeaders.ts` already uses `crypto.randomUUID()` for nonce generation.

### Code Changes

* `clients/privacy-center/middleware.ts`: replaced `import { v4 } from "uuid"` + `v4()` call with `crypto.randomUUID()`
* `clients/privacy-center/package.json`: removed `uuid: ^9.0.0` from dependencies
* `clients/package-lock.json`: removed corresponding uuid entry from privacy-center workspace section

### Steps to Confirm

1. Pull this branch, `cd clients/privacy-center`
2. Run `npx tsc --noEmit` — the original `TS2307` error on `middleware.ts:2` is gone (any remaining `pages/api/fides-js.ts` errors are pre-existing on `main` and unrelated)
3. Run `npm run build` — build succeeds
4. Inspect a request in dev — `x-request-id` header on response is a v4 UUID string

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a `db-migration` label to the entry if your change includes a DB migration
  * [ ] Add a `high-risk` label to the entry if your change includes a high-risk change
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, PR opened in fidesdocs
  * [ ] Documentation issue created in fidesdocs
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-3773]: https://ethyca.atlassian.net/browse/ENG-3773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ