### PR TITLE
ENG-3555: Migrate SystemDataForm (history diff) to Ant Design

### DIFF
--- a/changelog/8239-system-data-form-antd.yaml
+++ b/changelog/8239-system-data-form-antd.yaml
@@ -1,0 +1,4 @@
+type: Changed
+description: Migrate the system history diff view (SystemDataForm) from Chakra/Formik to Ant Design.
+pr: 8239
+labels: []

--- a/clients/admin-ui/src/features/system/history/modal/SystemDataForm.tsx
+++ b/clients/admin-ui/src/features/system/history/modal/SystemDataForm.tsx
@@ -1,5 +1,4 @@
-import { ChakraStack as Stack } from "fidesui";
-import { Form, Formik } from "formik";
+import { Flex } from "fidesui";
 import React, { Fragment } from "react";
 
 import { LegacyResourceTypes } from "~/features/common/custom-fields/types";
@@ -19,255 +18,244 @@ interface SystemDataFormProps {
 const SystemDataForm = ({ initialValues }: SystemDataFormProps) => {
   const features = useFeatures();
   return (
-    <Formik
-      enableReinitialize
-      initialValues={initialValues}
-      onSubmit={() => {}}
-    >
-      {() => (
-        <Form>
-          <Stack>
-            {/* System information */}
-            <SystemDataGroup heading="System details">
-              {features.dictionaryService ? (
-                <SystemDataTextField
-                  name="vendor_id"
-                  label="Vendor"
-                  tooltip="Select the vendor that matches the system"
-                />
-              ) : null}
-              <SystemDataTextField
-                name="name"
-                label="System name"
-                tooltip="Give the system a unique, and relevant name for reporting purposes. e.g. “Email Data Warehouse”"
-              />
-              <SystemDataTextField
-                name="fides_key"
-                label="Unique ID"
-                disabled
-                tooltip="An auto-generated unique ID based on the system name"
-              />
-              <SystemDataTextField
-                name="description"
-                label="Description"
-                tooltip="Give the system a unique, and relevant name for reporting purposes. e.g. “Email Data Warehouse”"
-              />
-              <SystemDataTags
-                name="tags"
-                label="System Tags"
-                tooltip="Are there any tags to associate with this system?"
-              />
-            </SystemDataGroup>
-            <SystemDataGroup heading="Dataset reference">
-              <SystemDataTags
-                name="dataset_references"
-                label="Dataset references"
-                tooltip="Is there a dataset configured for this system"
-              />
-            </SystemDataGroup>
-            <SystemDataGroup heading="Data processing properties">
-              <SystemDataSwitch
-                name="processes_personal_data"
-                label="This system processes personal data"
-                tooltip="Does this system process personal data?"
-              />
-              <SystemDataSwitch
-                name="exempt_from_privacy_regulations"
-                label="This system is exempt from privacy regulations"
-                tooltip="Is this system exempt from privacy regulations?"
-              />
-              <SystemDataTextField
-                name="reason_for_exemption"
-                label="Reason for exemption"
-                tooltip="Why is this system exempt from privacy regulation?"
-              />
-              <SystemDataSwitch
-                name="uses_profiling"
-                label="This system performs profiling"
-                tooltip="Does this system perform profiling that could have a legal effect?"
-              />
-              <SystemDataTags
-                name="legal_basis_for_profiling"
-                label="Legal basis for profiling"
-                tooltip="What is the legal basis under which profiling is performed?"
-              />
-              <SystemDataSwitch
-                name="does_international_transfers"
-                label="This system transfers data"
-                tooltip="Does this system transfer data to other countries or international organizations?"
-              />
-              <SystemDataTags
-                name="legal_basis_for_transfers"
-                label="Legal basis for transfer"
-                tooltip="What is the legal basis under which the data is transferred?"
-              />
-              <SystemDataSwitch
-                name="requires_data_protection_assessments"
-                label="This system requires Data Privacy Assessments"
-                tooltip="Does this system require (DPA/DPIA) assessments?"
-              />
-              <SystemDataTextField
-                label="DPIA/DPA location"
-                name="dpa_location"
-                tooltip="Where is the DPA/DPIA stored?"
-              />
-            </SystemDataGroup>
-            <SystemDataGroup heading="Administrative properties">
-              <SystemDataTextField
-                label="Data stewards"
-                name="data_stewards"
-                tooltip="Who are the stewards assigned to the system?"
-              />
-              <SystemDataTextField
-                name="privacy_policy"
-                label="Privacy policy URL"
-                tooltip="Where can the privacy
+    <Flex vertical>
+      {/* System information */}
+      <SystemDataGroup heading="System details">
+        {features.dictionaryService ? (
+          <SystemDataTextField
+            name="vendor_id"
+            label="Vendor"
+            tooltip="Select the vendor that matches the system"
+          />
+        ) : null}
+        <SystemDataTextField
+          name="name"
+          label="System name"
+          tooltip="Give the system a unique, and relevant name for reporting purposes. e.g. “Email Data Warehouse”"
+        />
+        <SystemDataTextField
+          name="fides_key"
+          label="Unique ID"
+          tooltip="An auto-generated unique ID based on the system name"
+        />
+        <SystemDataTextField
+          name="description"
+          label="Description"
+          tooltip="Give the system a unique, and relevant name for reporting purposes. e.g. “Email Data Warehouse”"
+        />
+        <SystemDataTags
+          name="tags"
+          label="System Tags"
+          tooltip="Are there any tags to associate with this system?"
+        />
+      </SystemDataGroup>
+      <SystemDataGroup heading="Dataset reference">
+        <SystemDataTags
+          name="dataset_references"
+          label="Dataset references"
+          tooltip="Is there a dataset configured for this system"
+        />
+      </SystemDataGroup>
+      <SystemDataGroup heading="Data processing properties">
+        <SystemDataSwitch
+          name="processes_personal_data"
+          label="This system processes personal data"
+          tooltip="Does this system process personal data?"
+        />
+        <SystemDataSwitch
+          name="exempt_from_privacy_regulations"
+          label="This system is exempt from privacy regulations"
+          tooltip="Is this system exempt from privacy regulations?"
+        />
+        <SystemDataTextField
+          name="reason_for_exemption"
+          label="Reason for exemption"
+          tooltip="Why is this system exempt from privacy regulation?"
+        />
+        <SystemDataSwitch
+          name="uses_profiling"
+          label="This system performs profiling"
+          tooltip="Does this system perform profiling that could have a legal effect?"
+        />
+        <SystemDataTags
+          name="legal_basis_for_profiling"
+          label="Legal basis for profiling"
+          tooltip="What is the legal basis under which profiling is performed?"
+        />
+        <SystemDataSwitch
+          name="does_international_transfers"
+          label="This system transfers data"
+          tooltip="Does this system transfer data to other countries or international organizations?"
+        />
+        <SystemDataTags
+          name="legal_basis_for_transfers"
+          label="Legal basis for transfer"
+          tooltip="What is the legal basis under which the data is transferred?"
+        />
+        <SystemDataSwitch
+          name="requires_data_protection_assessments"
+          label="This system requires Data Privacy Assessments"
+          tooltip="Does this system require (DPA/DPIA) assessments?"
+        />
+        <SystemDataTextField
+          label="DPIA/DPA location"
+          name="dpa_location"
+          tooltip="Where is the DPA/DPIA stored?"
+        />
+      </SystemDataGroup>
+      <SystemDataGroup heading="Administrative properties">
+        <SystemDataTextField
+          label="Data stewards"
+          name="data_stewards"
+          tooltip="Who are the stewards assigned to the system?"
+        />
+        <SystemDataTextField
+          name="privacy_policy"
+          label="Privacy policy URL"
+          tooltip="Where can the privacy
                 policy be located?"
+        />
+        <SystemDataTextField
+          name="legal_name"
+          label="Legal name"
+          tooltip="What is the legal name of the business?"
+        />
+        <SystemDataTextField
+          name="legal_address"
+          label="Legal address"
+          tooltip="What is the legal address for the business?"
+        />
+        <SystemDataTextField
+          label="Department"
+          name="administrating_department"
+          tooltip="Which department is concerned with this system?"
+        />
+        <SystemDataTags
+          label="Responsibility"
+          name="responsibility"
+          tooltip="What is the role of the business with regard to data processing?"
+        />
+        <SystemDataTextField
+          name="dpo"
+          label="Legal contact (DPO)"
+          tooltip="What is the official privacy contact information?"
+        />
+        <SystemDataTextField
+          label="Joint controller"
+          name="joint_controller_info"
+          tooltip="Who are the party or parties that share responsibility for processing data?"
+        />
+        <SystemDataTextField
+          label="Data security practices"
+          name="data_security_practices"
+          tooltip="Which data security practices are employed to keep the data safe?"
+        />
+      </SystemDataGroup>
+      <SystemCustomFieldGroup
+        customFields={initialValues.custom_fields}
+        resourceType={LegacyResourceTypes.SYSTEM}
+      />
+      {/* Data uses */}
+      {initialValues.privacy_declarations &&
+        initialValues.privacy_declarations.map(
+          (_: PrivacyDeclaration, index: number) => (
+            // eslint-disable-next-line react/no-array-index-key
+            <Fragment key={index}>
+              <SystemDataGroup heading="Data use">
+                <SystemDataTextField
+                  label="Declaration name (optional)"
+                  name={`privacy_declarations[${index}].name`}
+                  tooltip="Would you like to append anything to the system name?"
+                />
+                <SystemDataTextField
+                  name={`privacy_declarations[${index}].data_use`}
+                  label="Data use"
+                  tooltip="For which business purposes is this data used?"
+                />
+                <SystemDataTags
+                  name={`privacy_declarations[${index}].data_categories`}
+                  label="Data categories"
+                  tooltip="Which categories of personal data are collected for this purpose?"
+                />
+                <SystemDataTags
+                  name={`privacy_declarations[${index}].data_subjects`}
+                  label="Data subjects"
+                  tooltip="Who are the subjects for this personal data?"
+                />
+                <SystemDataTextField
+                  name={`privacy_declarations[${index}].legal_basis_for_processing`}
+                  label="Legal basis for processing"
+                  tooltip="What is the legal basis under which personal data is processed for this purpose?"
+                />
+                <SystemDataTextField
+                  name={`privacy_declarations[${index}].impact_assessment_location`}
+                  label="Impact assessment location"
+                  tooltip="Where is the legitimate interest impact assessment stored?"
+                />
+                <SystemDataTextField
+                  name={`privacy_declarations[${index}].retention_period`}
+                  label="Retention period (days)"
+                  tooltip="How long is personal data retained for this purpose?"
+                />
+              </SystemDataGroup>
+              <SystemDataGroup heading="Features">
+                <SystemDataTags
+                  name={`privacy_declarations[${index}].features`}
+                  label="Features"
+                  tooltip="What are some features of how data is processed?"
+                />
+              </SystemDataGroup>
+              <SystemDataGroup heading="Dataset reference">
+                <SystemDataTags
+                  name={`privacy_declarations[${index}].dataset_references`}
+                  label="Dataset references"
+                  tooltip="Is there a dataset configured for this system?"
+                />
+              </SystemDataGroup>
+              <SystemDataGroup heading="Special category data">
+                <SystemDataSwitch
+                  name={`privacy_declarations[${index}].processes_special_category_data`}
+                  label="This system processes special category data"
+                  tooltip="Is this system processing special category data as defined by GDPR Article 9?"
+                />
+                <SystemDataTextField
+                  name={`privacy_declarations[${index}].special_category_legal_basis`}
+                  label="Legal basis for processing"
+                  tooltip="What is the legal basis under which the special category data is processed?"
+                />
+              </SystemDataGroup>
+              <SystemDataGroup heading="Third parties">
+                <SystemDataSwitch
+                  name={`privacy_declarations[${index}].data_shared_with_third_parties`}
+                  label="This system shares data with 3rd parties for this purpose"
+                  tooltip="Does this system disclose, sell, or share personal data collected for this business use with 3rd parties?"
+                />
+                <SystemDataTextField
+                  name={`privacy_declarations[${index}].third_parties`}
+                  label="Third parties"
+                  tooltip="Which type of third parties is the data shared with?"
+                />
+                <SystemDataTags
+                  name={`privacy_declarations[${index}].shared_categories`}
+                  label="Shared categories"
+                  tooltip="Which categories of personal data does this system share with third parties?"
+                />
+              </SystemDataGroup>
+              <SystemCustomFieldGroup
+                customFields={
+                  initialValues.privacy_declarations[0].custom_fields
+                }
+                resourceType={LegacyResourceTypes.PRIVACY_DECLARATION}
               />
-              <SystemDataTextField
-                name="legal_name"
-                label="Legal name"
-                tooltip="What is the legal name of the business?"
-              />
-              <SystemDataTextField
-                name="legal_address"
-                label="Legal address"
-                tooltip="What is the legal address for the business?"
-              />
-              <SystemDataTextField
-                label="Department"
-                name="administrating_department"
-                tooltip="Which department is concerned with this system?"
-              />
-              <SystemDataTags
-                label="Responsibility"
-                name="responsibility"
-                tooltip="What is the role of the business with regard to data processing?"
-              />
-              <SystemDataTextField
-                name="dpo"
-                label="Legal contact (DPO)"
-                tooltip="What is the official privacy contact information?"
-              />
-              <SystemDataTextField
-                label="Joint controller"
-                name="joint_controller_info"
-                tooltip="Who are the party or parties that share responsibility for processing data?"
-              />
-              <SystemDataTextField
-                label="Data security practices"
-                name="data_security_practices"
-                tooltip="Which data security practices are employed to keep the data safe?"
-              />
-            </SystemDataGroup>
-            <SystemCustomFieldGroup
-              customFields={initialValues.custom_fields}
-              resourceType={LegacyResourceTypes.SYSTEM}
-            />
-            {/* Data uses */}
-            {initialValues.privacy_declarations &&
-              initialValues.privacy_declarations.map(
-                (_: PrivacyDeclaration, index: number) => (
-                  // eslint-disable-next-line react/no-array-index-key
-                  <Fragment key={index}>
-                    <SystemDataGroup heading="Data use">
-                      <SystemDataTextField
-                        label="Declaration name (optional)"
-                        name={`privacy_declarations[${index}].name`}
-                        tooltip="Would you like to append anything to the system name?"
-                      />
-                      <SystemDataTextField
-                        name={`privacy_declarations[${index}].data_use`}
-                        label="Data use"
-                        tooltip="For which business purposes is this data used?"
-                      />
-                      <SystemDataTags
-                        name={`privacy_declarations[${index}].data_categories`}
-                        label="Data categories"
-                        tooltip="Which categories of personal data are collected for this purpose?"
-                      />
-                      <SystemDataTags
-                        name={`privacy_declarations[${index}].data_subjects`}
-                        label="Data subjects"
-                        tooltip="Who are the subjects for this personal data?"
-                      />
-                      <SystemDataTextField
-                        name={`privacy_declarations[${index}].legal_basis_for_processing`}
-                        label="Legal basis for processing"
-                        tooltip="What is the legal basis under which personal data is processed for this purpose?"
-                      />
-                      <SystemDataTextField
-                        name={`privacy_declarations[${index}].impact_assessment_location`}
-                        label="Impact assessment location"
-                        tooltip="Where is the legitimate interest impact assessment stored?"
-                      />
-                      <SystemDataTextField
-                        name={`privacy_declarations[${index}].retention_period`}
-                        label="Retention period (days)"
-                        tooltip="How long is personal data retained for this purpose?"
-                      />
-                    </SystemDataGroup>
-                    <SystemDataGroup heading="Features">
-                      <SystemDataTags
-                        name={`privacy_declarations[${index}].features`}
-                        label="Features"
-                        tooltip="What are some features of how data is processed?"
-                      />
-                    </SystemDataGroup>
-                    <SystemDataGroup heading="Dataset reference">
-                      <SystemDataTags
-                        name={`privacy_declarations[${index}].dataset_references`}
-                        label="Dataset references"
-                        tooltip="Is there a dataset configured for this system?"
-                      />
-                    </SystemDataGroup>
-                    <SystemDataGroup heading="Special category data">
-                      <SystemDataSwitch
-                        name={`privacy_declarations[${index}].processes_special_category_data`}
-                        label="This system processes special category data"
-                        tooltip="Is this system processing special category data as defined by GDPR Article 9?"
-                      />
-                      <SystemDataTextField
-                        name={`privacy_declarations[${index}].special_category_legal_basis`}
-                        label="Legal basis for processing"
-                        tooltip="What is the legal basis under which the special category data is processed?"
-                      />
-                    </SystemDataGroup>
-                    <SystemDataGroup heading="Third parties">
-                      <SystemDataSwitch
-                        name={`privacy_declarations[${index}].data_shared_with_third_parties`}
-                        label="This system shares data with 3rd parties for this purpose"
-                        tooltip="Does this system disclose, sell, or share personal data collected for this business use with 3rd parties?"
-                      />
-                      <SystemDataTextField
-                        name={`privacy_declarations[${index}].third_parties`}
-                        label="Third parties"
-                        tooltip="Which type of third parties is the data shared with?"
-                      />
-                      <SystemDataTags
-                        name={`privacy_declarations[${index}].shared_categories`}
-                        label="Shared categories"
-                        tooltip="Which categories of personal data does this system share with third parties?"
-                      />
-                    </SystemDataGroup>
-                    <SystemCustomFieldGroup
-                      customFields={
-                        initialValues.privacy_declarations[0].custom_fields
-                      }
-                      resourceType={LegacyResourceTypes.PRIVACY_DECLARATION}
-                    />
-                  </Fragment>
-                ),
-              )}
-            {/* System flow */}
-            <SystemDataGroup heading="Data flow">
-              <SystemDataTags name="ingress" label="Sources" />
-              <SystemDataTags name="egress" label="Destinations" />
-            </SystemDataGroup>
-          </Stack>
-        </Form>
-      )}
-    </Formik>
+            </Fragment>
+          ),
+        )}
+      {/* System flow */}
+      <SystemDataGroup heading="Data flow">
+        <SystemDataTags name="ingress" label="Sources" />
+        <SystemDataTags name="egress" label="Destinations" />
+      </SystemDataGroup>
+    </Flex>
   );
 };
 

--- a/clients/admin-ui/src/features/system/history/modal/SystemDataGroup.tsx
+++ b/clients/admin-ui/src/features/system/history/modal/SystemDataGroup.tsx
@@ -1,8 +1,4 @@
-import {
-  ChakraBox as Box,
-  ChakraHeading as Heading,
-  ChakraStack as Stack,
-} from "fidesui";
+import { Card } from "fidesui";
 import _ from "lodash";
 import React from "react";
 
@@ -38,40 +34,22 @@ const SystemDataGroup = ({
     return false;
   });
 
-  // If no children should be rendered, return null
   if (filteredChildren.length === 0) {
     return null;
   }
 
   return (
-    <Stack marginTop="0px !important">
-      <Box
-        maxWidth="720px"
-        border="1px"
-        borderColor="gray.200"
-        borderRadius={6}
-        overflow="visible"
-        mt={6}
-      >
-        <Box
-          backgroundColor="gray.50"
-          px={6}
-          py={4}
-          display="flex"
-          flexDirection="row"
-          alignItems="center"
-          borderBottom="1px"
-          borderColor="gray.200"
-          borderTopRadius={6}
-        >
-          <Heading as="h3" size="xs">
-            {heading}
-          </Heading>
-        </Box>
-
-        <Stack>{filteredChildren}</Stack>
-      </Box>
-    </Stack>
+    <Card
+      title={heading}
+      variant="outlined"
+      className="mt-6 max-w-[720px] overflow-visible"
+      styles={{
+        body: { padding: 0 },
+        header: { padding: "16px" },
+      }}
+    >
+      {filteredChildren}
+    </Card>
   );
 };
 

