### PR TITLE
ENG-3552: Migrate AddNewSystemModal to antd Form

### DIFF
--- a/changelog/8195-add-new-system-modal-antd.yaml
+++ b/changelog/8195-add-new-system-modal-antd.yaml
@@ -1,0 +1,4 @@
+type: Changed
+description: Migrated the "Add New System" modal from Formik to antd
+pr: 8195
+labels: []

--- a/clients/admin-ui/src/features/system/AddNewSystemModal.tsx
+++ b/clients/admin-ui/src/features/system/AddNewSystemModal.tsx
@@ -1,38 +1,44 @@
-import { Button, Flex, Typography, useMessage } from "fidesui";
-import { Form, FormikProvider, useFormik } from "formik";
-import { useMemo, useState } from "react";
-import * as Yup from "yup";
+import {
+  Button,
+  Flex,
+  Form,
+  FormRule,
+  Input,
+  Select,
+  Typography,
+  useMessage,
+} from "fidesui";
+import { useEffect, useMemo, useState } from "react";
 
 import { useAppDispatch, useAppSelector } from "~/app/hooks";
 import ConfirmCloseModal from "~/features/common/modals/ConfirmCloseModal";
 import { System } from "~/types/api";
 
 import { useFeatures } from "../common/features";
-import { ControlledSelect } from "../common/form/ControlledSelect";
-import { CustomTextInput } from "../common/form/inputs";
 import {
   extractVendorSource,
   getErrorMessage,
   isErrorResult,
   VendorSources,
 } from "../common/helpers";
-import { FormGuard } from "../common/hooks/useIsAnyFormDirty";
 import { formatKey } from "../datastore-connections/system_portal_config/helpers";
 import {
   selectAllDictEntries,
+  selectDictEntry,
   useGetAllDictionaryEntriesQuery,
   usePostSystemVendorsMutation,
 } from "../plus/plus.slice";
 import {
-  dictSuggestionsSlice,
   selectLockedForGVL,
+  selectSuggestions,
+  setLockedForGVL,
+  setSuggestions,
 } from "./dictionary-form/dict-suggestion.slice";
-import { DictSuggestionTextArea } from "./dictionary-form/DictSuggestionInputs";
 import {
   useCreateSystemMutation,
   useLazyGetSystemsQuery,
 } from "./system.slice";
-import VendorSelector from "./VendorSelector";
+import VendorSelectorAnt from "./VendorSelectorAnt";
 
 const { Text } = Typography;
 
@@ -70,37 +76,60 @@ export const AddNewSystemModal = ({
   });
   const dictionaryOptions = useAppSelector(selectAllDictEntries);
   const lockedForGVL = useAppSelector(selectLockedForGVL);
+  const suggestionsState = useAppSelector(selectSuggestions);
   const [getSystemQueryTrigger] = useLazyGetSystemsQuery();
   const [postVendorIds] = usePostSystemVendorsMutation();
   const [createSystemMutationTrigger] = useCreateSystemMutation();
   const message = useMessage();
 
-  const { setSuggestions, setLockedForGVL } = dictSuggestionsSlice.actions;
+  const [form] = Form.useForm<FormValues>();
 
-  const ValidationSchema = useMemo(
-    () =>
-      Yup.object().shape({
-        name: Yup.string()
-          .required()
-          .label("System name")
-          .test("is-unique", "", async (value, context) => {
-            const { data } = await getSystemQueryTrigger({
-              page: 1,
-              size: 10,
-              search: value,
-            });
-            const systemResults = data?.items || [];
-            const similarSystemNames = systemResults.filter(
-              (s) => s.name === value,
+  const watchedValues = Form.useWatch([], form);
+  const vendorId = Form.useWatch<string | undefined>("vendor_id", form);
+  const dictEntry = useAppSelector(selectDictEntry(vendorId || ""));
+
+  const [submittable, setSubmittable] = useState(false);
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    form
+      .validateFields({ validateOnly: true })
+      .then(() => setSubmittable(true))
+      .catch(() => setSubmittable(false));
+  }, [form, watchedValues, isOpen]);
+
+  // Dictionary auto-populate for the description field. Mirrors the legacy
+  // `DictSuggestionTextArea` behavior without pulling in the Formik-bound
+  // component.
+  useEffect(() => {
+    if (suggestionsState === "showing" && dictEntry?.description) {
+      form.setFieldValue("description", dictEntry.description);
+    }
+  }, [suggestionsState, dictEntry, form]);
+
+  const nameRules: FormRule[] = useMemo(
+    () => [
+      { required: true, message: "System name is a required field" },
+      {
+        async validator(_, value: string) {
+          if (!value) {
+            return;
+          }
+          const { data } = await getSystemQueryTrigger({
+            page: 1,
+            size: 10,
+            search: value,
+          });
+          const similarSystemNames = data?.items || [];
+          if (similarSystemNames.some((s) => s.name === value)) {
+            throw new Error(
+              `You already have a system called "${value}". Please specify a unique name for this system.`,
             );
-            if (similarSystemNames.some((s) => s.name === value)) {
-              return context.createError({
-                message: `You already have a system called "${value}". Please specify a unique name for this system.`,
-              });
-            }
-            return true;
-          }),
-      }),
+          }
+        },
+      },
+    ],
     [getSystemQueryTrigger],
   );
 
