### PR TITLE
ENG-3818: Fix Action Center keyboard shortcut infinite render loop

### DIFF
--- a/changelog/8194-action-center-keyboard-shortcut-loop.yaml
+++ b/changelog/8194-action-center-keyboard-shortcut-loop.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Fixed infinite render loop when using keyboard shortcuts in the Action Center
+pr: 8194
+labels: []

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/page.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/page.tsx
@@ -14,7 +14,7 @@ import {
 } from "fidesui";
 import _ from "lodash";
 import { useRouter } from "next/router";
-import { Key, useEffect, useRef, useState } from "react";
+import { Key, useCallback, useEffect, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 
 import ErrorPage from "~/features/common/errors/ErrorPage";
@@ -140,7 +140,7 @@ const ActionCenterFields = ({
   const [activeListItem, setActiveListItem] = useState<
     MonitorResource & { key: React.Key }
   >();
-  const [setActiveListItemIndex, setSetActiveListItemIndex] = useState<
+  const setActiveListItemIndexRef = useRef<
     ((index: number | null) => void) | null
   >(null);
 
@@ -191,14 +191,15 @@ const ActionCenterFields = ({
   });
 
   const handleNavigate = async (urn: string | undefined) => {
-    if (activeListItem?.urn && urn && setActiveListItemIndex) {
+    const setActiveIndex = setActiveListItemIndexRef.current;
+    if (activeListItem?.urn && urn && setActiveIndex) {
       // When navigating via mouse click after using the keyboard,
       // update the active item to match the clicked item
       const itemIndex = [...listNodes.values()].findIndex(
         (item) => item.urn === urn,
       );
       if (itemIndex !== -1) {
-        setActiveListItemIndex(itemIndex);
+        setActiveIndex(itemIndex);
       }
     }
     setDetailsUrn(urn);
@@ -223,6 +224,31 @@ const ActionCenterFields = ({
     () => setHotkeysHelperModalOpen(!hotkeysHelperModalOpen),
     { useKey: true },
     [hotkeysHelperModalOpen],
+  );
+
+  const handleActiveItemChange = useCallback(
+    (
+      item: MonitorResource | null,
+      _activeListItemIndex: number | null,
+      setActiveIndexFn: (index: number | null) => void,
+    ) => {
+      // Store the setter via ref so handleNavigate can use it without
+      // triggering a re-render (which would re-create this callback and
+      // loop the CustomList effect).
+      setActiveListItemIndexRef.current = setActiveIndexFn;
+
+      if (item?.urn) {
+        if (item.urn !== activeListItem?.urn) {
+          setActiveListItem({ ...item, key: item.urn });
+        }
+        if (detailsUrn && item.urn !== detailsUrn) {
+          setDetailsUrn(item.urn);
+        }
+      } else if (activeListItem) {
+        setActiveListItem(undefined);
+      }
+    },
+    [activeListItem, detailsUrn],
   );
 
   const availableActions =
@@ -478,26 +504,7 @@ const ActionCenterFields = ({
                     }
                   : undefined
               }
-              onActiveItemChange={(
-                item,
-                _activeListItemIndex,
-                setActiveIndexFn,
-              ) => {
-                // Store the setter function so handleNavigate can use it
-                setSetActiveListItemIndex(() => setActiveIndexFn);
-
-                if (item?.urn) {
-                  setActiveListItem({
-                    ...item,
-                    key: item.urn,
-                  });
-                  if (detailsUrn && item.urn !== detailsUrn) {
-                    setDetailsUrn(item.urn);
-                  }
-                } else {
-                  setActiveListItem(undefined);
-                }
-              }}
+              onActiveItemChange={handleActiveItemChange}
               renderItem={(props) =>
                 renderMonitorFieldListItem({
                   ...props,


### PR DESCRIPTION
Ticket [ENG-3818]

### Description Of Changes

Using `j`/`k` (or any other list hotkey) in the Action Center → Fields view crashed the app with `Maximum update depth exceeded`. The infinite loop was at the `<List onActiveItemChange={...}>` call site in `ActionCenterFields`, not in `CustomList` itself:

1. `onActiveItemChange` was an inline arrow function — a new reference on every render. `CustomList`'s effect lists it as a dependency, so the effect fired every render.
2. The callback called `setSetActiveListItemIndex(() => setActiveIndexFn)`, which always wrote a brand-new wrapper function into `useState`. `Object.is` always saw a change → re-render → new inline callback ref → effect re-fires → loop.
3. `setActiveListItem({ ...item, key: item.urn })` always wrote a new object, compounding the problem.

Fix: stop storing the setter in state (it's only read in event handlers, so a `useRef` is sufficient and doesn't trigger renders), memoize the callback with `useCallback`, and guard the inner `setState` calls so they no-op when the value hasn't actually changed.

### Code Changes

* `clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/page.tsx`
  * Replaced `useState` for `setActiveListItemIndex` with `useRef` (`setActiveListItemIndexRef`).
  * Updated `handleNavigate` to read the setter via the ref.
  * Extracted the `onActiveItemChange` body into `handleActiveItemChange`, memoized with `useCallback([activeListItem, detailsUrn])`.
  * Added equality guards on `setActiveListItem` so we don't overwrite state with an equivalent new-object reference.

### Steps to Confirm

1. Navigate to Action Center → a monitor with results → Fields view.
2. Press `j` repeatedly — list focus moves down one item per keystroke, no Next.js error overlay, no "Maximum update depth exceeded" in the browser console.
3. Press `k` — moves up.
4. Press `Escape` — clears focus.
5. Press `Space` on a focused item — toggles selection.
6. Click a list item with the mouse after using `j`/`k` — drawer opens and the focus index syncs to the clicked item.
7. Press `?` — hotkeys helper modal opens.

Regression: load the Fields list with no results / a single result / change filters mid-navigation. No crashes.

See the Loom in the ticket for the original repro.

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [x] No migrations
* Documentation:
  * [x] No documentation updates required


[ENG-3818]: https://ethyca.atlassian.net/browse/ENG-3818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