--- a/clients/admin-ui/src/features/system/history/modal/fields/SystemDataField.module.scss
+++ b/clients/admin-ui/src/features/system/history/modal/fields/SystemDataField.module.scss
@@ -1,0 +1,25 @@
+.cell {
+  position: relative;
+  margin-top: -1px;
+}
+
+.highlightBefore {
+  background-color: var(--fidesui-color-error-bg);
+  border-color: var(--fidesui-color-error-border);
+  border-top: 1px dashed var(--fidesui-color-error);
+  border-bottom: 1px dashed var(--fidesui-color-error);
+}
+
+.highlightAfter {
+  background-color: var(--fidesui-color-success-bg);
+  border-color: var(--fidesui-color-success-border);
+  border-top: 1px dashed var(--fidesui-color-success);
+  border-bottom: 1px dashed var(--fidesui-color-success);
+}
+
+.arrow {
+  position: absolute;
+  right: -22px;
+  top: 50%;
+  transform: translateY(-50%);
+}

--- a/clients/admin-ui/src/features/system/history/modal/fields/SystemDataSwitch.tsx
+++ b/clients/admin-ui/src/features/system/history/modal/fields/SystemDataSwitch.tsx
@@ -1,30 +1,28 @@
-import {
-  ChakraFlex as Flex,
-  ChakraFormControl as FormControl,
-  ChakraVStack as VStack,
-  Tag,
-} from "fidesui";
-import { useField } from "formik";
+import classNames from "classnames";
+import { Flex, Tag, Typography } from "fidesui";
 import _ from "lodash";
 import { useEffect, useState } from "react";
 
