### PR TITLE
ENG-3730: Add ATT exempt toggle for privacy notices in Admin UI

### DIFF
--- a/changelog/8233-att-exempt-toggle.yaml
+++ b/changelog/8233-att-exempt-toggle.yaml
@@ -1,0 +1,4 @@
+type: Added
+description: Added ATT exempt toggle for privacy notices in Admin UI
+pr: 8233
+labels: []

--- a/clients/admin-ui/cypress/e2e/privacy-notices.cy.ts
+++ b/clients/admin-ui/cypress/e2e/privacy-notices.cy.ts
@@ -321,6 +321,7 @@ describe("Privacy notices", () => {
         consent_mechanism: "opt_in",
         enforcement_level: "frontend",
         has_gpc_flag: true,
+        att_exempt: false,
         data_uses: ["analytics"],
         notice_key: "my_notice",
         disabled: true,

--- a/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
+++ b/clients/admin-ui/src/features/privacy-experience/PrivacyExperienceForm.tsx
@@ -251,6 +251,7 @@ export const PrivacyExperienceForm = ({
           data_uses: [],
           consent_mechanism: ConsentMechanism.NOTICE_ONLY,
           disabled: false,
+          att_exempt: false,
         });
       }
       if (hasFilteredGppNotices) {
@@ -261,6 +262,7 @@ export const PrivacyExperienceForm = ({
           data_uses: [],
           consent_mechanism: ConsentMechanism.NOTICE_ONLY,
           disabled: true,
+          att_exempt: false,
         });
       }
       return noticesWithTcfPlaceholder;

--- a/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
@@ -260,15 +260,22 @@ const PrivacyNoticeForm = ({
             </Form.Item>
             <Form.Item
               name="att_exempt"
-              label="Exempt from App Tracking Transparency (ATT)"
-              valuePropName="checked"
-              help={
-                consentMechanism === ConsentMechanism.NOTICE_ONLY
-                  ? "Notice-only notices are not affected by this setting."
-                  : undefined
+              label={
+                <Flex align="center" gap={4}>
+                  Exempt from App Tracking Transparency (ATT)
+                  {consentMechanism === ConsentMechanism.NOTICE_ONLY && (
+                    <InfoTooltip label="Notice-only notices are not affected by this setting." />
+                  )}
+                </Flex>
               }
+              valuePropName="checked"
             >
-              <Switch data-testid="input-att_exempt" />
+              <Switch
+                data-testid="input-att_exempt"
+                disabled={
+                  consentMechanism === ConsentMechanism.NOTICE_ONLY
+                }
+              />
             </Form.Item>
             <PrivacyNoticeLocationDisplay
               regions={passedInPrivacyNotice?.configured_regions}

--- a/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
@@ -32,6 +32,7 @@ import {
 } from "~/features/data-use/data-use.slice";
 import { PrivacyNoticeTranslationForm } from "~/features/privacy-notices/PrivacyNoticeTranslationForm";
 import {
+  ConsentMechanism,
   LimitedPrivacyNoticeResponseSchema,
   NoticeTranslation,
   PrivacyNoticeCreation,
@@ -191,6 +192,8 @@ const PrivacyNoticeForm = ({
     [allValues, initialValues],
   );
 
+  const consentMechanism = Form.useWatch("consent_mechanism", form);
+
   // Read children and translations reactively via useWatch so ScrollableList
   // and the translation form stay in sync with the hidden Form.Items below.
   const children =
@@ -254,6 +257,18 @@ const PrivacyNoticeForm = ({
               valuePropName="checked"
             >
               <Switch data-testid="input-has_gpc_flag" />
+            </Form.Item>
+            <Form.Item
+              name="att_exempt"
+              label="Exempt from App Tracking Transparency (ATT)"
+              valuePropName="checked"
+              help={
+                consentMechanism === ConsentMechanism.NOTICE_ONLY
+                  ? "Notice-only notices are not affected by this setting."
+                  : undefined
+              }
+            >
+              <Switch data-testid="input-att_exempt" />
             </Form.Item>
             <PrivacyNoticeLocationDisplay
               regions={passedInPrivacyNotice?.configured_regions}

--- a/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
+++ b/clients/admin-ui/src/features/privacy-notices/PrivacyNoticeForm.tsx
@@ -272,9 +272,7 @@ const PrivacyNoticeForm = ({
             >
               <Switch
                 data-testid="input-att_exempt"
-                disabled={
-                  consentMechanism === ConsentMechanism.NOTICE_ONLY
-                }
+                disabled={consentMechanism === ConsentMechanism.NOTICE_ONLY}
               />
             </Form.Item>
             <PrivacyNoticeLocationDisplay

--- a/clients/admin-ui/src/features/privacy-notices/form.ts
+++ b/clients/admin-ui/src/features/privacy-notices/form.ts
@@ -37,6 +37,7 @@ export const defaultInitialValues: PrivacyNoticeUpdateOrCreate = {
   enforcement_level: EnforcementLevel.FRONTEND,
   // When creating, set to disabled to start
   disabled: true,
+  att_exempt: false,
   translations: defaultInitialTranslations,
   children: [],
 };
@@ -53,6 +54,7 @@ export const transformPrivacyNoticeResponseToCreation = (
   notice_key: notice.notice_key,
   disabled: notice.disabled,
   has_gpc_flag: notice.has_gpc_flag,
+  att_exempt: notice.att_exempt,
   id: notice.id,
   internal_description: notice.internal_description,
   translations: notice.translations

--- a/clients/admin-ui/src/types/api/models/LimitedPrivacyNoticeResponseSchema.ts
+++ b/clients/admin-ui/src/types/api/models/LimitedPrivacyNoticeResponseSchema.ts
@@ -42,6 +42,10 @@ export type LimitedPrivacyNoticeResponseSchema = {
    * Disabled
    */
   disabled: boolean;
+  /**
+   * Att Exempt
+   */
+  att_exempt: boolean;
   framework?: PrivacyNoticeFramework | null;
   /**
    * Children

--- a/clients/admin-ui/src/types/api/models/PrivacyNoticeCreation.ts
+++ b/clients/admin-ui/src/types/api/models/PrivacyNoticeCreation.ts
@@ -39,6 +39,10 @@ export type PrivacyNoticeCreation = {
    * Has Gpc Flag
    */
   has_gpc_flag?: boolean | null;
+  /**
+   * Att Exempt
+   */
+  att_exempt?: boolean | null;
   framework?: PrivacyNoticeFramework | null;
   /**
    * Gpp Field Mapping

--- a/clients/admin-ui/src/types/api/models/PrivacyNoticeResponse.ts
+++ b/clients/admin-ui/src/types/api/models/PrivacyNoticeResponse.ts
@@ -43,6 +43,10 @@ export type PrivacyNoticeResponse = {
    * Has Gpc Flag
    */
   has_gpc_flag: boolean;
+  /**
+   * Att Exempt
+   */
+  att_exempt: boolean;
   framework?: PrivacyNoticeFramework | null;
   default_preference?: UserConsentPreference | null;
   /**

--- a/clients/admin-ui/src/types/api/models/PrivacyNoticeResponseWithRegions.ts
+++ b/clients/admin-ui/src/types/api/models/PrivacyNoticeResponseWithRegions.ts
@@ -57,6 +57,10 @@ export type PrivacyNoticeResponseWithRegions = {
    */
   has_gpc_flag: boolean;
   /**
+   * Att Exempt
+   */
+  att_exempt: boolean;
+  /**
    * Translations
    */
   translations?: Array<NoticeTranslationResponse>;

--- a/clients/admin-ui/src/types/api/models/PrivacyNoticeUpdate.ts
+++ b/clients/admin-ui/src/types/api/models/PrivacyNoticeUpdate.ts
@@ -42,6 +42,10 @@ export type PrivacyNoticeUpdate = {
    * Has Gpc Flag
    */
   has_gpc_flag?: boolean | null;
+  /**
+   * Att Exempt
+   */
+  att_exempt?: boolean | null;
   framework?: PrivacyNoticeFramework | null;
   /**
    * Gpp Field Mapping


### PR DESCRIPTION
## Summary
- Adds an "Exempt from App Tracking Transparency (ATT)" toggle switch to the privacy notice form in the Admin UI, following the existing `has_gpc_flag` pattern
- When the consent mechanism is set to "notice only", the toggle is disabled (greyed out) and an info tooltip icon appears next to the label explaining "Notice-only notices are not affected by this setting."
- Updates TypeScript types (`PrivacyNoticeCreation`, `PrivacyNoticeUpdate`, `PrivacyNoticeResponse`, `PrivacyNoticeResponseWithRegions`, `LimitedPrivacyNoticeResponseSchema`) to include the `att_exempt` field
- Updates form defaults and transform function to handle the new field

## Related
- API support added in https://github.com/ethyca/fidesplus/pull/3466

## Test plan
- [ ] Create a new privacy notice and verify the ATT exempt toggle appears after the GPC toggle and that it's default to off
- [ ] Toggle ATT exempt on and save. Confirm it persists on reload
- [ ] Set consent mechanism to "Notice only" and verify the toggle is disabled and the info tooltip icon appears
- [ ] Hover over the info tooltip and confirm it shows "Notice-only notices are not affected by this setting."
- [ ] Change consent mechanism away from "Notice only" and verify the toggle re-enables and the tooltip disappears
- [ ] Edit an existing privacy notice and confirm the ATT exempt value loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)