### PR TITLE
ENG-3884: Invalidate dashboard priority actions on privacy request mutations

### DIFF
--- a/changelog/8242-invalidate-dashboard-on-request-mutation.yaml
+++ b/changelog/8242-invalidate-dashboard-on-request-mutation.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Fixed stale dashboard priority actions after privacy request mutations (approve, deny, delete, finalize)
+pr: 8242
+labels: []

--- a/clients/admin-ui/src/features/privacy-requests/privacy-requests.slice.ts
+++ b/clients/admin-ui/src/features/privacy-requests/privacy-requests.slice.ts
@@ -325,7 +325,7 @@ export const privacyRequestApi = baseApi.injectEndpoints({
           request_ids: [id],
         },
       }),
-      invalidatesTags: ["Request"],
+      invalidatesTags: ["Request", { type: "Fides Dashboard", id: "actions" }],
     }),
     bulkApproveRequest: build.mutation<
       { succeeded: string[]; failed: any[] },
@@ -336,7 +336,7 @@ export const privacyRequestApi = baseApi.injectEndpoints({
         method: "PATCH",
         body,
       }),
-      invalidatesTags: ["Request"],
+      invalidatesTags: ["Request", { type: "Fides Dashboard", id: "actions" }],
     }),
     bulkRetry: build.mutation<BulkPostPrivacyRequests, string[]>({
       query: (values) => ({
@@ -344,7 +344,7 @@ export const privacyRequestApi = baseApi.injectEndpoints({
         method: "POST",
         body: values,
       }),
-      invalidatesTags: ["Request"],
+      invalidatesTags: ["Request", { type: "Fides Dashboard", id: "actions" }],
     }),
     denyRequest: build.mutation<PrivacyRequestEntity, DenyPrivacyRequest>({
       query: ({ id, reason }) => ({
@@ -355,7 +355,7 @@ export const privacyRequestApi = baseApi.injectEndpoints({
           reason,
         },
       }),
-      invalidatesTags: ["Request"],
+      invalidatesTags: ["Request", { type: "Fides Dashboard", id: "actions" }],
     }),
     bulkDenyRequest: build.mutation<
       { succeeded: string[]; failed: any[] },
@@ -366,7 +366,7 @@ export const privacyRequestApi = baseApi.injectEndpoints({
         method: "PATCH",
         body,
       }),
-      invalidatesTags: ["Request"],
+      invalidatesTags: ["Request", { type: "Fides Dashboard", id: "actions" }],
     }),
     softDeleteRequest: build.mutation<
       PrivacyRequestEntity,
@@ -376,7 +376,7 @@ export const privacyRequestApi = baseApi.injectEndpoints({
         url: `privacy-request/${id}/soft-delete`,
         method: "POST",
       }),
-      invalidatesTags: ["Request"],
+      invalidatesTags: ["Request", { type: "Fides Dashboard", id: "actions" }],
     }),
     bulkSoftDeleteRequest: build.mutation<
       { succeeded: string[]; failed: any[] },
@@ -387,7 +387,7 @@ export const privacyRequestApi = baseApi.injectEndpoints({
         method: "POST",
         body,
       }),
-      invalidatesTags: ["Request"],
+      invalidatesTags: ["Request", { type: "Fides Dashboard", id: "actions" }],
     }),
     bulkFinalizeRequest: build.mutation<
       { succeeded: string[]; failed: any[] },
@@ -398,7 +398,7 @@ export const privacyRequestApi = baseApi.injectEndpoints({
         method: "POST",
         body,
       }),
-      invalidatesTags: ["Request"],
+      invalidatesTags: ["Request", { type: "Fides Dashboard", id: "actions" }],
     }),
     getAllPrivacyRequests: build.query<
       PrivacyRequestResponse,
@@ -469,7 +469,7 @@ export const privacyRequestApi = baseApi.injectEndpoints({
           source: PrivacyRequestSource.REQUEST_MANAGER,
         })),
       }),
-      invalidatesTags: () => ["Request"],
+      invalidatesTags: () => ["Request", { type: "Fides Dashboard", id: "actions" }],
     }),
     getNotification: build.query<PrivacyRequestNotificationInfo, void>({
       // NOTE: This will intentionally return a 404 with `details` if the notification is not yet set.
@@ -508,7 +508,7 @@ export const privacyRequestApi = baseApi.injectEndpoints({
         url: `privacy-request/${privacy_request_id}/resume_from_requires_input`,
         method: "POST",
       }),
-      invalidatesTags: ["Request"],
+      invalidatesTags: ["Request", { type: "Fides Dashboard", id: "actions" }],
     }),
     retry: build.mutation<
       PrivacyRequestEntity,
@@ -518,7 +518,7 @@ export const privacyRequestApi = baseApi.injectEndpoints({
         url: `privacy-request/${id}/retry`,
         method: "POST",
       }),
-      invalidatesTags: ["Request"],
+      invalidatesTags: ["Request", { type: "Fides Dashboard", id: "actions" }],
     }),
     saveNotification: build.mutation<any, PrivacyRequestNotificationInfo>({
       query: (params) => ({
@@ -633,7 +633,7 @@ export const privacyRequestApi = baseApi.injectEndpoints({
         method: "POST",
         url: `/privacy-request/${privacyRequestId}/finalize`,
       }),
-      invalidatesTags: ["Request"],
+      invalidatesTags: ["Request", { type: "Fides Dashboard", id: "actions" }],
     }),
   }),
 });


### PR DESCRIPTION
Ticket [ENG-3884]

### Description Of Changes

The dashboard "Priority actions" widget could show stale data (including deleted/modified privacy requests) because privacy request mutations only invalidated the `"Request"` RTK Query tag. The dashboard priority actions query uses the `"Fides Dashboard"` tag with `id: "actions"`, so it was never refetched after request mutations.

This fix adds `{ type: "Fides Dashboard", id: "actions" }` to `invalidatesTags` on all privacy request mutations in `privacy-requests.slice.ts`, ensuring the priority actions query refetches whenever a request is approved, denied, deleted, finalized, retried, or created.

### Code Changes

* Added `{ type: "Fides Dashboard", id: "actions" }` to `invalidatesTags` on 12 mutations in `privacy-requests.slice.ts`: `approveRequest`, `bulkApproveRequest`, `bulkRetry`, `denyRequest`, `bulkDenyRequest`, `softDeleteRequest`, `bulkSoftDeleteRequest`, `bulkFinalizeRequest`, `postPrivacyRequest`, `resumePrivacyRequestFromRequiresInput`, `retry`, `postPrivacyRequestFinalize`

### Steps to Confirm

1. Open the dashboard and note the priority actions displayed
2. Navigate to privacy requests and approve, deny, or soft-delete a request
3. Return to the dashboard — priority actions should update immediately without a page refresh
4. Verify that only the priority actions widget refetches, not all dashboard data

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required

[ENG-3884]: https://ethyca.atlassian.net/browse/ENG-3884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