### PR TITLE
ENG-3339: Rename /access-policy to /access-policies (frontend)

### DIFF
--- a/changelog/8225-rename-access-policy-to-plural.yaml
+++ b/changelog/8225-rename-access-policy-to-plural.yaml
@@ -1,0 +1,4 @@
+type: Changed
+description: Rename frontend API calls from `/access-policy` to `/access-policies` to align with REST naming conventions
+pr: 8225
+labels: []

--- a/clients/admin-ui/src/features/access-policies/access-policies.slice.ts
+++ b/clients/admin-ui/src/features/access-policies/access-policies.slice.ts
@@ -40,7 +40,7 @@ const accessPoliciesApi = baseApi.injectEndpoints({
     >({
       query: ({ page = 1, size = 50 } = {}) => ({
         method: "GET",
-        url: "plus/access-policy",
+        url: "plus/access-policies",
         params: { page, size },
       }),
       providesTags: () => ["Access Policies"],
@@ -48,14 +48,14 @@ const accessPoliciesApi = baseApi.injectEndpoints({
     getAccessPolicy: build.query<AccessPolicy, string>({
       query: (id) => ({
         method: "GET",
-        url: `plus/access-policy/${id}`,
+        url: `plus/access-policies/${id}`,
       }),
       providesTags: (_result, _error, id) => [{ type: "Access Policies", id }],
     }),
     createAccessPolicy: build.mutation<AccessPolicy, Partial<AccessPolicy>>({
       query: (body) => ({
         method: "POST",
-        url: "plus/access-policy",
+        url: "plus/access-policies",
         body,
       }),
       invalidatesTags: ["Access Policies"],
@@ -66,7 +66,7 @@ const accessPoliciesApi = baseApi.injectEndpoints({
     >({
       query: ({ id, ...body }) => ({
         method: "PATCH",
-        url: `plus/access-policy/${id}`,
+        url: `plus/access-policies/${id}`,
         body,
       }),
       invalidatesTags: (_result, _error, { id }) => [
@@ -77,7 +77,7 @@ const accessPoliciesApi = baseApi.injectEndpoints({
     deleteAccessPolicy: build.mutation<void, string>({
       query: (id) => ({
         method: "DELETE",
-        url: `plus/access-policy/${id}`,
+        url: `plus/access-policies/${id}`,
       }),
       invalidatesTags: ["Access Policies"],
     }),
@@ -87,7 +87,7 @@ const accessPoliciesApi = baseApi.injectEndpoints({
     >({
       query: ({ id, insert_after_id }) => ({
         method: "POST",
-        url: `plus/access-policy/${id}/reorder`,
+        url: `plus/access-policies/${id}/reorder`,
         body: { insert_after_id },
       }),
       invalidatesTags: ["Access Policies"],
@@ -138,7 +138,7 @@ const accessPoliciesApi = baseApi.injectEndpoints({
     getOnboardingIndustries: build.query<OnboardingIndustriesResponse, void>({
       query: () => ({
         method: "GET",
-        url: "plus/access-policy/presets/industries",
+        url: "plus/access-policies/presets/industries",
       }),
     }),
     getOnboardingDataUses: build.query<
@@ -151,20 +151,20 @@ const accessPoliciesApi = baseApi.injectEndpoints({
         geographies.forEach((g) => params.append("geographies", g));
         return {
           method: "GET",
-          url: `plus/access-policy/presets/data-uses?${params.toString()}`,
+          url: `plus/access-policies/presets/data-uses?${params.toString()}`,
         };
       },
     }),
     getOnboardingConfig: build.query<OnboardingConfigResponse, void>({
       query: () => ({
         method: "GET",
-        url: "plus/access-policy/presets/config",
+        url: "plus/access-policies/presets/config",
       }),
     }),
     generatePolicies: build.mutation<GeneratePoliciesResponse, FormData>({
       query: (formData) => ({
         method: "POST",
-        url: "plus/access-policy/presets/generate",
+        url: "plus/access-policies/presets/generate",
         body: formData,
       }),
       invalidatesTags: ["Access Policies"],

--- a/clients/admin-ui/src/features/access-policies/agent-chat.slice.ts
+++ b/clients/admin-ui/src/features/access-policies/agent-chat.slice.ts
@@ -39,7 +39,7 @@ const agentChatApi = baseApi.injectEndpoints({
     >({
       query: (body) => ({
         method: "POST",
-        url: "plus/access-policy/agent",
+        url: "plus/access-policies/agent",
         body,
       }),
     }),

--- a/clients/admin-ui/src/mocks/access-policies/agent-chat-handlers.ts
+++ b/clients/admin-ui/src/mocks/access-policies/agent-chat-handlers.ts
@@ -88,7 +88,7 @@ export const agentChatHandlers = () => {
   ];
 
   return [
-    rest.post("*/api/v1/plus/access-policy/agent", async (req, res, ctx) => {
+    rest.post("*/api/v1/plus/access-policies/agent", async (req, res, ctx) => {
       const body = await req.json();
       const chatHistoryId =
         (body.chat_history_id as string) ?? crypto.randomUUID();

--- a/clients/admin-ui/src/mocks/access-policies/handlers.ts
+++ b/clients/admin-ui/src/mocks/access-policies/handlers.ts
@@ -24,8 +24,8 @@ export const accessPoliciesHandlers = () => {
   const controls: Control[] = [...mockControls];
 
   return [
-    // GET /api/v1/plus/access-policy - list all
-    rest.get(`${apiBase}/plus/access-policy`, (req, res, ctx) => {
+    // GET /api/v1/plus/access-policies - list all
+    rest.get(`${apiBase}/plus/access-policies`, (req, res, ctx) => {
       const page = parseInt(req.url.searchParams.get("page") ?? "1", 10);
       const size = parseInt(req.url.searchParams.get("size") ?? "50", 10);
 
@@ -44,9 +44,9 @@ export const accessPoliciesHandlers = () => {
       );
     }),
 
-    // GET /api/v1/plus/access-policy/presets/industries - available industries
+    // GET /api/v1/plus/access-policies/presets/industries - available industries
     rest.get(
-      `${apiBase}/plus/access-policy/presets/industries`,
+      `${apiBase}/plus/access-policies/presets/industries`,
       (_req, res, ctx) =>
         res(
           ctx.status(200),
@@ -59,17 +59,19 @@ export const accessPoliciesHandlers = () => {
         ),
     ),
 
-    // GET /api/v1/plus/access-policy/presets/config - saved config
-    rest.get(`${apiBase}/plus/access-policy/presets/config`, (_req, res, ctx) =>
-      res(
-        ctx.status(200),
-        ctx.json({ industry: "fintech", geographies: ["eea", "us"] }),
-      ),
+    // GET /api/v1/plus/access-policies/presets/config - saved config
+    rest.get(
+      `${apiBase}/plus/access-policies/presets/config`,
+      (_req, res, ctx) =>
+        res(
+          ctx.status(200),
+          ctx.json({ industry: "fintech", geographies: ["eea", "us"] }),
+        ),
     ),
 
-    // GET /api/v1/plus/access-policy/presets/data-uses - data uses by industry + geography
+    // GET /api/v1/plus/access-policies/presets/data-uses - data uses by industry + geography
     rest.get(
-      `${apiBase}/plus/access-policy/presets/data-uses`,
+      `${apiBase}/plus/access-policies/presets/data-uses`,
       (req, res, ctx) => {
         const industry = req.url.searchParams.get("industry") ?? "";
         const geographies = req.url.searchParams.getAll("geographies");
@@ -85,9 +87,9 @@ export const accessPoliciesHandlers = () => {
       },
     ),
 
-    // POST /api/v1/plus/access-policy/presets/generate - generate policies from onboarding
+    // POST /api/v1/plus/access-policies/presets/generate - generate policies from onboarding
     rest.post(
-      `${apiBase}/plus/access-policy/presets/generate`,
+      `${apiBase}/plus/access-policies/presets/generate`,
       (_req, res, ctx) => {
         // Push generated policies into the mutable array so the list view picks them up
         const generated = generatedPoliciesForIndustry();
@@ -188,8 +190,8 @@ export const accessPoliciesHandlers = () => {
       return res(ctx.status(204));
     }),
 
-    // GET /api/v1/plus/access-policy/:id - get single
-    rest.get(`${apiBase}/plus/access-policy/:id`, (req, res, ctx) => {
+    // GET /api/v1/plus/access-policies/:id - get single
+    rest.get(`${apiBase}/plus/access-policies/:id`, (req, res, ctx) => {
       const { id } = req.params;
       const policy = policies.find((p) => p.id === id);
 
@@ -203,8 +205,8 @@ export const accessPoliciesHandlers = () => {
       return res(ctx.status(200), ctx.json(policy));
     }),
 
-    // POST /api/v1/plus/access-policy - create
-    rest.post(`${apiBase}/plus/access-policy`, async (req, res, ctx) => {
+    // POST /api/v1/plus/access-policies - create
+    rest.post(`${apiBase}/plus/access-policies`, async (req, res, ctx) => {
       const body = await req.json();
       const newPolicy: AccessPolicy = {
         ...body,
@@ -216,9 +218,9 @@ export const accessPoliciesHandlers = () => {
       return res(ctx.status(201), ctx.json(newPolicy));
     }),
 
-    // POST /api/v1/plus/access-policy/:id/reorder - reorder
+    // POST /api/v1/plus/access-policies/:id/reorder - reorder
     rest.post(
-      `${apiBase}/plus/access-policy/:id/reorder`,
+      `${apiBase}/plus/access-policies/:id/reorder`,
       async (req, res, ctx) => {
         const { id } = req.params;
         const body = await req.json();
@@ -264,8 +266,8 @@ export const accessPoliciesHandlers = () => {
       },
     ),
 
-    // PATCH /api/v1/plus/access-policy/:id - partial update
-    rest.patch(`${apiBase}/plus/access-policy/:id`, async (req, res, ctx) => {
+    // PATCH /api/v1/plus/access-policies/:id - partial update
+    rest.patch(`${apiBase}/plus/access-policies/:id`, async (req, res, ctx) => {
       const { id } = req.params;
       const index = policies.findIndex((p) => p.id === id);
 
@@ -286,8 +288,8 @@ export const accessPoliciesHandlers = () => {
       return res(ctx.status(200), ctx.json(policies[index]));
     }),
 
-    // DELETE /api/v1/plus/access-policy/:id - delete
-    rest.delete(`${apiBase}/plus/access-policy/:id`, (req, res, ctx) => {
+    // DELETE /api/v1/plus/access-policies/:id - delete
+    rest.delete(`${apiBase}/plus/access-policies/:id`, (req, res, ctx) => {
       const { id } = req.params;
       const index = policies.findIndex((p) => p.id === id);
 

--- a/clients/admin-ui/src/types/api/types.ts
+++ b/clients/admin-ui/src/types/api/types.ts
@@ -12710,7 +12710,7 @@ export type listAccessPoliciesApiV1PlusAccessPolicyGetData = {
      */
     size?: number;
   };
-  url: "/api/v1/plus/access-policy";
+  url: "/api/v1/plus/access-policies";
 };
 
 export type listAccessPoliciesApiV1PlusAccessPolicyGetErrors = {
@@ -12737,7 +12737,7 @@ export type createAccessPolicyApiV1PlusAccessPolicyPostData = {
   body: AccessPolicyCreate;
   path?: never;
   query?: never;
-  url: "/api/v1/plus/access-policy";
+  url: "/api/v1/plus/access-policies";
 };
 
 export type createAccessPolicyApiV1PlusAccessPolicyPostErrors = {
@@ -12769,7 +12769,7 @@ export type deleteAccessPolicyApiV1PlusAccessPolicyAccessPolicyIdDeleteData = {
     access_policy_id: string;
   };
   query?: never;
-  url: "/api/v1/plus/access-policy/{access_policy_id}";
+  url: "/api/v1/plus/access-policies/{access_policy_id}";
 };
 
 export type deleteAccessPolicyApiV1PlusAccessPolicyAccessPolicyIdDeleteErrors =
@@ -12803,7 +12803,7 @@ export type getAccessPolicyApiV1PlusAccessPolicyAccessPolicyIdGetData = {
     access_policy_id: string;
   };
   query?: never;
-  url: "/api/v1/plus/access-policy/{access_policy_id}";
+  url: "/api/v1/plus/access-policies/{access_policy_id}";
 };
 
 export type getAccessPolicyApiV1PlusAccessPolicyAccessPolicyIdGetErrors = {
@@ -12835,7 +12835,7 @@ export type updateAccessPolicyApiV1PlusAccessPolicyAccessPolicyIdPatchData = {
     access_policy_id: string;
   };
   query?: never;
-  url: "/api/v1/plus/access-policy/{access_policy_id}";
+  url: "/api/v1/plus/access-policies/{access_policy_id}";
 };
 
 export type updateAccessPolicyApiV1PlusAccessPolicyAccessPolicyIdPatchErrors = {


### PR DESCRIPTION
Ticket [ENG-3339](https://ethyca.atlassian.net/browse/ENG-3339)

### Description Of Changes

Updates all frontend URL strings to use the pluralised `/access-policies` path, matching the companion backend rename in [ethyca/fidesplus](https://github.com/ethyca/fidesplus).

**Accepted risk — no API versioning:** These endpoints are not yet exposed to external clients. The Admin UI is the only consumer, and both the frontend and backend are updated atomically across these two PRs.

### Code Changes

* `clients/admin-ui/src/features/access-policies/access-policies.slice.ts` — all RTK Query endpoint URLs updated (`plus/access-policy` → `plus/access-policies`)
* `clients/admin-ui/src/features/access-policies/agent-chat.slice.ts` — agent endpoint URL updated
* `clients/admin-ui/src/mocks/access-policies/handlers.ts` — all MSW mock handler URL patterns updated
* `clients/admin-ui/src/mocks/access-policies/agent-chat-handlers.ts` — agent mock handler URL updated
* `clients/admin-ui/src/types/api/types.ts` — generated TypeScript API type URL strings updated

### Steps to Confirm

1. Navigate to `/access-policies` in the Admin UI → page loads, network tab shows `GET /api/v1/plus/access-policies` returning **200**
2. Navigate to `/access-policies/new` → editor loads, `GET /api/v1/plus/controls` called correctly
3. Navigate to `/access-policies/controls` → controls list renders
4. Verify no requests to the old `/api/v1/plus/access-policy` path appear in the network tab on any of the above pages

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated — N/A, internal API path rename with no user-facing impact
  * [x] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [x] No UX review needed — URL path rename, no visible UI changes
* Followup issues:
  * [x] No followup issues
* Database migrations:
  * [x] No migrations
* Documentation:
  * [x] No documentation updates required — `/access-policy` path is not referenced in public docs

[ENG-3339]: https://ethyca.atlassian.net/browse/ENG-3339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