### PR TITLE
Security: Redux store exposed on window for testing

### DIFF
--- a/clients/admin-ui/global.d.ts
+++ b/clients/admin-ui/global.d.ts
@@ -8,6 +8,6 @@ declare module globalThis {
 interface Window {
   // Cypress is available on window when running in Cypress tests
   Cypress?: any;
-  // Redux store is exposed for Cypress testing
-  __REDUX_STORE__?: any;
+  // Redux store is exposed for Cypress testing only
+  __REDUX_STORE__?: process.env.NODE_ENV === 'test' ? any : never;
 }


### PR DESCRIPTION
## Summary

Security: Redux store exposed on window for testing

## Problem

**Severity**: `Medium` | **File**: `clients/admin-ui/global.d.ts:L10`

In `clients/admin-ui/global.d.ts`, the `__REDUX_STORE__` is exposed on the `Window` interface. While this is intended for Cypress testing, it could leak sensitive application state if accessed in production.

## Solution

Ensure this is only exposed in test environments. Consider using environment checks or build-time configuration to exclude this from production builds.

## Changes

- `clients/admin-ui/global.d.ts` (modified)