### PR TITLE
ENG-3877: Wait for custom fields to load before mounting declaration form

### DIFF
--- a/changelog/8238-fix-privacy-declaration-custom-fields-reopen.yaml
+++ b/changelog/8238-fix-privacy-declaration-custom-fields-reopen.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Privacy declaration custom field values now repopulate when re-opening a saved declaration after the antd Form migration.
+pr: 8238
+labels: []

--- a/clients/admin-ui/cypress/e2e/systems.cy.ts
+++ b/clients/admin-ui/cypress/e2e/systems.cy.ts
@@ -586,6 +586,70 @@ describe("System management page", () => {
     });
   });
 
+  describe("Data uses - custom field values on re-open (ENG-3877)", () => {
+    const declarationId = "pri_ac9d4dfb-d033-4b06-bc7f-968df8d125ff";
+    const definitionId = "id-custom-field-definition-decl-test";
+
+    beforeEach(() => {
+      stubPlus(true);
+
+      cy.intercept(
+        "GET",
+        "/api/v1/plus/custom-metadata/custom-field-definition/resource-type/*",
+        {
+          body: [
+            {
+              name: "cf decl test",
+              description: null,
+              field_type: "string",
+              allow_list_id: null,
+              resource_type: "privacy declaration",
+              field_definition: null,
+              active: true,
+              id: definitionId,
+            },
+          ],
+        },
+      ).as("getDeclarationCustomFieldDefinitions");
+
+      cy.intercept(
+        "GET",
+        `/api/v1/plus/custom-metadata/custom-field/resource/${declarationId}`,
+        {
+          delay: 200,
+          body: [
+            {
+              resource_id: declarationId,
+              custom_field_definition_id: definitionId,
+              value: "Alpha custom value",
+              id: "plu_12485068-aaaa-bbbb-cccc-dddddddddddd",
+            },
+          ],
+        },
+      ).as("getDeclarationCustomFields");
+
+      cy.intercept("/api/v1/system/*", {
+        fixture: "systems/system.json",
+      }).as("getDemoAnalyticsSystem");
+      cy.visit(`/${SYSTEM_ROUTE}/configure/demo_analytics_system#data-uses`);
+      cy.wait("@getDemoAnalyticsSystem");
+    });
+
+    it("repopulates custom field values when re-opening a saved declaration", () => {
+      cy.getByTestId("row-functional.service.improve")
+        .find('[role="button"]')
+        .click();
+      cy.wait("@getDeclarationCustomFieldDefinitions");
+      cy.wait("@getDeclarationCustomFields");
+      cy.getByTestId("declaration-form").within(() => {
+        cy.findByLabelText("cf decl test").should(
+          "have.value",
+          "Alpha custom value",
+        );
+      });
+    });
+  });
+
   describe("Data flow", () => {
     beforeEach(() => {
       stubSystemCrud();

--- a/clients/admin-ui/cypress/e2e/systems.cy.ts
+++ b/clients/admin-ui/cypress/e2e/systems.cy.ts
@@ -648,6 +648,29 @@ describe("System management page", () => {
         );
       });
     });
+
+    // Regression guard: the antd migration (#8229) dropped untracked fields
+    // (`id`, `egress`, `ingress`) from form submissions because they aren't
+    // registered as Form.Items. That made every edit look like a create and
+    // collide with the existing declaration's data_use.
+    it("saves edits to an existing declaration without colliding on data_use", () => {
+      cy.getByTestId("row-functional.service.improve")
+        .find('[role="button"]')
+        .click();
+      cy.wait("@getDeclarationCustomFieldDefinitions");
+      cy.wait("@getDeclarationCustomFields");
+      cy.getByTestId("declaration-form").within(() => {
+        cy.findByLabelText("cf decl test").clear().type("Beta custom value");
+        cy.getByTestId("save-btn").click();
+      });
+      cy.wait("@putSystem").then((interception) => {
+        const declarations = interception.request.body.privacy_declarations;
+        expect(declarations).to.have.length(1);
+        expect(declarations[0].id).to.eq(declarationId);
+        expect(declarations[0].data_use).to.eq("functional.service.improve");
+      });
+      cy.shouldShowMessage("success");
+    });
   });
 
   describe("Data flow", () => {

--- a/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationForm.tsx
+++ b/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationForm.tsx
@@ -6,7 +6,7 @@
  * features, retention period). Validation lives on each Form.Item's `rules` array — no Yup.
  */
 
-import { Button, Card, Flex, Form, Input, Select, Switch } from "fidesui";
+import { Button, Card, Flex, Form, Input, Select, Spin, Switch } from "fidesui";
 import { useMemo } from "react";
 
 import { useAppSelector } from "~/app/hooks";
@@ -131,7 +131,7 @@ export const PrivacyDeclarationForm = ({
   const { specialCategoryLegalBasisOptions } =
     useSpecialCategoryLegalBasisOptions();
 
-  const { customFieldValues, upsertCustomFields } = useCustomFields({
+  const { customFieldValues, upsertCustomFields, isLoading } = useCustomFields({
     resourceType: LegacyResourceTypes.PRIVACY_DECLARATION,
     resourceFidesKey: privacyDeclarationId,
   });
@@ -164,6 +164,14 @@ export const PrivacyDeclarationForm = ({
       }
     }
   };
+
+  if (isEditing && isLoading) {
+    return (
+      <Flex justify="center" align="center" className="py-8">
+        <Spin />
+      </Flex>
+    );
+  }
 
   return (
     <Form

--- a/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationForm.tsx
+++ b/clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationForm.tsx
@@ -148,7 +148,13 @@ export const PrivacyDeclarationForm = ({
   const [form] = Form.useForm<FormValues>();
 
   const handleFinish = async (values: FormValues) => {
-    const declaration = transformFormValueToDeclaration(values);
+    // antd Form only tracks fields with a Form.Item; untracked fields
+    // (`id`, `egress`, `ingress`) are silently dropped from `values`. Merge
+    // them back in from initialValues so updates aren't mistaken for creates.
+    const declaration = transformFormValueToDeclaration({
+      ...initialValues,
+      ...values,
+    });
     const success = await onSubmit(declaration);
     if (success) {
       const matched = success.find(


### PR DESCRIPTION
Ticket [ENG-3877]

### Description Of Changes

After the antd Form migration (#8229), re-opening a saved privacy declaration showed custom field inputs as empty even though the values were persisted on the backend and returned by `useCustomFields()`. This is the regression that ENG-3603's Cardea tests at `cardea/tests/independent/custom-fields-declarations.spec.ts` were originally added to guard against.

Root cause: antd `Form` only consumes `initialValues` once per mount. The modal mounts before `useCustomFields()` resolves, so the form is seeded with empty `customFieldValues: {}`. When the hook resolves and `initialValues` recomputes, antd ignores it — there's no Formik `enableReinitialize` equivalent. The `key={privacyDeclarationId ?? "new"}` doesn't change in the meantime so nothing remounts.

Fix: gate the form mount on `useCustomFields()`'s `isLoading` when editing an existing declaration. The form only mounts after `customFieldValues` are resolved, so antd seeds them correctly on its one-and-only mount. The create flow (`!isEditing`) renders immediately as before — there are no saved values to wait for.

`SimplifiedPrivacyDeclarationForm` (the drawer side panel from #8227) is not affected — it doesn't call `useCustomFields()` and doesn't render any custom field inputs.

### Code Changes

* `clients/admin-ui/src/features/system/system-form-declaration-tab/PrivacyDeclarationForm.tsx` — pull `isLoading` from `useCustomFields()` and render a `Spin` while loading when editing.
* `clients/admin-ui/cypress/e2e/systems.cy.ts` — add a regression test that stubs a delayed custom-field values response (200ms) and asserts the input is repopulated when the modal re-opens. Test fails on `main` and passes after the fix.

### Steps to Confirm

1. As an owner, go to Settings → Taxonomy → Custom fields → Add new.
2. Name = "manual repro", **Applies to = System data use**, Field type = Open text → Save.
3. Data inventory → System inventory → edit any system.
4. **Data uses** tab → *Add data use*. Fill required fields (name, data use, data category) and put a value in the "manual repro" custom field. Save.
5. Click the saved row to re-open it. The "manual repro" input should now show the saved value (previously empty).
6. Edit the value, save, re-open again — value round-trips cleanly.

Or run the new Cypress test:

```bash
cd clients/admin-ui
npm run cy:start    # in another terminal
npx cypress run --spec cypress/e2e/systems.cy.ts \
  --env grep="custom field values on re-open"
```

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
* UX feedback:
  * [x] No UX review needed
* Followup issues:
  * [x] No followup issues
* Database migrations:
  * [x] No migrations
* Documentation:
  * [x] No documentation updates required

[ENG-3877]: https://ethyca.atlassian.net/browse/ENG-3877
