### PR TITLE
Add high-risk label to credential provider changelog entry

### DIFF
--- a/changelog/8176-wire-credential-provider.yaml
+++ b/changelog/8176-wire-credential-provider.yaml
@@ -1,4 +1,4 @@
 type: Changed
 description: Route all database connections through DBCredentialProvider for dynamic credential resolution
 pr: 8176
-labels: []
+labels: ["high-risk"]


### PR DESCRIPTION
Adds `high-risk` label to the #8176 changelog entry since it changes all database connection paths.