-import {
-  CustomInputProps,
-  Label,
-  StringField,
-} from "~/features/common/form/inputs";
 import { InfoTooltip } from "~/features/common/InfoTooltip";
 
 import { useSelectedHistory } from "../SelectedHistoryContext";
+import styles from "./SystemDataField.module.scss";
+
+interface SystemDataSwitchProps {
+  name: string;
+  label?: string;
+  tooltip?: string | null;
+}
 
 const SystemDataSwitch = ({
   label,
   tooltip,
   ...props
-}: CustomInputProps & StringField) => {
+}: SystemDataSwitchProps) => {
   const { selectedHistory, formType } = useSelectedHistory();
-  const [initialField] = useField(props);
-  const field = { ...initialField, value: initialField.value };
+  const value = _.get(selectedHistory?.[formType], props.name) as
+    | boolean
+    | undefined;
 
   const [shouldHighlight, setShouldHighlight] = useState(false);
 
@@ -32,65 +30,33 @@ const SystemDataSwitch = ({
     const beforeValue = _.get(selectedHistory?.before, props.name);
     const afterValue = _.get(selectedHistory?.after, props.name);
 
-    // Determine whether to highlight
     setShouldHighlight(beforeValue !== afterValue);
-  }, [selectedHistory, props.name, field.value]);
-
-  let highlightStyle = {};
-
-  if (shouldHighlight) {
-    if (formType === "before") {
-      highlightStyle = {
-        backgroundColor: "#FFF5F5",
-        borderColor: "#E53E3E",
-        borderTop: "1px dashed #E53E3E",
-        borderBottom: "1px dashed #E53E3E",
-      };
-    } else {
-      highlightStyle = {
-        backgroundColor: "#F0FFF4",
-        borderColor: "#38A169",
-        borderTop: "1px dashed #38A169",
-        borderBottom: "1px dashed #38A169",
-      };
-    }
-  }
+  }, [selectedHistory, props.name, value]);
 
   return (
-    <FormControl
-      style={highlightStyle}
-      paddingLeft={4}
-      paddingRight={4}
-      paddingTop={3}
-      paddingBottom={3}
-      marginTop="-1px !important"
+    <div
+      className={classNames("px-4 py-3", styles.cell, {
+        [styles.highlightBefore]: shouldHighlight && formType === "before",
+        [styles.highlightAfter]: shouldHighlight && formType === "after",
+      })}
     >
-      <VStack alignItems="start" minHeight="46px">
-        <Flex alignItems="center">
-          <Label htmlFor={props.id || props.name} fontSize="xs" my={0} mr={1}>
+      <Flex vertical align="flex-start" className="min-h-[46px]">
+        <Flex align="center" gap="small">
+          <Typography.Text strong className="!text-xs">
             {label}
-          </Label>
+          </Typography.Text>
           <InfoTooltip label={tooltip} />
         </Flex>
-        {field.value !== undefined && (
+        {value !== undefined && (
           <Tag color="marble" className="m-1">
-            {field.value ? "YES" : "NO"}
+            {value ? "YES" : "NO"}
           </Tag>
         )}
         {formType === "before" && shouldHighlight && (
-          <div
-            style={{
-              position: "absolute",
-              right: "-22px",
-              top: "50%",
-              transform: "translateY(-50%)",
-            }}
-          >
-            →
-          </div>
+          <div className={styles.arrow}>→</div>
         )}
-      </VStack>
-    </FormControl>
+      </Flex>
+    </div>
   );
 };
 

--- a/clients/admin-ui/src/features/system/history/modal/fields/SystemDataTags.tsx
+++ b/clients/admin-ui/src/features/system/history/modal/fields/SystemDataTags.tsx
@@ -1,46 +1,39 @@
-import {
-  ChakraFlex as Flex,
-  ChakraFormControl as FormControl,
-  ChakraVStack as VStack,
-  Tag,
-} from "fidesui";
-import { useField } from "formik";
+import classNames from "classnames";
+import { Flex, Tag, Typography } from "fidesui";
 import _ from "lodash";
 import React, { useEffect, useRef, useState } from "react";
 
-import { Label } from "~/features/common/form/inputs";
 import { InfoTooltip } from "~/features/common/InfoTooltip";
 
 import { useSelectedHistory } from "../SelectedHistoryContext";
+import styles from "./SystemDataField.module.scss";
 
-const SystemDataTags = ({
-  label,
-  tooltip,
-  ...props
-}: {
+interface SystemDataTagsProps {
   label: string;
-  tooltip?: string;
+  tooltip?: string | null;
   name: string;
-}) => {
+}
+
+type TagValue = string | { fides_key: string };
+
+const SystemDataTags = ({ label, tooltip, ...props }: SystemDataTagsProps) => {
   const { selectedHistory, formType } = useSelectedHistory();
-  const [initialField] = useField(props.name);
-  const field = { ...initialField, value: initialField.value ?? [] };
+  const value =
+    (_.get(selectedHistory?.[formType], props.name) as TagValue[]) ?? [];
 
   const contentRef = useRef<HTMLDivElement | null>(null);
   const [height, setHeight] = useState<number | null>(null);
-  const [longestValue, setLongestValue] = useState<any[]>([]);
+  const [longestValue, setLongestValue] = useState<TagValue[]>([]);
   const [shouldHighlight, setShouldHighlight] = useState(false);
 
   useEffect(() => {
     const beforeValue =
-      (_.get(selectedHistory?.before, props.name) as any[]) || [];
+      (_.get(selectedHistory?.before, props.name) as TagValue[]) || [];
     const afterValue =
-      (_.get(selectedHistory?.after, props.name) as any[]) || [];
+      (_.get(selectedHistory?.after, props.name) as TagValue[]) || [];
 
-    // Determine whether to highlight
     setShouldHighlight(!_.isEqual(beforeValue, afterValue));
 
-    // Determine the longest value for height calculation
     setLongestValue(
       beforeValue.length > afterValue.length ? beforeValue : afterValue,
     );
@@ -52,71 +45,38 @@ const SystemDataTags = ({
     }
   }, [longestValue]);
 
-  let highlightStyle = {};
-
-  if (shouldHighlight) {
-    if (formType === "before") {
-      highlightStyle = {
-        backgroundColor: "#FFF5F5",
-        borderColor: "#E53E3E",
-        borderTop: "1px dashed #E53E3E",
-        borderBottom: "1px dashed #E53E3E",
-      };
-    } else {
-      highlightStyle = {
-        backgroundColor: "#F0FFF4",
-        borderColor: "#38A169",
-        borderTop: "1px dashed #38A169",
-        borderBottom: "1px dashed #38A169",
-      };
-    }
-  }
-
   return (
-    <FormControl
-      style={highlightStyle}
-      paddingLeft={4}
-      paddingRight={4}
-      paddingTop={3}
-      paddingBottom={3}
-      marginTop="-1px !important"
+    <div
+      className={classNames("px-4 py-3", styles.cell, {
+        [styles.highlightBefore]: shouldHighlight && formType === "before",
+        [styles.highlightAfter]: shouldHighlight && formType === "after",
+      })}
     >
-      <VStack alignItems="start">
-        <Flex alignItems="center">
-          <Label htmlFor={props.name} fontSize="xs" my={0} mr={1}>
+      <Flex vertical align="flex-start">
+        <Flex align="center" gap="small">
+          <Typography.Text strong className="!text-xs">
             {label}
-          </Label>
+          </Typography.Text>
           <InfoTooltip label={tooltip} />
         </Flex>
         <Flex
           wrap="wrap"
-          alignItems="flex-start"
+          align="flex-start"
           ref={contentRef}
           style={{ minHeight: `${height}px` }}
         >
-          {(height ? field.value : longestValue).map(
-            (value: any, index: number) => (
-              // eslint-disable-next-line react/no-array-index-key
-              <Tag key={index} color="marble" className="m-1">
-                {typeof value === "object" ? value.fides_key : value}
-              </Tag>
-            ),
-          )}
+          {(height ? value : longestValue).map((tagValue, index) => (
+            // eslint-disable-next-line react/no-array-index-key
+            <Tag key={index} color="marble" className="m-1">
+              {typeof tagValue === "object" ? tagValue.fides_key : tagValue}
+            </Tag>
+          ))}
         </Flex>
         {formType === "before" && shouldHighlight && (
-          <div
-            style={{
-              position: "absolute",
-              right: "-22px",
-              top: "50%",
-              transform: "translateY(-50%)",
-            }}
-          >
-            →
-          </div>
+          <div className={styles.arrow}>→</div>
         )}
-      </VStack>
-    </FormControl>
+      </Flex>
+    </div>
   );
 };
 

--- a/clients/admin-ui/src/features/system/history/modal/fields/SystemDataTextField.tsx
+++ b/clients/admin-ui/src/features/system/history/modal/fields/SystemDataTextField.tsx
@@ -1,32 +1,29 @@
-import {
-  ChakraFlex as Flex,
-  ChakraFormControl as FormControl,
-  ChakraText as Text,
-  ChakraVStack as VStack,
-} from "fidesui";
-import { useField } from "formik";
+import classNames from "classnames";
+import { Flex, Typography } from "fidesui";
 import _ from "lodash";
 import { useEffect, useRef, useState } from "react";
 
-import {
-  CustomInputProps,
-  Label,
-  StringField,
-} from "~/features/common/form/inputs";
 import { InfoTooltip } from "~/features/common/InfoTooltip";
 
 import { useSelectedHistory } from "../SelectedHistoryContext";
+import styles from "./SystemDataField.module.scss";
+
+interface SystemDataTextFieldProps {
+  name: string;
+  label?: string;
+  tooltip?: string | null;
+}
 
 const SystemDataTextField = ({
   label,
   tooltip,
   ...props
-}: CustomInputProps & StringField) => {
+}: SystemDataTextFieldProps) => {
   const { selectedHistory, formType } = useSelectedHistory();
-  const [initialField] = useField(props);
-  const field = { ...initialField, value: initialField.value ?? "" };
+  const value =
+    (_.get(selectedHistory?.[formType], props.name) as string) ?? "";
 
-  const contentRef = useRef<HTMLParagraphElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
   const [height, setHeight] = useState<number | null>(null);
   const [shouldHighlight, setShouldHighlight] = useState(false);
 
@@ -36,81 +33,40 @@ const SystemDataTextField = ({
     const afterValue =
       (_.get(selectedHistory?.after, props.name) as string) || "";
 
-    // Determine whether to highlight
     setShouldHighlight(!_.isEqual(beforeValue, afterValue));
 
     const longestValue =
       beforeValue.length > afterValue.length ? beforeValue : afterValue;
 
     if (contentRef.current) {
-      // Temporarily set the value to the longest one to measure height
       contentRef.current.textContent = longestValue;
-
-      // Measure and set the height
       setHeight(contentRef.current.offsetHeight);
-
-      // Reset the value to the actual one
-      contentRef.current.textContent = field.value;
+      contentRef.current.textContent = value;
     }
-  }, [selectedHistory, props.name, field.value]);
-
-  let highlightStyle = {};
-
-  if (shouldHighlight) {
-    if (formType === "before") {
-      highlightStyle = {
-        backgroundColor: "#FFF5F5",
-        borderColor: "#E53E3E",
-        borderTop: "1px dashed #E53E3E",
-        borderBottom: "1px dashed #E53E3E",
-      };
-    } else {
-      highlightStyle = {
-        backgroundColor: "#F0FFF4",
-        borderColor: "#38A169",
-        borderTop: "1px dashed #38A169",
-        borderBottom: "1px dashed #38A169",
-      };
-    }
-  }
+  }, [selectedHistory, props.name, value]);
 
   return (
-    <FormControl
-      style={highlightStyle}
-      paddingLeft={4}
-      paddingRight={4}
-      paddingTop={3}
-      paddingBottom={3}
-      marginTop="-1px !important"
+    <div
+      className={classNames("px-4 py-3", styles.cell, {
+        [styles.highlightBefore]: shouldHighlight && formType === "before",
+        [styles.highlightAfter]: shouldHighlight && formType === "after",
+      })}
     >
-      <VStack alignItems="start">
-        <Flex alignItems="center">
-          <Label htmlFor={props.id || props.name} fontSize="xs" my={0} mr={1}>
+      <Flex vertical align="flex-start">
+        <Flex align="center" gap="small">
+          <Typography.Text strong className="!text-xs">
             {label}
-          </Label>
+          </Typography.Text>
           <InfoTooltip label={tooltip} />
         </Flex>
-        <Text
-          fontSize="14px"
-          ref={contentRef}
-          style={{ height: `${height}px` }}
-        >
-          {field.value}
-        </Text>
+        <Typography.Text ref={contentRef} style={{ height: `${height}px` }}>
+          {value}
+        </Typography.Text>
         {formType === "before" && shouldHighlight && (
-          <div
-            style={{
-              position: "absolute",
-              right: "-22px",
-              top: "50%",
-              transform: "translateY(-50%)",
-            }}
-          >
-            →
-          </div>
+          <div className={styles.arrow}>→</div>
         )}
-      </VStack>
-    </FormControl>
+      </Flex>
+    </div>
   );
 };
 


