### PR TITLE
ENG-2902: Default ATTRIBUTION_ENABLED to true in Privacy Center

### DIFF
--- a/changelog/8219-attribution-enabled-default-true.yaml
+++ b/changelog/8219-attribution-enabled-default-true.yaml
@@ -1,0 +1,4 @@
+type: Changed
+description: Privacy Center attribution link is now enabled by default. Set `FIDES_PRIVACY_CENTER__ATTRIBUTION_ENABLED=false` to disable.
+pr: 8219
+labels: []

--- a/clients/privacy-center/__tests__/app/fides-js-attribution.test.ts
+++ b/clients/privacy-center/__tests__/app/fides-js-attribution.test.ts
@@ -20,14 +20,8 @@ describe("fides-js attribution config", () => {
     process.env = originalEnv;
   });
 
-  it("does not include attribution fields when ATTRIBUTION_ENABLED is false", () => {
+  it("defaults to true when ATTRIBUTION_ENABLED is not set", () => {
     delete process.env.FIDES_PRIVACY_CENTER__ATTRIBUTION_ENABLED;
-    const settings = getClientSettings();
-    expect(settings.ATTRIBUTION_ENABLED).toBe(false);
-  });
-
-  it("includes attribution fields when ATTRIBUTION_ENABLED is true", () => {
-    process.env.FIDES_PRIVACY_CENTER__ATTRIBUTION_ENABLED = "true";
     const settings = getClientSettings();
     expect(settings.ATTRIBUTION_ENABLED).toBe(true);
     expect(settings.ATTRIBUTION_ANCHOR_TEXT).toBe(
@@ -37,6 +31,12 @@ describe("fides-js attribution config", () => {
       DEFAULT_ATTRIBUTION_DESTINATION_URL,
     );
     expect(settings.ATTRIBUTION_NOFOLLOW).toBe(false);
+  });
+
+  it("does not include attribution fields when ATTRIBUTION_ENABLED is false", () => {
+    process.env.FIDES_PRIVACY_CENTER__ATTRIBUTION_ENABLED = "false";
+    const settings = getClientSettings();
+    expect(settings.ATTRIBUTION_ENABLED).toBe(false);
   });
 
   it("includes custom attribution values when overridden", () => {
@@ -81,18 +81,18 @@ describe("fides-js handler attribution config building", () => {
     process.env = originalEnv;
   });
 
-  it("produces undefined attribution when disabled", () => {
+  it("produces attribution object with defaults when not set", () => {
     delete process.env.FIDES_PRIVACY_CENTER__ATTRIBUTION_ENABLED;
-    expect(buildAttributionOptions(getClientSettings())).toBeUndefined();
-  });
-
-  it("produces attribution object with defaults when enabled", () => {
-    process.env.FIDES_PRIVACY_CENTER__ATTRIBUTION_ENABLED = "true";
     expect(buildAttributionOptions(getClientSettings())).toEqual({
       anchorText: DEFAULT_ATTRIBUTION_ANCHOR_TEXT,
       destinationUrl: DEFAULT_ATTRIBUTION_DESTINATION_URL,
       nofollow: false,
     });
+  });
+
+  it("produces undefined attribution when explicitly disabled", () => {
+    process.env.FIDES_PRIVACY_CENTER__ATTRIBUTION_ENABLED = "false";
+    expect(buildAttributionOptions(getClientSettings())).toBeUndefined();
   });
 
   it("produces attribution object with custom values when overridden", () => {
@@ -108,16 +108,8 @@ describe("fides-js handler attribution config building", () => {
     });
   });
 
-  it("serializes cleanly to JSON without attribution when disabled", () => {
+  it("serializes attribution to JSON by default when not set", () => {
     delete process.env.FIDES_PRIVACY_CENTER__ATTRIBUTION_ENABLED;
-    const attribution = buildAttributionOptions(getClientSettings());
-    const options = { attribution, otherField: true };
-    const parsed = JSON.parse(JSON.stringify(options));
-    expect(parsed).not.toHaveProperty("attribution");
-  });
-
-  it("serializes attribution to JSON when enabled", () => {
-    process.env.FIDES_PRIVACY_CENTER__ATTRIBUTION_ENABLED = "true";
     const attribution = buildAttributionOptions(getClientSettings());
     const options = { attribution, otherField: true };
     const parsed = JSON.parse(JSON.stringify(options));
@@ -126,6 +118,14 @@ describe("fides-js handler attribution config building", () => {
       destinationUrl: DEFAULT_ATTRIBUTION_DESTINATION_URL,
       nofollow: false,
     });
+  });
+
+  it("serializes cleanly to JSON without attribution when explicitly disabled", () => {
+    process.env.FIDES_PRIVACY_CENTER__ATTRIBUTION_ENABLED = "false";
+    const attribution = buildAttributionOptions(getClientSettings());
+    const options = { attribution, otherField: true };
+    const parsed = JSON.parse(JSON.stringify(options));
+    expect(parsed).not.toHaveProperty("attribution");
   });
 });
 

--- a/clients/privacy-center/__tests__/server-utils/loadEnvironmentVariables.test.ts
+++ b/clients/privacy-center/__tests__/server-utils/loadEnvironmentVariables.test.ts
@@ -15,22 +15,22 @@ describe("loadEnvironmentVariables", () => {
   });
 
   describe("ATTRIBUTION_ENABLED", () => {
-    it("defaults to false when not set", () => {
+    it("defaults to true when not set", () => {
       delete process.env.FIDES_PRIVACY_CENTER__ATTRIBUTION_ENABLED;
-      const settings = loadEnvironmentVariables();
-      expect(settings.ATTRIBUTION_ENABLED).toBe(false);
-    });
-
-    it('is true when set to "true"', () => {
-      process.env.FIDES_PRIVACY_CENTER__ATTRIBUTION_ENABLED = "true";
       const settings = loadEnvironmentVariables();
       expect(settings.ATTRIBUTION_ENABLED).toBe(true);
     });
 
-    it("is false for any other value", () => {
-      process.env.FIDES_PRIVACY_CENTER__ATTRIBUTION_ENABLED = "yes";
+    it('is false when set to "false"', () => {
+      process.env.FIDES_PRIVACY_CENTER__ATTRIBUTION_ENABLED = "false";
       const settings = loadEnvironmentVariables();
       expect(settings.ATTRIBUTION_ENABLED).toBe(false);
+    });
+
+    it("is true for any other value", () => {
+      process.env.FIDES_PRIVACY_CENTER__ATTRIBUTION_ENABLED = "yes";
+      const settings = loadEnvironmentVariables();
+      expect(settings.ATTRIBUTION_ENABLED).toBe(true);
     });
   });
 

--- a/clients/privacy-center/app/server-utils/PrivacyCenterSettings.ts
+++ b/clients/privacy-center/app/server-utils/PrivacyCenterSettings.ts
@@ -79,7 +79,7 @@ export interface PrivacyCenterSettings {
     | "disabled"; // (optional) controls handling of unsupported repeated script loading (defaults to "disabled")
   FIDES_COOKIE_SUFFIX: string | null; // (optional) attaches as suffix to the cookie fides.js uses to store consent preferences in the format `fides_consent_{FIDES_COOKIE_SUFFIX}`
   FIDES_COOKIE_COMPRESSION: "gzip" | "none"; // (optional) compression method to use for the consent cookie (defaults to "none")
-  ATTRIBUTION_ENABLED: boolean; // (optional) whether attribution link is enabled (defaults to false)
+  ATTRIBUTION_ENABLED: boolean; // (optional) whether attribution link is enabled (defaults to true)
   ATTRIBUTION_ANCHOR_TEXT: string; // (optional) anchor text for attribution link (defaults to "Consent powered by Ethyca")
   ATTRIBUTION_DESTINATION_URL: string; // (optional) destination URL for attribution link. Must begin with "http://" or "https://". (defaults to "https://ethyca.com/consent")
   ATTRIBUTION_NOFOLLOW: boolean; // (optional) whether attribution link should have rel="nofollow" (defaults to false)

--- a/clients/privacy-center/app/server-utils/loadEnvironmentVariables.ts
+++ b/clients/privacy-center/app/server-utils/loadEnvironmentVariables.ts
@@ -197,7 +197,7 @@ const loadEnvironmentVariables = () => {
         | "none") || "none",
     // Attribution link options
     ATTRIBUTION_ENABLED:
-      process.env.FIDES_PRIVACY_CENTER__ATTRIBUTION_ENABLED === "true", // default: false
+      process.env.FIDES_PRIVACY_CENTER__ATTRIBUTION_ENABLED !== "false", // default: true
     ATTRIBUTION_ANCHOR_TEXT:
       process.env.FIDES_PRIVACY_CENTER__ATTRIBUTION_ANCHOR_TEXT ||
       DEFAULT_ATTRIBUTION_ANCHOR_TEXT,


### PR DESCRIPTION
## Summary
- Changes the `ATTRIBUTION_ENABLED` default from `false` to `true` in the Privacy Center, so the Ethyca attribution link is shown by default
- Operators can still disable it by setting `FIDES_PRIVACY_CENTER__ATTRIBUTION_ENABLED=false`
- Updates all related tests to reflect the new default behavior

## Test plan
- [ ] Verify Privacy Center shows attribution link by default (no env var set)
- [ ] Verify setting `FIDES_PRIVACY_CENTER__ATTRIBUTION_ENABLED=false` hides the attribution link
- [ ] Run `npm test` in `clients/privacy-center` and confirm all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)