### PR TITLE
ENG-1958: Add ON DELETE SET NULL to tcf_version_hash_history FK

### DIFF
--- a/changelog/8241-tcf-hash-history-fk-on-delete.yaml
+++ b/changelog/8241-tcf-hash-history-fk-on-delete.yaml
@@ -1,4 +1,4 @@
 type: Fixed
-description: Fixed missing ON DELETE SET NULL on tcf_version_hash_history foreign key
+description: Fixed missing ON DELETE CASCADE on tcf_version_hash_history foreign key
 pr: 8241
 labels: ["db-migration"]

--- a/changelog/8241-tcf-hash-history-fk-on-delete.yaml
+++ b/changelog/8241-tcf-hash-history-fk-on-delete.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Fixed missing ON DELETE SET NULL on tcf_version_hash_history foreign key
+pr: 8241
+labels: ["db-migration"]

--- a/src/fides/api/alembic/migrations/versions/xx_2026_05_07_1000_96fa22d82c26_add_tcf_version_hash_history.py
+++ b/src/fides/api/alembic/migrations/versions/xx_2026_05_07_1000_96fa22d82c26_add_tcf_version_hash_history.py
@@ -35,6 +35,7 @@ def upgrade() -> None:
         sa.Column(
             "privacy_experience_config_id",
             sa.String(length=255),
+            nullable=True,
         ),
         sa.Column("previous_hash", sa.String(), nullable=True),
         sa.Column("current_hash", sa.String(), nullable=False),
@@ -49,6 +50,7 @@ def upgrade() -> None:
         sa.ForeignKeyConstraint(
             ["privacy_experience_config_id"],
             ["privacyexperienceconfig.id"],
+            ondelete="SET NULL",
         ),
         sa.PrimaryKeyConstraint("id"),
     )

--- a/src/fides/api/alembic/migrations/versions/xx_2026_05_07_1000_96fa22d82c26_add_tcf_version_hash_history.py
+++ b/src/fides/api/alembic/migrations/versions/xx_2026_05_07_1000_96fa22d82c26_add_tcf_version_hash_history.py
@@ -49,7 +49,6 @@ def upgrade() -> None:
         sa.ForeignKeyConstraint(
             ["privacy_experience_config_id"],
             ["privacyexperienceconfig.id"],
-            ondelete="CASCADE",
         ),
         sa.PrimaryKeyConstraint("id"),
     )

--- a/src/fides/api/alembic/migrations/versions/xx_2026_05_07_1000_96fa22d82c26_add_tcf_version_hash_history.py
+++ b/src/fides/api/alembic/migrations/versions/xx_2026_05_07_1000_96fa22d82c26_add_tcf_version_hash_history.py
@@ -35,7 +35,6 @@ def upgrade() -> None:
         sa.Column(
             "privacy_experience_config_id",
             sa.String(length=255),
-            nullable=True,
         ),
         sa.Column("previous_hash", sa.String(), nullable=True),
         sa.Column("current_hash", sa.String(), nullable=False),
@@ -50,7 +49,7 @@ def upgrade() -> None:
         sa.ForeignKeyConstraint(
             ["privacy_experience_config_id"],
             ["privacyexperienceconfig.id"],
-            ondelete="SET NULL",
+            ondelete="CASCADE",
         ),
         sa.PrimaryKeyConstraint("id"),
     )