@@ -123,6 +152,7 @@ export const AddNewSystemModal = ({
 
   const handleCloseModal = () => {
     onClose();
+    form.resetFields();
     dispatch(setSuggestions("initial"));
     dispatch(setLockedForGVL(false));
   };
@@ -171,96 +201,96 @@ export const AddNewSystemModal = ({
     setIsSubmitting(false);
   };
 
-  const formik = useFormik({
-    initialValues: defaultInitialValues,
-    onSubmit: handleSubmit,
-    validationSchema: ValidationSchema,
-  });
-  const { dirty, isValid } = formik;
-
   return (
-    <FormikProvider value={formik}>
-      <ConfirmCloseModal
-        title="Add New System"
-        open={isOpen}
-        onClose={() => {
-          formik.resetForm();
-          handleCloseModal();
-        }}
-        getIsDirty={() => formik.dirty}
-        centered
-        data-testid="add-modal-content"
-        destroyOnHidden
-        footer={null}
+    <ConfirmCloseModal
+      title="Add New System"
+      open={isOpen}
+      onClose={handleCloseModal}
+      getIsDirty={() => form.isFieldsTouched()}
+      centered
+      data-testid="add-modal-content"
+      destroyOnHidden
+      footer={
+        <Flex justify="space-between">
+          <Button onClick={handleCloseModal} data-testid="cancel-btn">
+            Cancel
+          </Button>
+          <Button
+            type="primary"
+            onClick={() => form.submit()}
+            disabled={isLoading || !submittable}
+            loading={isSubmitting}
+            data-testid="save-btn"
+          >
+            Save
+          </Button>
+        </Flex>
+      }
+    >
+      <Form<FormValues>
+        form={form}
+        initialValues={defaultInitialValues}
+        layout="vertical"
+        onFinish={handleSubmit}
       >
-        <Form>
-          <FormGuard id="new-system-modal" name="Add New System" />
-          <Flex vertical gap={20} className="pb-6 pt-4">
-            <Text>
-              Fides will add this system to your inventory and configure it for
-              consent using the categories of consent listed below. Optionally,
-              you can check if this system is listed within the Fides compass
-              library by selecting the compass icon below.
-            </Text>
-            {dictionaryService ? (
-              <VendorSelector
-                label="System name"
-                options={dictionaryOptions}
-                onVendorSelected={handleVendorSelected}
-                isCreate
-                lockedForGVL={lockedForGVL}
-                isLoading={isLoading}
-              />
-            ) : (
-              <CustomTextInput
-                id="name"
-                name="name"
-                label="System name"
-                tooltip="Give the system a unique, and relevant name for reporting purposes. e.g. “Email Data Warehouse”"
-                variant="stacked"
-                isRequired
-              />
-            )}
-            <DictSuggestionTextArea
-              id="description"
-              name="description"
-              label="Description"
-              tooltip="What services does this system perform?"
-              disabled={lockedForGVL}
+        <Flex vertical gap={20} className="pb-6 pt-4">
+          <Text>
+            Fides will add this system to your inventory and configure it for
+            consent using the categories of consent listed below. Optionally,
+            you can check if this system is listed within the Fides compass
+            library by selecting the compass icon below.
+          </Text>
+          {dictionaryService ? (
+            <VendorSelectorAnt
+              label="System name"
+              options={dictionaryOptions}
+              onVendorSelected={handleVendorSelected}
+              isCreate
+              lockedForGVL={lockedForGVL}
+              isLoading={isLoading}
+              nameRules={nameRules}
             />
-            {/* TODO [HJ-379] Add in the Categories of consent */}
-            {/* TODO [HJ-373] Add in the Data steward support */}
-            <ControlledSelect
+          ) : (
+            <Form.Item
+              name="name"
+              label="System name"
+              required
+              tooltip='Give the system a unique, and relevant name for reporting purposes. e.g. "Email Data Warehouse"'
+              rules={nameRules}
+              className="mb-0"
+            >
+              <Input data-testid="input-name" />
+            </Form.Item>
+          )}
+          <Form.Item
+            name="description"
+            label="Description"
+            tooltip="What services does this system perform?"
+            className="mb-0"
+          >
+            <Input.TextArea
+              disabled={lockedForGVL}
+              data-testid="input-description"
+            />
+          </Form.Item>
+          {/* TODO [HJ-379] Add in the Categories of consent */}
+          {/* TODO [HJ-373] Add in the Data steward support */}
+          <Form.Item
+            name="tags"
+            label="System Tags"
+            tooltip="Are there any tags to associate with this system?"
+            className="mb-0"
+          >
+            <Select
               mode="tags"
-              id="tags"
-              name="tags"
-              label="System Tags"
               options={[]}
-              layout="stacked"
-              tooltip="Are there any tags to associate with this system?"
               disabled={lockedForGVL}
+              aria-label="System Tags"
+              data-testid="input-tags"
             />
-          </Flex>
-          <Flex justify="space-between">
-            <Button
-              htmlType="reset"
-              onClick={handleCloseModal}
-              data-testid="cancel-btn"
-            >
-              Cancel
-            </Button>
-            <Button
-              htmlType="submit"
-              type="primary"
-              disabled={isLoading || !dirty || !isValid}
-              loading={isSubmitting}
-              data-testid="save-btn"
-            >
-              Save
-            </Button>
-          </Flex>
-        </Form>
-      </ConfirmCloseModal>
-    </FormikProvider>
+          </Form.Item>
+        </Flex>
+      </Form>
+    </ConfirmCloseModal>
   );
 };


### PR DESCRIPTION
Ticket [ENG-3552]

### Description Of Changes

Follow-up to [#8156](https://github.com/ethyca/fides/pull/8156). Migrates the "Add New System" modal off Formik + Yup + Chakra wrappers to antd `Form`. Reuses the `VendorSelectorAnt` and dirty-aware `ConfirmCloseModal` that #8156 already shipped.

Two deliberate variances from #8156's `AddVendor` migration:

- **`ConfirmCloseModal` is preserved.** The ticket explicitly calls for swapping `formik.dirty` for `form.isFieldsTouched()` rather than dropping the guard. The modal is reachable from three call sites (`AssignSystemModal`, action-center `SystemCell`, system-assets `AssetSystemCell`) and the unsaved-changes UX is worth keeping.
- **Public props are unchanged** (`isOpen`, `onClose`, `onSuccessfulSubmit`, `toastOnSuccess`), so none of the three call sites need edits.

The legacy `features/system/VendorSelector.tsx` stays in place; it's still consumed by `SystemInformationForm`, which will migrate in a separate ticket. After that lands the legacy selector can be deleted.

### Code Changes

- `clients/admin-ui/src/features/system/AddNewSystemModal.tsx`
  - `useFormik` / `FormikProvider` / Yup → `Form.useForm<FormValues>()` + `FormRule[]` (async uniqueness rule mirrors `AddVendor.nameRules`).
  - `VendorSelector` → `VendorSelectorAnt` with `nameRules` prop. Non-dictionary branch becomes a plain `Form.Item name="name"` + `Input`.
  - `DictSuggestionTextArea` → `Form.Item name="description"` + `Input.TextArea` with an inline `useEffect` watching `vendor_id` + the dict-suggestion redux state; on `"showing"` it calls `form.setFieldValue("description", dictEntry.description)`. The legacy component is untouched (still used by `SystemInformationForm`).
  - `ControlledSelect mode="tags"` → antd `Select mode="tags"` inside `Form.Item`, with `aria-label` to satisfy `jsx-a11y/control-has-associated-label`.
  - Save / Cancel moved into `ConfirmCloseModal`'s `footer` prop. Save is gated by `Form.useWatch([], form)` + `validateFields({ validateOnly: true })` driving a `submittable` boolean (same pattern as `AddVendor`). Save calls `form.submit()`.
  - `ConfirmCloseModal` now reads dirty via `() => form.isFieldsTouched()`.
  - `FormGuard` dropped (matches #8156).

### Steps to Confirm

These exercise the dictionary path that matches a standard local dev setup. The non-dictionary path is covered by the same `Form.Item` + `Input` fallback used in `AddVendor` after #8156.

1. **Open the modal.** Go to **Data discovery → Action center**, click an unassigned asset row, choose **Add new system**. Modal opens with `data-testid="add-modal-content"`.
2. **Dictionary typeahead.** Start typing a known vendor (e.g. *Aniview LTD*) and pick the suggestion. The **Description** field should auto-populate with the dictionary description. Compass button activates. **System Tags** stays editable.
3. **Custom (off-dictionary) entry.** Open the modal again, type a name that isn't in the dictionary, and pick the *Create new system "…"* option. Description stays empty; tags accept free-text Enter-to-tag. Click **Save** → toast appears, modal closes, the asset cell shows the new system.
4. **GVL lock** (TCF enabled). Pick a GVL vendor. Description + tags should disable; name field becomes read-only via `VendorSelectorAnt`'s `nameFieldLockedForGVL`.
5. **Dirty close-guard.** Type a name, then press Escape or click the backdrop. The "Unsaved Changes" confirm dialog should appear. Open a clean modal → backdrop closes immediately without a prompt.
6. **Save gating.** Open the modal; **Save** is disabled until a name is entered. Type a name that already exists → the async uniqueness rule shows the existing error message.
7. **Other entry points.** Repeat the smoke flow from **System Assets tab → "+" cell** and **Action Center → Assign System** to confirm the three call sites still work without prop changes.

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [x] No migrations
* Documentation:
  * [x] No documentation updates required

[ENG-3552]: https://ethyca.atlassian.net/browse/ENG-3552