### PR TITLE
ENG-1958: Add TCF version hash history table and model

### DIFF
--- a/.fides/db_dataset.yml
+++ b/.fides/db_dataset.yml
@@ -3665,6 +3665,24 @@ dataset:
         data_categories: [system.operations]
       - name: updated_at
         data_categories: [system.operations]
+  - name: tcf_version_hash_history
+    fields:
+      - name: id
+        data_categories: [system.operations]
+      - name: created_at
+        data_categories: [system.operations]
+      - name: updated_at
+        data_categories: [system.operations]
+      - name: privacy_experience_config_id
+        data_categories: [system.operations]
+      - name: previous_hash
+        data_categories: [system.operations]
+      - name: current_hash
+        data_categories: [system.operations]
+      - name: changed_at
+        data_categories: [system.operations]
+      - name: trigger_source
+        data_categories: [system.operations]
   - name: stagedresourceancestor
     fields:
       - name: id

--- a/changelog/8200-tcf-version-hash-history.yaml
+++ b/changelog/8200-tcf-version-hash-history.yaml
@@ -1,0 +1,4 @@
+type: Added
+description: Add TCF version hash history table to track changes to TCF configuration hashes over time
+pr: 8200
+labels: ["db-migration"]

--- a/src/fides/api/alembic/migrations/versions/xx_2026_05_07_1000_96fa22d82c26_add_tcf_version_hash_history.py
+++ b/src/fides/api/alembic/migrations/versions/xx_2026_05_07_1000_96fa22d82c26_add_tcf_version_hash_history.py
@@ -1,0 +1,98 @@
+"""add tcf_version_hash_history table
+
+Revision ID: 96fa22d82c26
+Revises: 3a91e5d4f7b2
+Create Date: 2026-05-07 10:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "96fa22d82c26"
+down_revision = "1e00f8e12f44"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "tcf_version_hash_history",
+        sa.Column("id", sa.String(length=255), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=True,
+        ),
+        sa.Column(
+            "privacy_experience_config_id",
+            sa.String(length=255),
+        ),
+        sa.Column("previous_hash", sa.String(), nullable=True),
+        sa.Column("current_hash", sa.String(), nullable=False),
+        sa.Column(
+            "changed_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("trigger_source", sa.String(), nullable=False),
+        sa.Column("details", sa.dialects.postgresql.JSONB(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["privacy_experience_config_id"],
+            ["privacyexperienceconfig.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_tcf_version_hash_history_id"),
+        "tcf_version_hash_history",
+        ["id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_tcf_version_hash_history_privacy_experience_config_id"),
+        "tcf_version_hash_history",
+        ["privacy_experience_config_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_tcf_version_hash_history_current_hash"),
+        "tcf_version_hash_history",
+        ["current_hash"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_tcf_version_hash_history_changed_at"),
+        "tcf_version_hash_history",
+        ["changed_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_tcf_version_hash_history_changed_at"),
+        table_name="tcf_version_hash_history",
+    )
+    op.drop_index(
+        op.f("ix_tcf_version_hash_history_current_hash"),
+        table_name="tcf_version_hash_history",
+    )
+    op.drop_index(
+        op.f("ix_tcf_version_hash_history_privacy_experience_config_id"),
+        table_name="tcf_version_hash_history",
+    )
+    op.drop_index(
+        op.f("ix_tcf_version_hash_history_id"),
+        table_name="tcf_version_hash_history",
+    )
+    op.drop_table("tcf_version_hash_history")

--- a/src/fides/api/db/base.py
+++ b/src/fides/api/db/base.py
@@ -114,5 +114,6 @@ from fides.api.models.tcf_publisher_restrictions import (
     TCFPublisherRestriction,
 )
 from fides.api.models.tcf_purpose_overrides import TCFPurposeOverride
+from fides.api.models.tcf_version_hash_history import TCFVersionHashHistory
 from fides.api.models.v3.privacy_preferences import PrivacyPreferences
 from fides.system_integration_link.models import SystemConnectionConfigLink

--- a/src/fides/api/models/tcf_version_hash_history.py
+++ b/src/fides/api/models/tcf_version_hash_history.py
@@ -1,0 +1,41 @@
+from enum import Enum
+
+from sqlalchemy import Column, DateTime, ForeignKey, String
+from sqlalchemy.dialects.postgresql import JSONB as jsonb
+from sqlalchemy.ext.declarative import declared_attr
+from sqlalchemy.sql import func
+
+from fides.api.db.base_class import Base
+
+
+class TCFVersionHashTriggerSource(str, Enum):
+    experience_config_update = "experience_config_update"
+    experience_config_limited_update = "experience_config_limited_update"
+    experience_serve_uncached = "experience_serve_uncached"
+    compass_sync = "compass_sync"
+    tcf_configuration_delete = "tcf_configuration_delete"
+    tcf_publisher_restriction_create = "tcf_publisher_restriction_create"
+    tcf_publisher_restriction_update = "tcf_publisher_restriction_update"
+    tcf_publisher_restriction_delete = "tcf_publisher_restriction_delete"
+    unknown = "unknown"
+
+
+class TCFVersionHashHistory(Base):
+    """Records each transition of the TCF version hash for each experience config, enabling audit of when consent re-collection is required."""
+
+    @declared_attr
+    def __tablename__(self) -> str:
+        return "tcf_version_hash_history"
+
+    privacy_experience_config_id = Column(
+        String(255),
+        ForeignKey("privacyexperienceconfig.id"),
+        index=True,
+    )
+    previous_hash = Column(String, nullable=True)
+    current_hash = Column(String, nullable=False, index=True)
+    changed_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False, index=True
+    )
+    trigger_source = Column(String, nullable=False)
+    details = Column(jsonb, nullable=True)


### PR DESCRIPTION
## Summary
- Adds `TCFVersionHashHistory` SQLAlchemy model to track changes to TCF configuration hashes over time
- Adds Alembic migration to create the `tcf_version_hash_history` table with columns for `id`, `privacy_config_experience_id`, `previous_hash`, `current_hash`, `changed_at`, and `trigger_source`

## Test plan
- [ ] Run migration: `alembic upgrade head` — verify `tcf_version_hash_history` table is created
- [ ] Verify model relationships and FK to `privacyexperience` table
- [ ] Run backend tests: `pytest --no-cov tests/` targeting models/migrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)