--- a/src/fides/api/alembic/migrations/versions/xx_2026_05_20_1200_c8d4e2f6a9b1_cascade_delete_tcf_hash_history.py
+++ b/src/fides/api/alembic/migrations/versions/xx_2026_05_20_1200_c8d4e2f6a9b1_cascade_delete_tcf_hash_history.py
@@ -1,0 +1,46 @@
+"""cascade delete tcf_version_hash_history on experience config delete
+
+Revision ID: c8d4e2f6a9b1
+Revises: 96fa22d82c26
+Create Date: 2026-05-20 12:00:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c8d4e2f6a9b1"
+down_revision = "96fa22d82c26"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        "tcf_version_hash_history_privacy_experience_config_id_fkey",
+        "tcf_version_hash_history",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "tcf_version_hash_history_privacy_experience_config_id_fkey",
+        "tcf_version_hash_history",
+        "privacyexperienceconfig",
+        ["privacy_experience_config_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "tcf_version_hash_history_privacy_experience_config_id_fkey",
+        "tcf_version_hash_history",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "tcf_version_hash_history_privacy_experience_config_id_fkey",
+        "tcf_version_hash_history",
+        "privacyexperienceconfig",
+        ["privacy_experience_config_id"],
+        ["id"],
+    )

--- a/src/fides/api/alembic/migrations/versions/xx_2026_05_20_1200_c8d4e2f6a9b1_cascade_delete_tcf_hash_history.py
+++ b/src/fides/api/alembic/migrations/versions/xx_2026_05_20_1200_c8d4e2f6a9b1_cascade_delete_tcf_hash_history.py
@@ -1,7 +1,7 @@
 """cascade delete tcf_version_hash_history on experience config delete
 
 Revision ID: c8d4e2f6a9b1
-Revises: 96fa22d82c26
+Revises: 1e07732ff193
 Create Date: 2026-05-20 12:00:00.000000
 
 """
@@ -10,7 +10,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "c8d4e2f6a9b1"
-down_revision = "96fa22d82c26"
+down_revision = "1e07732ff193"
 branch_labels = None
 depends_on = None
 

--- a/src/fides/api/alembic/migrations/versions/xx_2026_05_20_1200_c8d4e2f6a9b1_cascade_delete_tcf_hash_history.py
+++ b/src/fides/api/alembic/migrations/versions/xx_2026_05_20_1200_c8d4e2f6a9b1_cascade_delete_tcf_hash_history.py
@@ -1,7 +1,7 @@
 """cascade delete tcf_version_hash_history on experience config delete
 
 Revision ID: c8d4e2f6a9b1
-Revises: 1e07732ff193
+Revises: b6d4f8e2c1a3
 Create Date: 2026-05-20 12:00:00.000000
 
 """
@@ -10,7 +10,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "c8d4e2f6a9b1"
-down_revision = "1e07732ff193"
+down_revision = "b6d4f8e2c1a3"
 branch_labels = None
 depends_on = None
 

--- a/src/fides/api/models/tcf_version_hash_history.py
+++ b/src/fides/api/models/tcf_version_hash_history.py
@@ -29,8 +29,7 @@ class TCFVersionHashHistory(Base):
 
     privacy_experience_config_id = Column(
         String(255),
-        ForeignKey("privacyexperienceconfig.id", ondelete="SET NULL"),
-        nullable=True,
+        ForeignKey("privacyexperienceconfig.id", ondelete="CASCADE"),
         index=True,
     )
     previous_hash = Column(String, nullable=True)

--- a/src/fides/api/models/tcf_version_hash_history.py
+++ b/src/fides/api/models/tcf_version_hash_history.py
@@ -29,7 +29,8 @@ class TCFVersionHashHistory(Base):
 
     privacy_experience_config_id = Column(
         String(255),
-        ForeignKey("privacyexperienceconfig.id"),
+        ForeignKey("privacyexperienceconfig.id", ondelete="SET NULL"),
+        nullable=True,
         index=True,
     )
     previous_hash = Column(String, nullable=True)


### PR DESCRIPTION
## Summary
- Adds `ON DELETE SET NULL` to the `privacy_experience_config_id` foreign key in `tcf_version_hash_history`
- Marks the column `nullable=True` in both the model and migration
- Without this, test teardowns that delete `PrivacyExperienceConfig` rows fail with a FK violation because hash history rows still reference them

## Test plan
- [ ] Existing fidesplus CI tests pass (FK violation on teardown is resolved)
- [ ] Verify `tcf_version_hash_history` rows are nulled out (not deleted) when a `PrivacyExperienceConfig` is deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)