### PR TITLE
ENG-3664: Allow for HTML in manage consent page description in Privacy Center

### DIFF
--- a/changelog/8226-privacy-center-consent-html.yaml
+++ b/changelog/8226-privacy-center-consent-html.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Fixed Privacy Center consent page heading and description rendering HTML as escaped text when ALLOW_HTML_DESCRIPTION is enabled.
+pr: 8226
+labels: []

--- a/clients/privacy-center/components/HomePage.tsx
+++ b/clients/privacy-center/components/HomePage.tsx
@@ -6,8 +6,6 @@ import {
   ChakraHeading as Heading,
   ChakraLink as Link,
   ChakraStack as Stack,
-  ChakraText as Text,
-  ChakraTextProps as TextProps,
   useChakraDisclosure as useDisclosure,
   useChakraToast as useToast,
 } from "fidesui";
@@ -18,7 +16,6 @@ import React, { ReactNode, useEffect, useState } from "react";
 import { useAppSelector } from "~/app/hooks";
 import { getEffectivePrivacyCenterLinks } from "~/common/config-links";
 import { encodePolicyKey } from "~/common/policy-key";
-import sanitizeHTML from "~/common/sanitize-html";
 import { ConfigErrorToastOptions } from "~/common/toast-options";
 import BrandLink from "~/components/BrandLink";
 import ConsentCard from "~/components/consent/ConsentCard";
@@ -28,6 +25,7 @@ import {
 } from "~/components/modals/consent-request-modal/ConsentRequestModal";
 import NoticeEmptyStateModal from "~/components/modals/NoticeEmptyStateModal";
 import PrivacyCard from "~/components/PrivacyCard";
