### PR TITLE
Always open Cmd+K search as centered modal

### DIFF
--- a/changelog/8202-cmd-k-centered-modal.yaml
+++ b/changelog/8202-cmd-k-centered-modal.yaml
@@ -1,0 +1,4 @@
+type: Changed
+description: Cmd+K search now always opens as a centered modal regardless of navbar state
+pr: 8202
+labels: []

--- a/clients/admin-ui/__tests__/features/common/nav/NavSearch.test.tsx
+++ b/clients/admin-ui/__tests__/features/common/nav/NavSearch.test.tsx
@@ -373,34 +373,38 @@ describe("NavSearch", () => {
   });
 
   describe("keyboard shortcuts", () => {
-    // jsdom has no Mac navigator, so isMac is false and only Ctrl+K is bound
-    it("opens search on Ctrl+K", async () => {
+    // jsdom has no Mac navigator, so isMac is false and only Ctrl+K is bound.
+    // Ctrl+K opens the centered modal (not the inline autocomplete).
+    it("opens the modal on Ctrl+K", async () => {
       const NavSearch = getNavSearch();
       render(<NavSearch groups={MOCK_GROUPS} />);
 
       fireEvent.keyDown(document, { key: "k", ctrlKey: true });
 
       await waitFor(() => {
-        expect(getAutoCompleteProps().open).toBe(true);
+        expect(screen.getByTestId("mock-modal")).toBeInTheDocument();
+        expect(
+          screen.getByTestId("nav-search-modal-input"),
+        ).toBeInTheDocument();
       });
     });
 
-    it("does not open on Cmd+K in non-Mac environment", () => {
+    it("does not open the modal on Cmd+K in non-Mac environment", () => {
       const NavSearch = getNavSearch();
       render(<NavSearch groups={MOCK_GROUPS} />);
 
       fireEvent.keyDown(document, { key: "k", metaKey: true });
 
-      expect(getAutoCompleteProps().open).toBeFalsy();
+      expect(screen.queryByTestId("mock-modal")).not.toBeInTheDocument();
     });
 
-    it("does not open on K without modifier key", () => {
+    it("does not open the modal on K without modifier key", () => {
       const NavSearch = getNavSearch();
       render(<NavSearch groups={MOCK_GROUPS} />);
 
       fireEvent.keyDown(document, { key: "k" });
 
-      expect(getAutoCompleteProps().open).toBeFalsy();
+      expect(screen.queryByTestId("mock-modal")).not.toBeInTheDocument();
     });
   });
 

--- a/clients/admin-ui/src/features/common/nav/NavSearch.tsx
+++ b/clients/admin-ui/src/features/common/nav/NavSearch.tsx
@@ -1,7 +1,6 @@
 import { AutoComplete, Icons, Input, InputRef } from "fidesui";
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useHotkeys } from "react-hotkeys-hook";
 
 import { NavGroup } from "./nav-config";
 import styles from "./NavSearch.module.scss";
@@ -103,18 +102,6 @@ const NavSearchExpanded = ({ groups }: { groups: NavGroup[] }) => {
     }
   }, []);
 
-  // Cmd+K on Mac, Ctrl+K elsewhere
-  useHotkeys(
-    isMac ? "meta+k" : "ctrl+k",
-    () => {
-      setOpen(true);
-      requestAnimationFrame(() => {
-        inputRef.current?.focus();
-      });
-    },
-    { enableOnFormTags: true, preventDefault: true },
-  );
-
   const handleEscapeKey = useCallback((e: React.KeyboardEvent) => {
     if (e.key === "Escape") {
       setOpen(false);
@@ -174,7 +161,12 @@ const NavSearch = ({ groups, collapsed = false }: NavSearchProps) => {
     return <NavSearchModal groups={groups} />;
   }
 
-  return <NavSearchExpanded groups={groups} />;
+  return (
+    <>
+      <NavSearchModal groups={groups} hideToggle />
+      <NavSearchExpanded groups={groups} />
+    </>
+  );
 };
 
 export default NavSearch;

--- a/clients/admin-ui/src/features/common/nav/NavSearchModal.tsx
+++ b/clients/admin-ui/src/features/common/nav/NavSearchModal.tsx
@@ -71,9 +71,13 @@ const NavSearchResultItem = ({
 
 interface NavSearchModalProps {
   groups: NavGroup[];
+  hideToggle?: boolean;
 }
 
-const NavSearchModal = ({ groups }: NavSearchModalProps) => {
+const NavSearchModal = ({
+  groups,
+  hideToggle = false,
+}: NavSearchModalProps) => {
   const [open, setOpen] = useState(false);
   const [searchValue, setSearchValue] = useState("");
   const modalInputRef = useRef<InputRef>(null);
@@ -154,16 +158,18 @@ const NavSearchModal = ({ groups }: NavSearchModalProps) => {
   const hasResults = indexedGroups.length > 0;
 
   return (
-    <div className="flex flex-col items-center pb-3">
-      <button
-        type="button"
-        className="flex size-9 cursor-pointer items-center justify-center rounded-md border-none bg-transparent transition-colors hover:bg-[var(--fidesui-neutral-700)]"
-        onClick={() => setOpen(true)}
-        aria-label="Search navigation"
-        data-testid="nav-search-toggle"
-      >
-        <Icons.Search style={COLLAPSED_ICON_STYLE} />
-      </button>
+    <div className={hideToggle ? "" : "flex flex-col items-center pb-3"}>
+      {!hideToggle && (
+        <button
+          type="button"
+          className="flex size-9 cursor-pointer items-center justify-center rounded-md border-none bg-transparent transition-colors hover:bg-[var(--fidesui-neutral-700)]"
+          onClick={() => setOpen(true)}
+          aria-label="Search navigation"
+          data-testid="nav-search-toggle"
+        >
+          <Icons.Search style={COLLAPSED_ICON_STYLE} />
+        </button>
+      )}
       <Modal
         open={open}
         onCancel={handleClose}


### PR DESCRIPTION
### Description Of Changes

The Cmd+K search shortcut previously had inconsistent behavior depending on the navbar state: when the navbar was expanded, it focused the inline sidebar search input; when collapsed, it opened a centered spotlight modal. This change makes Cmd+K always open the centered spotlight modal for a consistent experience regardless of navbar state.

The inline sidebar search input is still available for click interaction when the navbar is expanded.

### Code Changes

* Added `hideToggle` prop to `NavSearchModal` to suppress the icon button when rendered alongside the expanded sidebar
* Updated `NavSearch` to always render `NavSearchModal` (for Cmd+K) alongside the inline `NavSearchExpanded` when the navbar is expanded
* Removed the duplicate `useHotkeys` handler from `NavSearchExpanded` to avoid conflicts
* Updated keyboard shortcut tests to verify the modal opens instead of the autocomplete dropdown

### Steps to Confirm

1. Open the Admin UI with the navbar expanded (default state)
2. Press Cmd+K (or Ctrl+K on non-Mac) and verify the centered spotlight modal opens
3. Collapse the navbar and press Cmd+K again, verify the same centered modal opens
4. With navbar expanded, click the sidebar search input and verify inline search still works
5. In both modes, verify searching/selecting a result navigates correctly

### Pre-Merge Checklist

* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [x] No followup issues
* Database migrations:
  * [x] No migrations
* Documentation:
  * [x] No documentation updates required