### PR DESCRIPTION
Ticket [ENG-3555]

### Description Of Changes

Migrate the read-only system history diff view from Chakra UI and Formik to Ant Design. The form is purely for display (no validation, no submit) so Formik is dropped entirely — values are read directly from `SelectedHistoryContext` instead of via `useField`.

The diff highlight styling (red "before" / green "after" with the arrow indicator) moves from inline Chakra props into a CSS module using Ant theme tokens. The card chrome is now `fidesui` `Card` with the body padding zeroed so the field cells own their own spacing.

### Code Changes

- `clients/admin-ui/src/features/system/history/modal/SystemDataForm.tsx` — replace the `Formik` wrapper with a `Flex vertical` and pass values via context.
- `clients/admin-ui/src/features/system/history/modal/SystemDataGroup.tsx` — use fidesui `Card` (string `title` + `variant="outlined"`); align header padding with field cell padding; delete the per-group SCSS module.
- `clients/admin-ui/src/features/system/history/modal/fields/SystemDataTextField.tsx` — replace `ChakraVStack`/`ChakraFlex`/`ChakraText` with antd `Flex` and `Typography.Text`; preserve the height-measurement workaround that keeps before/after rows aligned.
- `clients/admin-ui/src/features/system/history/modal/fields/SystemDataTags.tsx` — same migration; replace `any[]` with a `TagValue = string | { fides_key: string }` union.
- `clients/admin-ui/src/features/system/history/modal/fields/SystemDataSwitch.tsx` — same migration; show a YES/NO `Tag` instead of a Chakra badge.
- `clients/admin-ui/src/features/system/history/modal/fields/SystemDataField.module.scss` — new module for the diff highlight classes; uses `color-error-bg`/`color-error-border` and the symmetric `color-success-bg`/`color-success-border` Ant tokens.

### Steps to Confirm

1. Navigate to **Data inventory → System inventory** and edit any system to generate a history entry (or pick a system that already has changes recorded).
2. Open the **History** tab on that system.
3. Click a history row — `SystemHistoryModal` opens with the before/after diff.
4. Verify each field type renders correctly:
   - **Text fields** (System name, Description, etc.) — labels and values align; rows where before/after differ show the dashed red border on the left and dashed green border on the right with the `→` arrow.
   - **Tag fields** (Data uses, Data categories, Data subjects) — tag lists render and align in height across before/after.
   - **Switch fields** (boolean toggles like `processes_personal_data`) — render as a YES/NO tag.
5. The `SystemDataGroup` card header ("System details", "Privacy declarations", etc.) sits flush with the field labels (16px left padding).

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
* UX feedback:
  * [x] No UX review needed
* Followup issues:
  * [x] No followup issues
* Database migrations:
  * [x] No migrations
* Documentation:
  * [x] No documentation updates required

[ENG-3555]: https://ethyca.atlassian.net/browse/ENG-3555
