### PR TITLE
ENG-3550: Migrate modal Privacy Declaration form to antd

### DIFF
--- a/changelog/8229-modal-privacy-declaration-form-antd.yaml
+++ b/changelog/8229-modal-privacy-declaration-form-antd.yaml
@@ -1,0 +1,4 @@
+type: Changed
+description: Migrated the system configure "Configure data use" modal form from Formik to antd, with unsaved-changes protection on close
+pr: 8229
+labels: []

--- a/clients/admin-ui/cypress/e2e/systems/plus/data-uses-tab.cy.ts
+++ b/clients/admin-ui/cypress/e2e/systems/plus/data-uses-tab.cy.ts
@@ -49,17 +49,15 @@ describe("System Data Uses Tab", () => {
     cy.getByTestId("row-functional.service.improve").click();
 
     // Check state of available inputs
-    cy.getByTestId("controlled-select-data_categories")
-      .find("input")
-      .should("be.disabled");
-    cy.getByTestId("controlled-select-data_subjects")
+    cy.getByTestId("input-data_categories").find("input").should("be.disabled");
+    cy.getByTestId("input-data_subjects")
       .find("input")
       .should("not.be.disabled");
     cy.getByTestId("input-impact_assessment_location").should("not.exist");
     cy.getByTestId("input-processes_special_category_data").should(
       "not.be.disabled",
     );
-    cy.getByTestId("controlled-select-dataset_references")
+    cy.getByTestId("input-dataset_references")
       .find("input")
       .should("not.be.disabled");
     cy.getByTestId("input-data_shared_with_third_parties").click();
@@ -82,13 +80,13 @@ describe("System Data Uses Tab", () => {
     cy.getByTestId("row-functional.service.improve").click();
 
     // Check state of available inputs
-    cy.getByTestId("controlled-select-data_categories")
+    cy.getByTestId("input-data_categories")
       .find("input")
       .should("not.be.disabled");
-    cy.getByTestId("controlled-select-data_subjects")
+    cy.getByTestId("input-data_subjects")
       .find("input")
       .should("not.be.disabled");
-    cy.getByTestId("controlled-select-legal_basis_for_processing").antSelect(
+    cy.getByTestId("input-legal_basis_for_processing").antSelect(
       "Legitimate interests",
     );
     cy.getByTestId("input-impact_assessment_location").should(
@@ -97,7 +95,7 @@ describe("System Data Uses Tab", () => {
     cy.getByTestId("input-processes_special_category_data").should(
       "not.be.disabled",
     );
-    cy.getByTestId("controlled-select-dataset_references")
+    cy.getByTestId("input-dataset_references")
       .find("input")
       .should("not.be.disabled");
     cy.getByTestId("input-data_shared_with_third_parties").click();
@@ -125,8 +123,6 @@ describe("System Data Uses Tab", () => {
     cy.getAntTab("Data uses").click();
 
     cy.getByTestId("row-functional.service.improve").click();
-    cy.getByTestId("controlled-select-data_use")
-      .find("input")
-      .should("be.disabled");
+    cy.getByTestId("input-data_use").find("input").should("be.disabled");
   });
 });

--- a/clients/admin-ui/src/features/system/privacy-declaration-fields/DataCategoriesFormItem.tsx
+++ b/clients/admin-ui/src/features/system/privacy-declaration-fields/DataCategoriesFormItem.tsx
@@ -5,26 +5,35 @@ import { DataCategory } from "~/types/api";
 interface DataCategoriesFormItemProps {
   allDataCategories: DataCategory[];
   disabled?: boolean;
+  required?: boolean;
+  tooltip?: string;
 }
+
+const DEFAULT_TOOLTIP =
+  "What type of data is your system processing? This could be various types of user or system data.";
 
 export const DataCategoriesFormItem = ({
   allDataCategories,
   disabled,
+  required,
+  tooltip = DEFAULT_TOOLTIP,
 }: DataCategoriesFormItemProps) => (
   <Form.Item
     name="data_categories"
     label="Data categories"
-    tooltip="What type of data is your system processing? This could be various types of user or system data."
-    rules={[
-      {
-        validator: (_, value: string[] | undefined) =>
-          value && value.length > 0
-            ? Promise.resolve()
-            : Promise.reject(
-                new Error("Must assign at least one data category"),
-              ),
-      },
-    ]}
+    tooltip={tooltip}
+    rules={
+      required
+        ? [
+            {
+              required: true,
+              type: "array",
+              min: 1,
+              message: "Must assign at least one data category",
+            },
+          ]
+        : undefined
+    }
   >
     <Select
       aria-label="Data categories"

--- a/clients/admin-ui/src/features/system/privacy-declaration-fields/DataSubjectsFormItem.tsx
+++ b/clients/admin-ui/src/features/system/privacy-declaration-fields/DataSubjectsFormItem.tsx
@@ -6,27 +6,30 @@ interface DataSubjectsFormItemProps {
   allDataSubjects: DataSubject[];
   disabled?: boolean;
   required?: boolean;
+  tooltip?: string;
 }
+
+const DEFAULT_TOOLTIP =
+  "Whose data are you processing? This could be customers, employees or any other type of user in your system.";
 
 export const DataSubjectsFormItem = ({
   allDataSubjects,
   disabled,
   required,
+  tooltip = DEFAULT_TOOLTIP,
 }: DataSubjectsFormItemProps) => (
   <Form.Item
     name="data_subjects"
     label="Data subjects"
-    tooltip="Whose data are you processing? This could be customers, employees or any other type of user in your system."
+    tooltip={tooltip}
     rules={
       required
         ? [
             {
-              validator: (_, value: string[] | undefined) =>
-                value && value.length > 0
-                  ? Promise.resolve()
-                  : Promise.reject(
-                      new Error("Must assign at least one data subject"),
-                    ),
+              required: true,
+              type: "array",
+              min: 1,
+              message: "Must assign at least one data subject",
             },
           ]
         : undefined

--- a/clients/admin-ui/src/features/system/privacy-declaration-fields/DataUseFormItem.tsx
+++ b/clients/admin-ui/src/features/system/privacy-declaration-fields/DataUseFormItem.tsx
@@ -5,16 +5,21 @@ import { DataUse } from "~/types/api";
 interface DataUseFormItemProps {
   allDataUses: DataUse[];
   disabled?: boolean;
+  tooltip?: string;
 }
+
+const DEFAULT_TOOLTIP =
+  "What is the system using the data for. For example, is it for third party advertising or perhaps simply providing system operations.";
 
 export const DataUseFormItem = ({
   allDataUses,
   disabled,
+  tooltip = DEFAULT_TOOLTIP,
 }: DataUseFormItemProps) => (
   <Form.Item
     name="data_use"
     label="Data use"
-    tooltip="What is the system using the data for. For example, is it for third party advertising or perhaps simply providing system operations."
+    tooltip={tooltip}
     rules={[{ required: true, message: "Data use is required" }]}
   >
     <Select

--- a/clients/admin-ui/src/features/system/privacy-declaration-fields/DatasetReferencesFormItem.tsx
+++ b/clients/admin-ui/src/features/system/privacy-declaration-fields/DatasetReferencesFormItem.tsx
@@ -6,16 +6,20 @@ import { Dataset } from "~/types/api";
 interface DatasetReferencesFormItemProps {
   allDatasets: Dataset[];
   disabled?: boolean;
+  tooltip?: string;
 }
+
+const DEFAULT_TOOLTIP = "Referenced Dataset fides keys used by the system.";
 
 export const DatasetReferencesFormItem = ({
   allDatasets,
   disabled,
+  tooltip = DEFAULT_TOOLTIP,
 }: DatasetReferencesFormItemProps) => (
   <Form.Item
     name="dataset_references"
     label="Dataset references"
-    tooltip="Referenced Dataset fides keys used by the system."
+    tooltip={tooltip}
   >
     <Select
       aria-label="Dataset references"

--- a/clients/admin-ui/src/features/system/privacy-declaration-fields/PrivacyDeclarationCustomFields.tsx
+++ b/clients/admin-ui/src/features/system/privacy-declaration-fields/PrivacyDeclarationCustomFields.tsx
@@ -1,0 +1,97 @@
+import { Form, Input, Select, Spin } from "fidesui";
+
+import { useCustomFields } from "~/features/common/custom-fields";
+import {
+  LegacyAllowedTypes,
+  LegacyResourceTypes,
+} from "~/features/common/custom-fields/types";
+import SystemFormInputGroup from "~/features/system/SystemFormInputGroup";
+
+interface PrivacyDeclarationCustomFieldsProps {
+  privacyDeclarationId?: string;
+}
+
+/**
+ * antd Form-aware renderer for privacy-declaration custom fields. Mirrors the
+ * Formik-based `CustomFieldsList` but uses `Form.Item` with nested name paths
+ * (`["customFieldValues", definitionId]`) so values land under the
+ * `customFieldValues` namespace in the parent antd form.
+ *
+ * Returns `null` when custom fields are disabled or no definitions exist.
+ */
+export const PrivacyDeclarationCustomFields = ({
+  privacyDeclarationId,
+}: PrivacyDeclarationCustomFieldsProps) => {
+  const {
+    idToAllowListWithOptions,
+    idToCustomFieldDefinition,
+    isEnabled,
+    isLoading,
+    sortedCustomFieldDefinitionIds,
+  } = useCustomFields({
+    resourceType: LegacyResourceTypes.PRIVACY_DECLARATION,
+    resourceFidesKey: privacyDeclarationId,
+  });
+
+  if (!isEnabled || sortedCustomFieldDefinitionIds.length === 0) {
+    return null;
+  }
+
+  return (
+    <SystemFormInputGroup heading="Custom fields">
+      {isLoading ? (
+        <Spin />
+      ) : (
+        sortedCustomFieldDefinitionIds.map((definitionId) => {
+          const definition = idToCustomFieldDefinition.get(definitionId);
+          if (!definition) {
+            return null;
+          }
+          const fieldName = ["customFieldValues", definition.id];
+          const isFreeText =
+            !definition.allow_list_id &&
+            definition.field_type === LegacyAllowedTypes.STRING;
+
+          if (isFreeText) {
+            return (
+              <Form.Item
+                key={definitionId}
+                name={fieldName}
+                label={definition.name}
+                tooltip={definition.description}
+              >
+                <Input aria-label={definition.name} />
+              </Form.Item>
+            );
+          }
+
+          const allowList = idToAllowListWithOptions.get(
+            definition.allow_list_id!,
+          );
+          if (!allowList) {
+            return null;
+          }
+
+          const isMulti = definition.field_type !== LegacyAllowedTypes.STRING;
+
+          return (
+            <Form.Item
+              key={definitionId}
+              name={fieldName}
+              label={definition.name}
+              tooltip={definition.description}
+            >
+              <Select
+                aria-label={definition.name}
+                allowClear
+                mode={isMulti ? "multiple" : undefined}
+                options={allowList.options}
+                className="w-full"
+              />
+            </Form.Item>
+          );
+        })
+      )}
+    </SystemFormInputGroup>
+  );
+};

--- a/clients/admin-ui/src/features/system/privacy-declaration-fields/PrivacyDeclarationCustomFields.tsx
+++ b/clients/admin-ui/src/features/system/privacy-declaration-fields/PrivacyDeclarationCustomFields.tsx
@@ -1,11 +1,10 @@
-import { Form, Input, Select, Spin } from "fidesui";
+import { Card, Form, Input, Select, Spin } from "fidesui";
 
 import { useCustomFields } from "~/features/common/custom-fields";
 import {
   LegacyAllowedTypes,
   LegacyResourceTypes,
 } from "~/features/common/custom-fields/types";
-import SystemFormInputGroup from "~/features/system/SystemFormInputGroup";
 
 interface PrivacyDeclarationCustomFieldsProps {
   privacyDeclarationId?: string;
@@ -38,7 +37,7 @@ export const PrivacyDeclarationCustomFields = ({
   }
 
   return (
-    <SystemFormInputGroup heading="Custom fields">
+    <Card size="small" title="Custom fields">
       {isLoading ? (
         <Spin />
       ) : (
@@ -92,6 +91,6 @@ export const PrivacyDeclarationCustomFields = ({
           );
         })
       )}
-    </SystemFormInputGroup>
+    </Card>
   );
 };

--- a/clients/admin-ui/src/features/system/privacy-declaration-fields/index.ts
+++ b/clients/admin-ui/src/features/system/privacy-declaration-fields/index.ts
@@ -3,3 +3,4 @@ export { DatasetReferencesFormItem } from "./DatasetReferencesFormItem";
 export { DataSubjectsFormItem } from "./DataSubjectsFormItem";
 export { DataUseFormItem } from "./DataUseFormItem";
 export { DeclarationNameFormItem } from "./DeclarationNameFormItem";
+export { PrivacyDeclarationCustomFields } from "./PrivacyDeclarationCustomFields";

--- a/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationForm.tsx
+++ b/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationForm.tsx
@@ -1,32 +1,29 @@
 /**
- * Exports various parts of the privacy declaration form for flexibility
+ * antd-based privacy declaration form for the system configure / add-system flow.
+ *
+ * Composes the shared per-field components in `~/features/system/privacy-declaration-fields/`
+ * with the modal-only fields (legal basis + impact assessment, special category, third parties,
+ * features, retention period). Validation lives on each Form.Item's `rules` array — no Yup.
  */
 
-import {
-  Button,
-  ChakraBox as Box,
-  ChakraFlex as Flex,
-  ChakraSpacer as Spacer,
-  ChakraStack as Stack,
-} from "fidesui";
-import { Form, Formik, FormikHelpers } from "formik";
+import { Button, Flex, Form, Input, Select, Switch } from "fidesui";
 import { useMemo } from "react";
-import * as Yup from "yup";
 
 import { useAppSelector } from "~/app/hooks";
 import {
-  CustomFieldsList,
   CustomFieldValues,
   useCustomFields,
 } from "~/features/common/custom-fields";
 import { LegacyResourceTypes } from "~/features/common/custom-fields/types";
-import { ControlledSelect } from "~/features/common/form/ControlledSelect";
-import { CustomSwitch, CustomTextInput } from "~/features/common/form/inputs";
-import { FormGuard } from "~/features/common/hooks/useIsAnyFormDirty";
-import DatasetSelectOption from "~/features/dataset/DatasetSelectOption";
 import { selectLockedForGVL } from "~/features/system/dictionary-form/dict-suggestion.slice";
-import useLegalBasisOptions from "~/features/system/system-form-declaration-tab/useLegalBasisOptions";
-import useSpecialCategoryLegalBasisOptions from "~/features/system/system-form-declaration-tab/useSpecialCategoryLegalBasisOptions";
+import {
+  DataCategoriesFormItem,
+  DatasetReferencesFormItem,
+  DataSubjectsFormItem,
+  DataUseFormItem,
+  DeclarationNameFormItem,
+  PrivacyDeclarationCustomFields,
+} from "~/features/system/privacy-declaration-fields";
 import SystemFormInputGroup from "~/features/system/SystemFormInputGroup";
 import {
   DataCategory,
@@ -36,12 +33,10 @@ import {
   PrivacyDeclarationResponse,
 } from "~/types/api";
 
-export const ValidationSchema = Yup.object().shape({
-  data_categories: Yup.array(Yup.string())
-    .min(1, "Must assign at least one data category")
-    .label("Data categories"),
-  data_use: Yup.string().required().label("Data use"),
-});
+import useLegalBasisOptions from "./useLegalBasisOptions";
+import useSpecialCategoryLegalBasisOptions from "./useSpecialCategoryLegalBasisOptions";
+
+const LEGITIMATE_INTERESTS = "Legitimate interests";
 
 export type FormValues = Omit<PrivacyDeclarationResponse, "cookies"> & {
   customFieldValues: CustomFieldValues;
@@ -68,9 +63,13 @@ const defaultInitialValues: FormValues = {
   id: "",
 };
 
-const transformFormValueToDeclaration = (values: FormValues) => {
-  const declaration = {
-    ...values,
+const transformFormValueToDeclaration = (
+  values: FormValues,
+): PrivacyDeclarationResponse => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { customFieldValues, ...rest } = values;
+  return {
+    ...rest,
     // fill in an empty string for name: https://github.com/ethyca/fideslang/issues/98
     name: values.name ?? "",
     special_category_legal_basis: values.processes_special_category_data
@@ -83,8 +82,18 @@ const transformFormValueToDeclaration = (values: FormValues) => {
       ? values.shared_categories
       : undefined,
   };
-  return declaration;
 };
+
+export const transformPrivacyDeclarationToFormValues = (
+  privacyDeclaration?: PrivacyDeclarationResponse,
+  customFieldValues?: CustomFieldValues,
+): FormValues =>
+  privacyDeclaration
+    ? {
+        ...privacyDeclaration,
+        customFieldValues: customFieldValues ?? {},
+      }
+    : defaultInitialValues;
 
 export interface DataProps {
   allDataCategories: DataCategory[];
@@ -94,236 +103,35 @@ export interface DataProps {
   includeCustomFields?: boolean;
 }
 
-export const PrivacyDeclarationFormComponents = ({
+interface Props {
+  onSubmit: (
+    values: PrivacyDeclarationResponse,
+  ) => Promise<PrivacyDeclarationResponse[] | undefined>;
+  onCancel: () => void;
+  initialValues?: PrivacyDeclarationResponse;
+  /** Fires whenever the form transitions to a dirty state. */
+  onDirtyChange?: (dirty: boolean) => void;
+}
+
+export const PrivacyDeclarationForm = ({
+  onSubmit,
+  onCancel,
+  initialValues: passedInInitialValues,
+  onDirtyChange,
   allDataUses,
   allDataCategories,
   allDataSubjects,
   allDatasets,
-  values,
   includeCustomFields,
-  privacyDeclarationId,
-  lockedForGVL,
-}: DataProps & {
-  values: FormValues;
-  privacyDeclarationId?: string;
-  lockedForGVL?: boolean;
-}) => {
+}: Props & DataProps) => {
+  const privacyDeclarationId = passedInInitialValues?.id;
   const isEditing = !!privacyDeclarationId;
+  const lockedForGVL = useAppSelector(selectLockedForGVL);
 
   const { legalBasisOptions } = useLegalBasisOptions();
-
   const { specialCategoryLegalBasisOptions } =
     useSpecialCategoryLegalBasisOptions();
-  const datasetSelectOptions = useMemo(
-    () =>
-      allDatasets
-        ? allDatasets.map((ds) => ({
-            value: ds.fides_key,
-            label: ds.name ? ds.name : ds.fides_key,
-          }))
-        : [],
-    [allDatasets],
-  );
 
-  return (
-    <Stack spacing={4}>
-      <SystemFormInputGroup heading="Data use declaration">
-        <CustomTextInput
-          id="name"
-          label="Declaration name (optional)"
-          name="name"
-          tooltip="Would you like to append anything to the system name?"
-          disabled={isEditing}
-          variant="stacked"
-        />
-        <ControlledSelect
-          id="data_use"
-          label="Data use"
-          name="data_use"
-          options={allDataUses.map((data) => ({
-            value: data.fides_key,
-            label: data.fides_key,
-          }))}
-          tooltip="For which business purposes is this data processed?"
-          layout="stacked"
-          isRequired
-          disabled={isEditing}
-        />
-        <ControlledSelect
-          name="data_categories"
-          label="Data categories"
-          options={allDataCategories.map((data) => ({
-            value: data.fides_key,
-            label: data.fides_key,
-          }))}
-          tooltip="Which categories of personal data are collected for this purpose?"
-          mode="multiple"
-          isRequired
-          disabled={lockedForGVL}
-          layout="stacked"
-        />
-        <ControlledSelect
-          name="data_subjects"
-          label="Data subjects"
-          options={allDataSubjects.map((data) => ({
-            value: data.fides_key,
-            label: data.fides_key,
-          }))}
-          tooltip="Who are the subjects for this personal data?"
-          mode="multiple"
-          layout="stacked"
-        />
-        {/* <ControlledSelect
-          name="data_sources"
-          label="Data sources"
-          options={[]}
-          tooltip="Where do these categories of data come from?"
-          mode="multiple"
-          layout="stacked"
-        /> */}
-        <Stack spacing={0}>
-          <ControlledSelect
-            name="legal_basis_for_processing"
-            label="Legal basis for processing"
-            options={legalBasisOptions}
-            tooltip="What is the legal basis under which personal data is processed for this purpose?"
-            layout="stacked"
-            disabled={lockedForGVL}
-          />
-          {values.legal_basis_for_processing === "Legitimate interests" && (
-            <Box mt={4}>
-              <CustomTextInput
-                name="impact_assessment_location"
-                label="Impact assessment location"
-                tooltip="Where is the legitimate interest impact assessment stored?"
-                variant="stacked"
-              />
-            </Box>
-          )}
-        </Stack>
-        <Box mt={5} pl={4}>
-          <CustomSwitch
-            name="flexible_legal_basis_for_processing"
-            label="This legal basis is flexible"
-            tooltip="Has the vendor declared that the legal basis may be overridden?"
-            variant="stacked"
-            isDisabled={lockedForGVL}
-          />
-        </Box>
-        <CustomTextInput
-          name="retention_period"
-          label="Retention period (days)"
-          tooltip="How long is personal data retained for this purpose?"
-          variant="stacked"
-          disabled={lockedForGVL}
-        />
-      </SystemFormInputGroup>
-      <SystemFormInputGroup heading="Features">
-        <ControlledSelect
-          name="features"
-          label="Features"
-          placeholder="Describe features..."
-          tooltip="What are some features of how data is processed?"
-          layout="stacked"
-          disabled={lockedForGVL}
-          mode="tags"
-        />
-      </SystemFormInputGroup>
-      <SystemFormInputGroup heading="Dataset reference">
-        <ControlledSelect
-          name="dataset_references"
-          label="Dataset references"
-          options={datasetSelectOptions}
-          optionRender={DatasetSelectOption}
-          tooltip="Is there a dataset configured for this system?"
-          mode="multiple"
-          layout="stacked"
-        />
-      </SystemFormInputGroup>
-      <SystemFormInputGroup heading="Special category data">
-        <Stack spacing={0}>
-          <CustomSwitch
-            name="processes_special_category_data"
-            label="This system processes special category data"
-            tooltip="Is this system processing special category data as defined by GDPR Article 9?"
-            variant="stacked"
-          />
-          {values.processes_special_category_data && (
-            <Box mt={4}>
-              <ControlledSelect
-                name="special_category_legal_basis"
-                label="Legal basis for processing"
-                options={specialCategoryLegalBasisOptions}
-                isRequired={values.processes_special_category_data}
-                tooltip="What is the legal basis under which the special category data is processed?"
-                layout="stacked"
-              />
-            </Box>
-          )}
-        </Stack>
-      </SystemFormInputGroup>
-      <SystemFormInputGroup heading="Third parties">
-        <Stack spacing={0}>
-          <CustomSwitch
-            name="data_shared_with_third_parties"
-            label="This system shares data with 3rd parties for this purpose"
-            tooltip="Does this system disclose, sell, or share personal data collected for this business use with 3rd parties?"
-            variant="stacked"
-          />
-          {values.data_shared_with_third_parties && (
-            <Stack mt={4} spacing={4}>
-              <CustomTextInput
-                name="third_parties"
-                label="Third parties"
-                tooltip="Which type of third parties is the data shared with?"
-                variant="stacked"
-              />
-              <ControlledSelect
-                name="shared_categories"
-                label="Shared categories"
-                options={allDataCategories.map((c) => ({
-                  value: c.fides_key,
-                  label: c.fides_key,
-                }))}
-                tooltip="Which categories of personal data does this system share with third parties?"
-                layout="stacked"
-                mode="multiple"
-              />
-            </Stack>
-          )}
-        </Stack>
-      </SystemFormInputGroup>
-      {includeCustomFields ? (
-        <CustomFieldsList
-          resourceType={LegacyResourceTypes.PRIVACY_DECLARATION}
-          resourceFidesKey={privacyDeclarationId}
-        />
-      ) : null}
-    </Stack>
-  );
-};
-
-export const transformPrivacyDeclarationToFormValues = (
-  privacyDeclaration?: PrivacyDeclarationResponse,
-  customFieldValues?: CustomFieldValues,
-): FormValues => {
-  return privacyDeclaration
-    ? {
-        ...privacyDeclaration,
-        customFieldValues: customFieldValues || {},
-      }
-    : defaultInitialValues;
-};
-
-/**
- * Hook to supply all data needed for the privacy declaration form
- * Purposefully excludes redux queries so that this can be used across apps
- */
-export const usePrivacyDeclarationForm = ({
-  onSubmit,
-  initialValues: passedInInitialValues,
-  privacyDeclarationId,
-}: Omit<Props, "onDelete"> & Pick<DataProps, "allDataUses">) => {
   const { customFieldValues, upsertCustomFields } = useCustomFields({
     resourceType: LegacyResourceTypes.PRIVACY_DECLARATION,
     resourceFidesKey: privacyDeclarationId,
@@ -338,99 +146,242 @@ export const usePrivacyDeclarationForm = ({
     [passedInInitialValues, customFieldValues],
   );
 
-  const handleSubmit = async (
-    values: FormValues,
-    formikHelpers: FormikHelpers<FormValues>,
-  ) => {
-    const { customFieldValues: formCustomFieldValues } = values;
-    const declarationToSubmit = transformFormValueToDeclaration(values);
+  const [form] = Form.useForm<FormValues>();
 
-    const success = await onSubmit(declarationToSubmit, formikHelpers);
+  const handleFinish = async (values: FormValues) => {
+    const declaration = transformFormValueToDeclaration(values);
+    const success = await onSubmit(declaration);
     if (success) {
-      // find the matching resource based on data use and name
-      const customFieldResource = success.filter(
+      const matched = success.find(
         (pd) =>
           pd.data_use === values.data_use &&
-          // name can be undefined, so avoid comparing undefined == ""
-          // (which we want to be true) - they both mean the PD has no name
           (pd.name ? pd.name === values.name : true),
       );
-      if (customFieldResource.length > 0) {
+      if (matched?.id) {
         await upsertCustomFields({
-          customFieldValues: formCustomFieldValues,
-          fides_key: customFieldResource[0].id,
+          customFieldValues: values.customFieldValues,
+          fides_key: matched.id,
         });
       }
     }
   };
 
-  return { handleSubmit, initialValues };
-};
-
-interface Props {
-  onSubmit: (
-    values: PrivacyDeclarationResponse,
-    formikHelpers: FormikHelpers<FormValues>,
-  ) => Promise<PrivacyDeclarationResponse[] | undefined>;
-  onCancel: () => void;
-  initialValues?: PrivacyDeclarationResponse;
-  privacyDeclarationId?: string;
-}
-
-export const PrivacyDeclarationForm = ({
-  onSubmit,
-  onCancel,
-  initialValues: passedInInitialValues,
-  ...dataProps
-}: Props & DataProps) => {
-  const privacyDeclarationId = passedInInitialValues?.id;
-
-  const { handleSubmit, initialValues } = usePrivacyDeclarationForm({
-    onSubmit,
-    onCancel,
-    initialValues: passedInInitialValues,
-    allDataUses: dataProps.allDataUses,
-    privacyDeclarationId,
-  });
-
-  const lockedForGVL = useAppSelector(selectLockedForGVL);
-
   return (
-    <Formik
-      enableReinitialize
+    <Form
+      form={form}
+      layout="vertical"
+      key={privacyDeclarationId ?? "new"}
       initialValues={initialValues}
-      onSubmit={handleSubmit}
-      validationSchema={ValidationSchema}
+      onFinish={handleFinish}
+      onValuesChange={() => onDirtyChange?.(true)}
+      data-testid="declaration-form"
     >
-      {({ dirty, values }) => {
-        return (
-          <Form data-testid="declaration-form">
-            <FormGuard id="PrivacyDeclaration" name="New Privacy Declaration" />
-            <Stack spacing={4}>
-              <PrivacyDeclarationFormComponents
-                values={values}
-                lockedForGVL={lockedForGVL}
-                privacyDeclarationId={privacyDeclarationId}
-                {...dataProps}
-              />
-              <Flex w="100%">
-                <Button onClick={onCancel} data-testid="cancel-btn">
-                  Cancel
-                </Button>
-                <Spacer />
-                <Button
-                  type="primary"
-                  htmlType="submit"
-                  disabled={!dirty}
-                  data-testid="save-btn"
+      <Flex vertical gap="middle">
+        <SystemFormInputGroup heading="Data use declaration">
+          <DeclarationNameFormItem
+            disabled={isEditing}
+            label="Declaration name (optional)"
+            tooltip="Would you like to append anything to the system name?"
+          />
+          <DataUseFormItem
+            allDataUses={allDataUses}
+            disabled={isEditing}
+            tooltip="For which business purposes is this data processed?"
+          />
+          <DataCategoriesFormItem
+            allDataCategories={allDataCategories}
+            disabled={lockedForGVL}
+            required
+            tooltip="Which categories of personal data are collected for this purpose?"
+          />
+          <DataSubjectsFormItem
+            allDataSubjects={allDataSubjects}
+            tooltip="Who are the subjects for this personal data?"
+          />
+          <Form.Item
+            name="legal_basis_for_processing"
+            label="Legal basis for processing"
+            tooltip="What is the legal basis under which personal data is processed for this purpose?"
+          >
+            <Select
+              aria-label="Legal basis for processing"
+              options={legalBasisOptions}
+              disabled={lockedForGVL}
+              allowClear
+            />
+          </Form.Item>
+          <Form.Item
+            noStyle
+            shouldUpdate={(prev, curr) =>
+              prev.legal_basis_for_processing !==
+              curr.legal_basis_for_processing
+            }
+          >
+            {({ getFieldValue }) =>
+              getFieldValue("legal_basis_for_processing") ===
+              LEGITIMATE_INTERESTS ? (
+                <Form.Item
+                  name="impact_assessment_location"
+                  label="Impact assessment location"
+                  tooltip="Where is the legitimate interest impact assessment stored?"
                 >
-                  Save
-                </Button>
-              </Flex>
-            </Stack>
-          </Form>
-        );
-      }}
-    </Formik>
+                  <Input aria-label="Impact assessment location" />
+                </Form.Item>
+              ) : null
+            }
+          </Form.Item>
+          <Form.Item
+            name="flexible_legal_basis_for_processing"
+            label="This legal basis is flexible"
+            tooltip="Has the vendor declared that the legal basis may be overridden?"
+            valuePropName="checked"
+          >
+            <Switch disabled={lockedForGVL} />
+          </Form.Item>
+          <Form.Item
+            name="retention_period"
+            label="Retention period (days)"
+            tooltip="How long is personal data retained for this purpose?"
+          >
+            <Input aria-label="Retention period" disabled={lockedForGVL} />
+          </Form.Item>
+        </SystemFormInputGroup>
+
+        <SystemFormInputGroup heading="Features">
+          <Form.Item
+            name="features"
+            label="Features"
+            tooltip="What are some features of how data is processed?"
+          >
+            <Select
+              aria-label="Features"
+              mode="tags"
+              placeholder="Describe features..."
+              disabled={lockedForGVL}
+            />
+          </Form.Item>
+        </SystemFormInputGroup>
+
+        <SystemFormInputGroup heading="Dataset reference">
+          <DatasetReferencesFormItem
+            allDatasets={allDatasets ?? []}
+            tooltip="Is there a dataset configured for this system?"
+          />
+        </SystemFormInputGroup>
+
+        <SystemFormInputGroup heading="Special category data">
+          <Form.Item
+            name="processes_special_category_data"
+            label="This system processes special category data"
+            tooltip="Is this system processing special category data as defined by GDPR Article 9?"
+            valuePropName="checked"
+          >
+            <Switch />
+          </Form.Item>
+          <Form.Item
+            noStyle
+            shouldUpdate={(prev, curr) =>
+              prev.processes_special_category_data !==
+              curr.processes_special_category_data
+            }
+          >
+            {({ getFieldValue }) =>
+              getFieldValue("processes_special_category_data") ? (
+                <Form.Item
+                  name="special_category_legal_basis"
+                  label="Legal basis for processing"
+                  tooltip="What is the legal basis under which the special category data is processed?"
+                  rules={[
+                    {
+                      required: true,
+                      message: "Legal basis for processing is required",
+                    },
+                  ]}
+                >
+                  <Select
+                    aria-label="Special category legal basis"
+                    options={specialCategoryLegalBasisOptions}
+                    allowClear
+                  />
+                </Form.Item>
+              ) : null
+            }
+          </Form.Item>
+        </SystemFormInputGroup>
+
+        <SystemFormInputGroup heading="Third parties">
+          <Form.Item
+            name="data_shared_with_third_parties"
+            label="This system shares data with 3rd parties for this purpose"
+            tooltip="Does this system disclose, sell, or share personal data collected for this business use with 3rd parties?"
+            valuePropName="checked"
+          >
+            <Switch />
+          </Form.Item>
+          <Form.Item
+            noStyle
+            shouldUpdate={(prev, curr) =>
+              prev.data_shared_with_third_parties !==
+              curr.data_shared_with_third_parties
+            }
+          >
+            {({ getFieldValue }) =>
+              getFieldValue("data_shared_with_third_parties") ? (
+                <>
+                  <Form.Item
+                    name="third_parties"
+                    label="Third parties"
+                    tooltip="Which type of third parties is the data shared with?"
+                  >
+                    <Input aria-label="Third parties" />
+                  </Form.Item>
+                  <Form.Item
+                    name="shared_categories"
+                    label="Shared categories"
+                    tooltip="Which categories of personal data does this system share with third parties?"
+                  >
+                    <Select
+                      aria-label="Shared categories"
+                      mode="multiple"
+                      options={allDataCategories.map((c) => ({
+                        value: c.fides_key,
+                        label: c.fides_key,
+                      }))}
+                    />
+                  </Form.Item>
+                </>
+              ) : null
+            }
+          </Form.Item>
+        </SystemFormInputGroup>
+
+        {includeCustomFields ? (
+          <PrivacyDeclarationCustomFields
+            privacyDeclarationId={privacyDeclarationId}
+          />
+        ) : null}
+
+        <Flex justify="space-between" align="center">
+          <Button onClick={onCancel} data-testid="cancel-btn">
+            Cancel
+          </Button>
+          <Form.Item shouldUpdate noStyle>
+            {() => (
+              <Button
+                type="primary"
+                htmlType="submit"
+                data-testid="save-btn"
+                disabled={
+                  !form.isFieldsTouched() ||
+                  form.getFieldsError().some((field) => field.errors.length > 0)
+                }
+              >
+                Save
+              </Button>
+            )}
+          </Form.Item>
+        </Flex>
+      </Flex>
+    </Form>
   );
 };

--- a/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationForm.tsx
+++ b/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationForm.tsx
@@ -367,7 +367,7 @@ export const PrivacyDeclarationForm = ({
           />
         ) : null}
 
-        <Flex justify="space-between" align="center">
+        <Flex justify="end" align="center" gap="small">
           <Button onClick={onCancel} data-testid="cancel-btn">
             Cancel
           </Button>

--- a/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationForm.tsx
+++ b/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationForm.tsx
@@ -6,7 +6,7 @@
  * features, retention period). Validation lives on each Form.Item's `rules` array — no Yup.
  */
 
-import { Button, Flex, Form, Input, Select, Switch } from "fidesui";
+import { Button, Card, Flex, Form, Input, Select, Switch } from "fidesui";
 import { useMemo } from "react";
 
 import { useAppSelector } from "~/app/hooks";
@@ -24,7 +24,6 @@ import {
   DeclarationNameFormItem,
   PrivacyDeclarationCustomFields,
 } from "~/features/system/privacy-declaration-fields";
-import SystemFormInputGroup from "~/features/system/SystemFormInputGroup";
 import {
   DataCategory,
   Dataset,
@@ -177,7 +176,7 @@ export const PrivacyDeclarationForm = ({
       data-testid="declaration-form"
     >
       <Flex vertical gap="middle">
-        <SystemFormInputGroup heading="Data use declaration">
+        <Card size="small" title="Data use declaration">
           <DeclarationNameFormItem
             disabled={isEditing}
             label="Declaration name (optional)"
@@ -242,16 +241,18 @@ export const PrivacyDeclarationForm = ({
             name="retention_period"
             label="Retention period (days)"
             tooltip="How long is personal data retained for this purpose?"
+            className="mb-0"
           >
             <Input aria-label="Retention period" disabled={lockedForGVL} />
           </Form.Item>
-        </SystemFormInputGroup>
+        </Card>
 
-        <SystemFormInputGroup heading="Features">
+        <Card size="small" title="Features">
           <Form.Item
             name="features"
             label="Features"
             tooltip="What are some features of how data is processed?"
+            className="mb-0"
           >
             <Select
               aria-label="Features"
@@ -260,21 +261,22 @@ export const PrivacyDeclarationForm = ({
               disabled={lockedForGVL}
             />
           </Form.Item>
-        </SystemFormInputGroup>
+        </Card>
 
-        <SystemFormInputGroup heading="Dataset reference">
+        <Card size="small" title="Dataset reference">
           <DatasetReferencesFormItem
             allDatasets={allDatasets ?? []}
             tooltip="Is there a dataset configured for this system?"
           />
-        </SystemFormInputGroup>
+        </Card>
 
-        <SystemFormInputGroup heading="Special category data">
+        <Card size="small" title="Special category data">
           <Form.Item
             name="processes_special_category_data"
             label="This system processes special category data"
             tooltip="Is this system processing special category data as defined by GDPR Article 9?"
             valuePropName="checked"
+            className="mb-0"
           >
             <Switch />
           </Form.Item>
@@ -291,6 +293,7 @@ export const PrivacyDeclarationForm = ({
                   name="special_category_legal_basis"
                   label="Legal basis for processing"
                   tooltip="What is the legal basis under which the special category data is processed?"
+                  className="mb-0 mt-4"
                   rules={[
                     {
                       required: true,
@@ -307,14 +310,15 @@ export const PrivacyDeclarationForm = ({
               ) : null
             }
           </Form.Item>
-        </SystemFormInputGroup>
+        </Card>
 
-        <SystemFormInputGroup heading="Third parties">
+        <Card size="small" title="Third parties">
           <Form.Item
             name="data_shared_with_third_parties"
             label="This system shares data with 3rd parties for this purpose"
             tooltip="Does this system disclose, sell, or share personal data collected for this business use with 3rd parties?"
             valuePropName="checked"
+            className="mb-0"
           >
             <Switch />
           </Form.Item>
@@ -327,11 +331,12 @@ export const PrivacyDeclarationForm = ({
           >
             {({ getFieldValue }) =>
               getFieldValue("data_shared_with_third_parties") ? (
-                <>
+                <Flex vertical gap="middle" className="mt-4">
                   <Form.Item
                     name="third_parties"
                     label="Third parties"
                     tooltip="Which type of third parties is the data shared with?"
+                    className="mb-0"
                   >
                     <Input aria-label="Third parties" />
                   </Form.Item>
@@ -339,6 +344,7 @@ export const PrivacyDeclarationForm = ({
                     name="shared_categories"
                     label="Shared categories"
                     tooltip="Which categories of personal data does this system share with third parties?"
+                    className="mb-0"
                   >
                     <Select
                       aria-label="Shared categories"
@@ -349,11 +355,11 @@ export const PrivacyDeclarationForm = ({
                       }))}
                     />
                   </Form.Item>
-                </>
+                </Flex>
               ) : null
             }
           </Form.Item>
-        </SystemFormInputGroup>
+        </Card>
 
         {includeCustomFields ? (
           <PrivacyDeclarationCustomFields

--- a/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationForm.tsx
+++ b/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationForm.tsx
@@ -204,6 +204,7 @@ export const PrivacyDeclarationForm = ({
           >
             <Select
               aria-label="Legal basis for processing"
+              data-testid="input-legal_basis_for_processing"
               options={legalBasisOptions}
               disabled={lockedForGVL}
               allowClear
@@ -224,7 +225,10 @@ export const PrivacyDeclarationForm = ({
                   label="Impact assessment location"
                   tooltip="Where is the legitimate interest impact assessment stored?"
                 >
-                  <Input aria-label="Impact assessment location" />
+                  <Input
+                    aria-label="Impact assessment location"
+                    data-testid="input-impact_assessment_location"
+                  />
                 </Form.Item>
               ) : null
             }
@@ -235,7 +239,10 @@ export const PrivacyDeclarationForm = ({
             tooltip="Has the vendor declared that the legal basis may be overridden?"
             valuePropName="checked"
           >
-            <Switch disabled={lockedForGVL} />
+            <Switch
+              disabled={lockedForGVL}
+              data-testid="input-flexible_legal_basis_for_processing"
+            />
           </Form.Item>
           <Form.Item
             name="retention_period"
@@ -243,7 +250,11 @@ export const PrivacyDeclarationForm = ({
             tooltip="How long is personal data retained for this purpose?"
             className="mb-0"
           >
-            <Input aria-label="Retention period" disabled={lockedForGVL} />
+            <Input
+              aria-label="Retention period"
+              data-testid="input-retention_period"
+              disabled={lockedForGVL}
+            />
           </Form.Item>
         </Card>
 
@@ -256,6 +267,7 @@ export const PrivacyDeclarationForm = ({
           >
             <Select
               aria-label="Features"
+              data-testid="input-features"
               mode="tags"
               placeholder="Describe features..."
               disabled={lockedForGVL}
@@ -278,7 +290,7 @@ export const PrivacyDeclarationForm = ({
             valuePropName="checked"
             className="mb-0"
           >
-            <Switch />
+            <Switch data-testid="input-processes_special_category_data" />
           </Form.Item>
           <Form.Item
             noStyle
@@ -303,6 +315,7 @@ export const PrivacyDeclarationForm = ({
                 >
                   <Select
                     aria-label="Special category legal basis"
+                    data-testid="input-special_category_legal_basis"
                     options={specialCategoryLegalBasisOptions}
                     allowClear
                   />
@@ -320,7 +333,7 @@ export const PrivacyDeclarationForm = ({
             valuePropName="checked"
             className="mb-0"
           >
-            <Switch />
+            <Switch data-testid="input-data_shared_with_third_parties" />
           </Form.Item>
           <Form.Item
             noStyle
@@ -338,7 +351,10 @@ export const PrivacyDeclarationForm = ({
                     tooltip="Which type of third parties is the data shared with?"
                     className="mb-0"
                   >
-                    <Input aria-label="Third parties" />
+                    <Input
+                      aria-label="Third parties"
+                      data-testid="input-third_parties"
+                    />
                   </Form.Item>
                   <Form.Item
                     name="shared_categories"
@@ -348,6 +364,7 @@ export const PrivacyDeclarationForm = ({
                   >
                     <Select
                       aria-label="Shared categories"
+                      data-testid="input-shared_categories"
                       mode="multiple"
                       options={allDataCategories.map((c) => ({
                         value: c.fides_key,

--- a/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationFormModal.tsx
+++ b/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationFormModal.tsx
@@ -1,5 +1,4 @@
-import { Modal } from "fidesui";
-
+import ConfirmCloseModal from "~/features/common/modals/ConfirmCloseModal";
 import { MODAL_SIZE } from "~/features/common/modals/modal-sizes";
 
 type DataUseFormModalProps = {
@@ -9,6 +8,8 @@ type DataUseFormModalProps = {
   isCentered?: boolean;
   testId?: string;
   children: React.ReactNode;
+  /** Evaluated at event time to guard against accidental close of a dirty form. */
+  getIsDirty: () => boolean;
 };
 
 export const PrivacyDeclarationFormModal = ({
@@ -18,10 +19,12 @@ export const PrivacyDeclarationFormModal = ({
   isCentered = false,
   testId = "privacy-declaration-modal",
   children,
+  getIsDirty,
 }: DataUseFormModalProps) => (
-  <Modal
+  <ConfirmCloseModal
     open={isOpen}
-    onCancel={onClose}
+    onClose={onClose}
+    getIsDirty={getIsDirty}
     centered={isCentered}
     destroyOnHidden
     width={MODAL_SIZE.lg}
@@ -30,5 +33,5 @@ export const PrivacyDeclarationFormModal = ({
     footer={null}
   >
     {children}
-  </Modal>
+  </ConfirmCloseModal>
 );

--- a/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationFormTab.tsx
+++ b/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationFormTab.tsx
@@ -1,7 +1,4 @@
-import {
-  ChakraStack as Stack,
-  useChakraDisclosure as useDisclosure,
-} from "fidesui";
+import { Flex } from "fidesui";
 import { useEffect, useState } from "react";
 
 import useSystemDataUseCrud from "~/features/data-use/useSystemDataUseCrud";
@@ -24,28 +21,30 @@ const PrivacyDeclarationFormTab = ({
   includeCustomFields,
   ...dataProps
 }: Props & DataProps) => {
-  const { isOpen, onClose, onOpen } = useDisclosure();
+  const [isOpen, setIsOpen] = useState(false);
   const [currentDeclaration, setCurrentDeclaration] = useState<
     PrivacyDeclarationResponse | undefined
   >(undefined);
+  const [isDirty, setIsDirty] = useState(false);
 
   const { createDataUse, updateDataUse, deleteDataUse } =
     useSystemDataUseCrud(system);
 
   const handleCloseForm = () => {
-    onClose();
+    setIsOpen(false);
     setCurrentDeclaration(undefined);
+    setIsDirty(false);
   };
 
   const handleOpenNewForm = () => {
-    onOpen();
+    setIsOpen(true);
     setCurrentDeclaration(undefined);
   };
 
   const handleOpenEditForm = (
     declarationToEdit: PrivacyDeclarationResponse,
   ) => {
-    onOpen();
+    setIsOpen(true);
     setCurrentDeclaration(declarationToEdit);
   };
 
@@ -57,13 +56,15 @@ const PrivacyDeclarationFormTab = ({
     return createDataUse(values);
   };
 
-  // Reset the new form when the system changes (i.e. when clicking on a new datamap node)
+  // Reset modal state when the system changes (e.g. switching datamap nodes)
   useEffect(() => {
-    onClose();
-  }, [onClose, system.fides_key]);
+    setIsOpen(false);
+    setCurrentDeclaration(undefined);
+    setIsDirty(false);
+  }, [system.fides_key]);
 
   return (
-    <Stack spacing={6} data-testid="data-use-tab">
+    <Flex vertical gap="large" data-testid="data-use-tab">
       {system.privacy_declarations.length === 0 ? (
         <EmptyTableState
           title="You don't have a data use set up for this system yet."
@@ -84,16 +85,18 @@ const PrivacyDeclarationFormTab = ({
         isOpen={isOpen}
         onClose={handleCloseForm}
         heading="Configure data use"
+        getIsDirty={() => isDirty}
       >
         <PrivacyDeclarationForm
           initialValues={currentDeclaration}
           onSubmit={handleSubmit}
           onCancel={handleCloseForm}
+          onDirtyChange={setIsDirty}
           includeCustomFields={includeCustomFields}
           {...dataProps}
         />
       </PrivacyDeclarationFormModal>
-    </Stack>
+    </Flex>
   );
 };
 


### PR DESCRIPTION
Ticket [ENG-3550]

### Description Of Changes

Migrates the modal "Configure data use" Privacy Declaration form (15+-field form used on the system configure and add-system pages) from Formik/Yup/Chakra to antd `Form`. Companion to [#8227 (ENG-3551)] which migrated the smaller datamap-drawer accordion form and extracted the shared per-field components this PR consumes.

* Replaces Formik + Yup with `Form.useForm()` + per-`Form.Item` `rules`. No central schema.
* Section wrappers swapped from the Chakra `SystemFormInputGroup` to antd `Card size="small"`. The modal renders entirely with antd components now (zero Chakra elements in the form DOM).
* Conditional fields (`impact_assessment_location` under "Legitimate interests", special category legal basis under its toggle, third-party fields under its toggle) render via `Form.Item shouldUpdate` predicates so they only re-render the dependent section.
* New antd-aware `PrivacyDeclarationCustomFields` component co-located in the shared `privacy-declaration-fields/` module. Uses nested `["customFieldValues", definitionId]` field paths so values land under the same namespace the existing `upsertCustomFields` helper expects. The Formik-based `CustomFieldsList` stays in place for its other consumer (`SystemInformationForm.tsx`).
* Modal wrapper now uses `ConfirmCloseModal`, so dismissing a dirty form via the X / Escape / overlay click prompts the user. Dirty state flows up through an `onDirtyChange` callback on the form so the modal's `getIsDirty` getter reflects real form state.
* Cancel/Save buttons are right-aligned together in the footer (was Cancel left, Save right with a Spacer between).
* Shared `DataCategoriesFormItem` gains an opt-in `required?: boolean` prop so the modal preserves the legacy "must select at least one" asterisk + validation while the simplified accordion form (where this field is disabled anyway) stays unchanged.
* Shared `DataUseFormItem` / `DataCategoriesFormItem` / `DataSubjectsFormItem` / `DatasetReferencesFormItem` now accept `tooltip?` overrides so each consumer can supply its own field copy.

Out of scope (will land separately if/when prioritized):
* `EmptyTableState.tsx` and `PrivacyDeclarationDisplayGroup.tsx` still use Chakra. Display-only sibling components, not part of ENG-3550's scope.
* An antd-aware replacement for the Formik `FormGuard` (route-navigation unsaved-changes guard). The `ConfirmCloseModal` covers the X / Escape / overlay paths, which is the meaningful exit surface for a modal-scoped form.

### Code Changes

* `clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationForm.tsx` — Formik → antd `Form`. Shared field components for the overlapping subset, inline `Form.Item` for modal-only fields. Section wrappers are antd `Card`. New `onDirtyChange` callback.
* `clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationFormTab.tsx` — `useChakraDisclosure` → `useState`. `ChakraStack` → `Flex`. Threads dirty state up to the modal.
* `clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationFormModal.tsx` — wraps `ConfirmCloseModal` instead of plain `Modal`, takes a `getIsDirty` getter.
* `clients/admin-ui/src/features/system/privacy-declaration-fields/PrivacyDeclarationCustomFields.tsx` (new) — antd Form-aware renderer for custom field definitions.
* `clients/admin-ui/src/features/system/privacy-declaration-fields/DataCategoriesFormItem.tsx`, `DataSubjectsFormItem.tsx`, `DataUseFormItem.tsx`, `DatasetReferencesFormItem.tsx` — accept `tooltip?` overrides; `DataCategoriesFormItem` adds opt-in `required?`.

### Steps to Confirm

1. `cd clients/admin-ui && npm run dev`.
2. Navigate to `/systems/configure/<some-system>` → Data uses tab → click "Add data use". Verify:
   * Modal opens with five antd Card sections (Data use declaration / Features / Dataset reference / Special category data / Third parties).
   * `Data use` and `Data categories` show required asterisks; Save is disabled until the form is touched.
   * Select "Legitimate interests" in `Legal basis for processing` → `Impact assessment location` appears below it. Switch to another option → it disappears.
   * Toggle "This system processes special category data" → a second `Legal basis for processing` field appears inside that card with its own required asterisk. Toggle off → disappears.
   * Toggle "This system shares data with 3rd parties for this purpose" → `Third parties` and `Shared categories` fields appear below the switch. Toggle off → both disappear.
3. Make changes, click the modal X (or press Escape) → `ConfirmCloseModal` shows "Unsaved Changes / Keep editing / Discard changes".
4. Click an existing declaration row → modal opens with `Data use` and `Declaration name` disabled and all existing values populated, including conditionals where applicable.
5. Hit Save → modal closes, success toast appears, the row reflects the change.
6. Cancel and Save buttons should be grouped at the bottom-right with a small gap between them.
7. Repeat the basic flow on `/add-systems/manual`.
8. Spot-check `/datamap` → click a system → the simplified accordion form (ENG-3551) still renders correctly.
9. `npm run check` from `clients/admin-ui` passes eslint + antd lint + prettier + tsc.

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated (via `changelog/8229-modal-privacy-declaration-form-antd.yaml`)
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed (functional parity migration; section visual treatment shifts from Chakra panel to antd Card)
* Followup issues:
  * [x] Followup issues created (antd-aware `FormGuard` equivalent; Chakra cleanup of `EmptyTableState` and `PrivacyDeclarationDisplayGroup`)
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-3550]: https://ethyca.atlassian.net/browse/ENG-3550
[#8227 (ENG-3551)]: https://github.com/ethyca/fides/pull/8227