### PR TITLE
Add google-cloud-pubsub dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dependencies = [
     "firebase-admin==5.3.0",
     "flower==2.0.1",
     "google-auth==2.48.0",
+    "google-cloud-pubsub==2.32.0",
     "httpx~=0.28.1",
     "iab-tcf==0.2.2",
     "immutables==0.21",


### PR DESCRIPTION
## Summary

Adds `google-cloud-pubsub==2.32.0` to the `ethyca-fides` dependency set so downstream can subscribe to BigQuery audit-log events delivered via Cloud Pub/Sub. Required by the proposed event-driven BigQuery discovery monitor prototype.

This is a one-line dependency addition with no source changes.

## Test plan

- [ ] CI passes against the existing test suite (no behavior change in this repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)