### PR TITLE
Fix Privacy Center Cypress path filter firing on every PR

### DIFF
--- a/.github/workflows/cypress_privacy-center.yml
+++ b/.github/workflows/cypress_privacy-center.yml
@@ -33,7 +33,6 @@ jobs:
           filters: |
             privacy_center:
               - 'clients/privacy-center/**'
-              - '!clients/privacy-center/pages/api/fides-js.ts'
               - '.github/workflows/cypress_privacy-center.yml'
 
       - name: Log changed files

--- a/changelog/8196-pc-cypress-filter-fix.yaml
+++ b/changelog/8196-pc-cypress-filter-fix.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Privacy Center Cypress workflow no longer triggers on PRs that don't touch the Privacy Center
+pr: 8196
+labels: []


### PR DESCRIPTION
### Description Of Changes

`Privacy-Center-Cypress` has been running on every PR (regardless of which files changed) since [#6979](https://github.com/ethyca/fides/pull/6979) landed in November 2025. Example: it ran 5m36s on [#8195](https://github.com/ethyca/fides/pull/8195) (admin-ui only) and 5m4s on [#8194](https://github.com/ethyca/fides/pull/8194) (changelog only).

**Root cause:** the filter spec in [`.github/workflows/cypress_privacy-center.yml`](.github/workflows/cypress_privacy-center.yml) looked like:

\`\`\`yaml
filters: |
  privacy_center:
    - 'clients/privacy-center/**'
    - '!clients/privacy-center/pages/api/fides-js.ts'
    - '.github/workflows/cypress_privacy-center.yml'
\`\`\`

`dorny/paths-filter@v4` evaluates each list entry as an independent `picomatch` matcher and ORs the results. A standalone negation pattern like `!clients/privacy-center/pages/api/fides-js.ts` matches **every file that isn't that exact path**, so the filter resolved to `true` for any non-empty diff. You can see this in the [Check-Privacy-Center-Changes log](https://github.com/ethyca/fides/actions/runs/25889116481/job/76088036846) for #8195 — `Detected 2 changed files` (changelog + admin-ui), then `Filter privacy_center = true`.

The negation was originally added to skip PC Cypress when the only changed file was `clients/privacy-center/pages/api/fides-js.ts`. Given how rarely that file changes in isolation, this carve-out isn't worth keeping — dropping it removes the foot-gun outright.

### Code Changes

- `.github/workflows/cypress_privacy-center.yml` — remove the `!clients/privacy-center/pages/api/fides-js.ts` entry from the `privacy_center` filter.

### Steps to Confirm

1. This PR touches **only** the workflow file + a changelog fragment. Nothing under `clients/privacy-center/**` changes.
2. CI on this PR should now show `Privacy-Center-Cypress` as **skipping** instead of running for ~5min. The `Check-Privacy-Center-Changes` job log should show `Filter privacy_center = false`.

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [x] No migrations
* Documentation:
  * [x] No documentation updates required