### PR TITLE
ENG-3828: Fix Pydantic serializer warning for AnyHttpUrlStringRemovesSlash

### DIFF
--- a/changelog/8193-fix-anyhttpurl-serializer.yaml
+++ b/changelog/8193-fix-anyhttpurl-serializer.yaml
@@ -1,0 +1,3 @@
+type: Fixed
+description: Suppressed `PydanticSerializationUnexpectedValue` warnings emitted by `AnyHttpUrlStringRemovesSlash` (e.g. `url_recorded` on the consent-reporting celery payload) by attaching a `PlainSerializer` that matches what the validator returns.
+pr: 8193

--- a/src/fides/api/custom_types.py
+++ b/src/fides/api/custom_types.py
@@ -6,7 +6,13 @@ from re import compile as regex
 from typing import Annotated, Optional
 
 from nh3 import clean
-from pydantic import AfterValidator, AnyHttpUrl, AnyUrl, BeforeValidator
+from pydantic import (
+    AfterValidator,
+    AnyHttpUrl,
+    AnyUrl,
+    BeforeValidator,
+    PlainSerializer,
+)
 
 from fides.api.util.text import is_valid_location_code
 from fides.api.util.unsafe_file_util import verify_css
@@ -186,7 +192,11 @@ def validate_path_of_http_url_no_slash(value: AnyHttpUrl) -> str:
 
 
 AnyHttpUrlStringRemovesSlash = Annotated[
-    AnyHttpUrl, AfterValidator(validate_path_of_http_url_no_slash)
+    AnyHttpUrl,
+    AfterValidator(validate_path_of_http_url_no_slash),
+    PlainSerializer(
+        lambda v: str(v).rstrip("/"), return_type=str, when_used="always"
+    ),
 ]
 
 

--- a/src/fides/api/custom_types.py
+++ b/src/fides/api/custom_types.py
@@ -194,9 +194,7 @@ def validate_path_of_http_url_no_slash(value: AnyHttpUrl) -> str:
 AnyHttpUrlStringRemovesSlash = Annotated[
     AnyHttpUrl,
     AfterValidator(validate_path_of_http_url_no_slash),
-    PlainSerializer(
-        lambda v: str(v).rstrip("/"), return_type=str, when_used="always"
-    ),
+    PlainSerializer(str, return_type=str),
 ]
 
 

--- a/tests/lib/test_custom_types.py
+++ b/tests/lib/test_custom_types.py
@@ -1,9 +1,11 @@
+import warnings
 from typing import Optional
 
 import pytest
 from pydantic import BaseModel, ValidationError
 
 from fides.api.custom_types import (
+    AnyHttpUrlStringRemovesSlash,
     GPPMechanismConsentValue,
     PhoneNumber,
     SafeStr,
@@ -306,3 +308,52 @@ class TestUserGeography:
     def test_none_accepted(self) -> None:
         instance = self.TestModel(geography=None)
         assert instance.geography is None
+
+
+@pytest.mark.unit
+class TestAnyHttpUrlStringRemovesSlash:
+    class TestModel(BaseModel):
+        url: Optional[AnyHttpUrlStringRemovesSlash] = None
+
+    @pytest.mark.parametrize(
+        "input_value, expected",
+        (
+            ("https://example.com", "https://example.com"),
+            ("https://example.com/", "https://example.com"),
+            ("http://example.com/path", "http://example.com/path"),
+            ("http://example.com/path/", "http://example.com/path"),
+            ("https://sub.example.com:8080", "https://sub.example.com:8080"),
+            (
+                "https://suscripciones.condenastamericas.com",
+                "https://suscripciones.condenastamericas.com",
+            ),
+        ),
+    )
+    def test_valid_urls_strip_trailing_slash(
+        self, input_value: str, expected: str
+    ) -> None:
+        instance = self.TestModel(url=input_value)
+        assert instance.url == expected
+
+    @pytest.mark.parametrize("value", ("not-a-url", "ftp://example.com", ""))
+    def test_invalid_urls_rejected(self, value: str) -> None:
+        with pytest.raises(ValidationError):
+            self.TestModel(url=value)
+
+    def test_serialization_does_not_warn(self) -> None:
+        """Regression: serializing the field must not emit
+        PydanticSerializationUnexpectedValue warning (ENG-2488 fallout).
+        """
+        instance = self.TestModel(url="https://example.com/path/")
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            dumped = instance.model_dump()
+            dumped_json = instance.model_dump_json()
+        assert dumped == {"url": "https://example.com/path"}
+        assert dumped_json == '{"url":"https://example.com/path"}'
+
+    def test_serialization_when_none(self) -> None:
+        instance = self.TestModel(url=None)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            assert instance.model_dump() == {"url": None}


### PR DESCRIPTION
Ticket  https://ethyca.atlassian.net/browse/ENG-3828

### Description Of Changes

`AnyHttpUrlStringRemovesSlash` was declared as `Annotated[AnyHttpUrl, AfterValidator(...)]`, but the `AfterValidator` returns a plain `str`. At serialization time Pydantic still expected an `AnyHttpUrl` instance and emitted a `PydanticSerializationUnexpectedValue` warning whenever the field held a real value.

Concretely surfaced in the celery task `Saving record(s) of current preferences and historical preferences for consent reporting` after ENG-2488 switched `url_recorded` from `SafeStr` to `AnyHttpUrlStringRemovesSlash`:

```
UserWarning: Pydantic serializer warnings:
  PydanticSerializationUnexpectedValue(Expected `<class 'pydantic.networks.AnyHttpUrl'>` but got `<class 'str'>` with value `'https://suscripciones.condenastamericas.com'` - serialized value may not be as expected.)
```

Attach a `PlainSerializer(return_type=str)` so the serializer type matches what the validator actually produces. No behavioral change to the output value (still `str` with trailing slash stripped), but the warning is gone and the field now round-trips cleanly.

### Code Changes

* `src/fides/api/custom_types.py` — added `PlainSerializer` to `AnyHttpUrlStringRemovesSlash`.
* `tests/lib/test_custom_types.py` — new `TestAnyHttpUrlStringRemovesSlash` covering validation, trailing-slash stripping, invalid-URL rejection, `None` passthrough, and a regression test that promotes the serializer warning to an error.

### Steps to Confirm

1. Run `nox -s "pytest(lib)"` (or `docker exec fides /opt/fides/bin/python -m pytest tests/lib/test_custom_types.py`) — all 208 tests pass, including the 11 new ones.
2. Verify regression coverage: revert only the `custom_types.py` change and re-run `TestAnyHttpUrlStringRemovesSlash::test_serialization_does_not_warn` — it fails with the exact `PydanticSerializationUnexpectedValue` warning quoted above.
3. In a Fidesplus environment, trigger the consent-reporting celery task with a non-null `url_recorded` — the warning no longer appears in worker logs.

### Pre-Merge Checklist

* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated (follow-up commit on this PR)
* No migrations
* No documentation updates required

[ENG-2488]: https://ethyca.atlassian.net/browse/ENG-2488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