+import TextOrHtml from "~/components/TextOrHtml";
 import { useConfig } from "~/features/common/config.slice";
 import {
   selectIsNoticeDriven,
@@ -36,28 +34,6 @@ import {
 import { selectPrivacyExperience } from "~/features/consent/consent.slice";
 import { useSubscribeToPrivacyExperienceQuery } from "~/features/consent/hooks";
 import { useGetIdVerificationConfigQuery } from "~/features/id-verification";
-
-const TextOrHtml = ({
-  allowHTMLDescription,
-  children,
-  ...props
-}: Omit<TextProps, "children"> & {
-  allowHTMLDescription: boolean | null;
-  children: string;
-}) => {
-  if (allowHTMLDescription) {
-    return (
-      <Text
-        {...props}
-        dangerouslySetInnerHTML={{
-          __html: sanitizeHTML(children.trim()),
-        }}
-      />
-    );
-  }
-
-  return <Text {...props}>{children}</Text>;
-};
 
 const HomePage: NextPage = () => {
   const config = useConfig();

--- a/clients/privacy-center/components/TextOrHtml.tsx
+++ b/clients/privacy-center/components/TextOrHtml.tsx
@@ -1,0 +1,32 @@
+import { ChakraText as Text, ChakraTextProps as TextProps } from "fidesui";
+import { ElementType } from "react";
+
+import sanitizeHTML from "~/common/sanitize-html";
+
+type TextOrHtmlProps = Omit<TextProps, "children"> & {
+  allowHTMLDescription: boolean | null;
+  children: string;
+  component?: ElementType;
+};
+
+const TextOrHtml = ({
+  allowHTMLDescription,
+  children,
+  component: Component = Text,
+  ...props
+}: TextOrHtmlProps) => {
+  if (allowHTMLDescription) {
+    return (
+      <Component
+        {...props}
+        dangerouslySetInnerHTML={{
+          __html: sanitizeHTML(children.trim()),
+        }}
+      />
+    );
+  }
+
+  return <Component {...props}>{children}</Component>;
+};
+
+export default TextOrHtml;

--- a/clients/privacy-center/components/consent/ConsentDescription.tsx
+++ b/clients/privacy-center/components/consent/ConsentDescription.tsx
@@ -1,13 +1,13 @@
-import {
-  ChakraBox as Box,
-  ChakraText as Text,
-  ChakraTextProps as TextProps,
-} from "fidesui";
+import { ChakraBox as Box, ChakraTextProps as TextProps } from "fidesui";
 
 import { useAppSelector } from "~/app/hooks";
 import useI18n from "~/common/hooks/useI18n";
+import TextOrHtml from "~/components/TextOrHtml";
 import { useConfig } from "~/features/common/config.slice";
-import { selectIsNoticeDriven } from "~/features/common/settings.slice";
+import {
+  selectIsNoticeDriven,
+  useSettings,
+} from "~/features/common/settings.slice";
 
 const TEXT_PROPS: TextProps = {
   fontSize: ["small", "medium"],
@@ -20,34 +20,41 @@ const TEXT_PROPS: TextProps = {
 const ConsentDescription = () => {
   const config = useConfig();
   const isNoticeDriven = useAppSelector(selectIsNoticeDriven);
+  const { ALLOW_HTML_DESCRIPTION } = useSettings();
   const { i18n } = useI18n();
 
   if (!isNoticeDriven) {
     return (
       <Box className="pc-page__description" data-testid="consent-description">
-        <Text {...TEXT_PROPS} data-testid="description">
-          {config.consent?.page.description}
-        </Text>
+        <TextOrHtml
+          {...TEXT_PROPS}
+          data-testid="description"
+          allowHTMLDescription={ALLOW_HTML_DESCRIPTION}
+        >
+          {config.consent?.page.description ?? ""}
+        </TextOrHtml>
         {config.consent?.page.description_subtext?.map((paragraph, index) => (
-          <Text
+          <TextOrHtml
             {...TEXT_PROPS}
+            allowHTMLDescription={ALLOW_HTML_DESCRIPTION}
             // eslint-disable-next-line react/no-array-index-key
             key={`description-subtext${index}`}
           >
             {paragraph}
-          </Text>
+          </TextOrHtml>
         ))}
       </Box>
     );
   }
   return (
-    <Text
+    <TextOrHtml
       className="pc-page__description"
       {...TEXT_PROPS}
       data-testid="consent-description"
+      allowHTMLDescription={ALLOW_HTML_DESCRIPTION}
     >
       {i18n.t("exp.description")}
-    </Text>
+    </TextOrHtml>
   );
 };
 

--- a/clients/privacy-center/components/consent/ConsentHeading.tsx
+++ b/clients/privacy-center/components/consent/ConsentHeading.tsx
@@ -3,24 +3,30 @@ import { useMemo } from "react";
 
 import { useAppSelector } from "~/app/hooks";
 import useI18n from "~/common/hooks/useI18n";
+import TextOrHtml from "~/components/TextOrHtml";
 import { useConfig } from "~/features/common/config.slice";
-import { selectIsNoticeDriven } from "~/features/common/settings.slice";
+import {
+  selectIsNoticeDriven,
+  useSettings,
+} from "~/features/common/settings.slice";
 
 const ConsentHeading = () => {
   const config = useConfig();
   const isNoticeDriven = useAppSelector(selectIsNoticeDriven);
+  const { ALLOW_HTML_DESCRIPTION } = useSettings();
   const { i18n } = useI18n();
 
   const headingText = useMemo(() => {
     if (!isNoticeDriven) {
-      return config.consent?.page.title;
+      return config.consent?.page.title ?? "";
     }
 
     return i18n.t("exp.title");
   }, [config, isNoticeDriven, i18n]);
 
   return (
-    <Heading
+    <TextOrHtml
+      component={Heading}
       className="pc-page__heading"
       fontSize={["3xl", "4xl"]}
       color="gray.800"
@@ -28,9 +34,10 @@ const ConsentHeading = () => {
       textAlign="center"
       data-testid="consent-heading"
       mb={3}
+      allowHTMLDescription={ALLOW_HTML_DESCRIPTION}
     >
       {headingText}
-    </Heading>
+    </TextOrHtml>
   );
 };
 

--- a/clients/privacy-center/cypress/e2e/privacy-center/consent.cy.ts
+++ b/clients/privacy-center/cypress/e2e/privacy-center/consent.cy.ts
@@ -225,6 +225,62 @@ describe("Consent settings", () => {
       cy.getByTestId("consent-description").contains("When you use our");
     });
 
+    describe("HTML in heading and description", () => {
+      const HTML_TITLE = "Manage <strong>your</strong> consent";
+      const HTML_DESCRIPTION =
+        "Review <em>your</em> consent preferences <strong>now</strong>";
+
+      const overrideConfigWithHtml = () => {
+        cy.fixture("config/config_consent.json").then((config) => {
+          cy.dispatch({
+            type: "config/loadConfig",
+            payload: {
+              ...config,
+              consent: {
+                ...config.consent,
+                page: {
+                  ...config.consent.page,
+                  title: HTML_TITLE,
+                  description: HTML_DESCRIPTION,
+                },
+              },
+            },
+          });
+        });
+      };
+
+      it("renders HTML when ALLOW_HTML_DESCRIPTION is true", () => {
+        cy.overrideSettings({
+          IS_OVERLAY_ENABLED: false,
+          ALLOW_HTML_DESCRIPTION: true,
+        });
+        overrideConfigWithHtml();
+
+        cy.getByTestId("consent-heading")
+          .find("strong")
+          .should("contain", "your");
+        cy.getByTestId("description").find("em").should("contain", "your");
+        cy.getByTestId("description").find("strong").should("contain", "now");
+      });
+
+      it("escapes HTML when ALLOW_HTML_DESCRIPTION is false", () => {
+        cy.overrideSettings({
+          IS_OVERLAY_ENABLED: false,
+          ALLOW_HTML_DESCRIPTION: false,
+        });
+        overrideConfigWithHtml();
+
+        cy.getByTestId("consent-heading")
+          .should("contain", HTML_TITLE)
+          .find("strong")
+          .should("not.exist");
+        cy.getByTestId("description")
+          .should("contain", HTML_DESCRIPTION)
+          .find("em")
+          .should("not.exist");
+      });
+    });
+
     it("lets the user update their consent", () => {
       cy.getByTestId("consent");
 


### PR DESCRIPTION
Ticket [ENG-3664] <!-- simply paste the ticket number between the brackets and it will auto-convert to a link -->

### Description Of Changes

HTML in the Privacy Center consent page heading and description rendered as escaped text even when `ALLOW_HTML_DESCRIPTION` was enabled. The setting was wired up for the landing page in #6643 but never applied to the consent page components.

This PR extracts the existing `TextOrHtml` helper from `HomePage.tsx` into a shared component and uses it in `ConsentHeading` and `ConsentDescription` (both notice-driven and config-driven branches), gated on the same setting and using the same allowlist sanitizer.

### Code Changes

* Extracted `TextOrHtml` from `HomePage.tsx` into a new shared `components/TextOrHtml.tsx`, with an optional `component` prop (defaults to `Text`) so callers can render different underlying typography.
* Updated `HomePage.tsx` to import the shared component and drop the local definition.
* Updated `ConsentDescription.tsx` to render the description and `description_subtext` through `TextOrHtml` in both notice-driven and config-driven branches, gated on `ALLOW_HTML_DESCRIPTION`.
* Updated `ConsentHeading.tsx` to render through `TextOrHtml` with `component={Heading}`, gated on `ALLOW_HTML_DESCRIPTION`.
* Added Cypress coverage in `consent.cy.ts` verifying HTML renders when the flag is on and escapes when off.

### Before

<img width="953" height="833" alt="image" src="https://github.com/user-attachments/assets/bd0f2792-3e38-4209-bf97-e51f81e6fb82" />

### After

<img width="1014" height="912" alt="image" src="https://github.com/user-attachments/assets/7d596f6b-f675-4d73-8247-304c0707de1b" />

### Steps to Confirm

1. Set `FIDES_PRIVACY_CENTER__ALLOW_HTML_DESCRIPTION=true` and `FIDES_PRIVACY_CENTER__IS_OVERLAY_ENABLED=true` on the Privacy Center, then restart it.
2. In the admin UI, edit a `privacy_center` experience's English translation and put HTML (e.g. `<strong>bold</strong>`, `<em>italic</em>`, `<ul><li>item</li></ul>`, `<a href="...">link</a>`) in both the title and description fields. Save.
3. Visit `/consent` on the Privacy Center, forcing a matching location via `?geolocation=US-XX` for one of the experience's locations. Confirm the heading and description render the HTML (bold, italic, list, link).
4. Restart with `FIDES_PRIVACY_CENTER__ALLOW_HTML_DESCRIPTION=false` and reload `/consent`. Confirm the HTML now renders as literal escaped tags.
5. Regression check: with the flag back on, put HTML in the PC `config.json` `description` and load `/` — confirm the landing page still renders HTML and escapes it when the flag is off.

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-3664]: https://ethyca.atlassian.net/browse/ENG-3664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
