### PR TITLE
ENG-3570 - Add cloud infra resource grouping frontend

### DIFF
--- a/changelog/8246-cloud-infra-grouping-frontend.yaml
+++ b/changelog/8246-cloud-infra-grouping-frontend.yaml
@@ -1,0 +1,4 @@
+type: Added
+description: Added frontend for cloud infra resource grouping with inline group assignment, group CRUD management tab, and create/edit modal with system linking
+pr: 8246
+labels: []

--- a/clients/admin-ui/src/features/common/api.slice.ts
+++ b/clients/admin-ui/src/features/common/api.slice.ts
@@ -105,6 +105,7 @@ export const baseApi = createApi({
     "Identity Provider Monitor Filters",
     "Cloud Infra Monitor Results",
     "Cloud Infra Monitor Filters",
+    "Cloud Infra Groups",
     "Privacy Assessment",
     "Privacy Assessment Config",
     "Privacy Assessment Questionnaire",

--- a/clients/admin-ui/src/features/common/nav/routes.ts
+++ b/clients/admin-ui/src/features/common/nav/routes.ts
@@ -39,6 +39,8 @@ export const ACTION_CENTER_CLOUD_INFRASTRUCTURE_MONITOR_ROUTE =
   "/data-discovery/action-center/cloud_infrastructure/[monitorId]";
 export const ACTION_CENTER_CLOUD_INFRASTRUCTURE_MONITOR_ACTIVITY_ROUTE =
   "/data-discovery/action-center/cloud_infrastructure/[monitorId]/activity";
+export const ACTION_CENTER_CLOUD_INFRASTRUCTURE_MONITOR_GROUPS_ROUTE =
+  "/data-discovery/action-center/cloud_infrastructure/[monitorId]/groups";
 export const UNCATEGORIZED_SEGMENT = "[undefined]";
 
 // Privacy requests group

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/components/CloudInfraResourceListItem.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/components/CloudInfraResourceListItem.tsx
@@ -4,6 +4,7 @@ import { INFRASTRUCTURE_DIFF_STATUS_COLOR } from "~/features/data-discovery-and-
 import { DiffStatus } from "~/types/api";
 import { CloudInfraStagedResource } from "~/types/api/models/CloudInfraStagedResource";
 
+import { GroupSelect } from "../fields/GroupSelect";
 import {
   getServiceIconUrl,
   getServiceLabel,
@@ -11,12 +12,17 @@ import {
 
 interface CloudInfraResourceListItemProps {
   item: CloudInfraStagedResource;
+  monitorId: string;
 }
 
 export const CloudInfraResourceListItem = ({
   item,
+  monitorId,
 }: CloudInfraResourceListItemProps) => {
   const resourceName = item.name ?? "Unnamed resource";
+  const groupsDisabled =
+    item.diff_status === DiffStatus.MUTED ||
+    item.diff_status === DiffStatus.REMOVAL;
 
   return (
     <List.Item>
@@ -68,12 +74,23 @@ export const CloudInfraResourceListItem = ({
               {item.tags && Object.keys(item.tags).length > 0 && (
                 <Flex gap={4} wrap="wrap">
                   {Object.entries(item.tags).map(([key, value]) => (
-                    <Tag key={key} className="text-xs" icon={<Icons.Tag />}>
+                    <Tag
+                      key={key}
+                      className="text-xs"
+                      color="marble"
+                      icon={<Icons.Tag />}
+                    >
                       {key}: {value}
                     </Tag>
                   ))}
                 </Flex>
               )}
+              <GroupSelect
+                monitorId={monitorId}
+                resourceUrn={item.urn}
+                groups={item.groups}
+                disabled={groupsDisabled}
+              />
             </Flex>
           }
         />

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/components/CreateCloudInfraGroupModal.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/components/CreateCloudInfraGroupModal.tsx
@@ -1,0 +1,181 @@
+import {
+  Button,
+  DefaultOptionType,
+  Flex,
+  Form,
+  Input,
+  Modal,
+  Typography,
+  useMessage,
+} from "fidesui";
+import { useEffect, useState } from "react";
+
+import { SystemSelect } from "~/features/common/dropdown/SystemSelect";
+import { getErrorMessage, isErrorResult } from "~/features/common/helpers";
+import { CloudInfraGroupResponse } from "~/types/api";
+
+import {
+  useCreateCloudInfraGroupMutation,
+  useUpdateCloudInfraGroupMutation,
+} from "../../discovery-detection.slice";
+
+const { Text } = Typography;
+
+interface CreateCloudInfraGroupModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  monitorId: string;
+  onSuccess?: (groupId: string) => void;
+  /** When provided, the modal operates in edit mode. */
+  group?: CloudInfraGroupResponse;
+}
+
+export const CreateCloudInfraGroupModal = ({
+  isOpen,
+  onClose,
+  monitorId,
+  onSuccess,
+  group,
+}: CreateCloudInfraGroupModalProps) => {
+  const isEditMode = !!group;
+
+  const [groupName, setGroupName] = useState("");
+  const [selectedSystem, setSelectedSystem] = useState<
+    DefaultOptionType | undefined
+  >();
+  const [createGroup, { isLoading: isCreating }] =
+    useCreateCloudInfraGroupMutation();
+  const [updateGroup, { isLoading: isUpdating }] =
+    useUpdateCloudInfraGroupMutation();
+  const messageApi = useMessage();
+
+  const isLoading = isCreating || isUpdating;
+
+  // Pre-fill values when editing
+  useEffect(() => {
+    if (group && isOpen) {
+      setGroupName(group.name ?? "");
+      if (group.system_key) {
+        setSelectedSystem({
+          value: group.system_key,
+          label: group.system_name ?? group.system_key,
+        });
+      } else {
+        setSelectedSystem(undefined);
+      }
+    }
+  }, [group, isOpen]);
+
+  const hasName = groupName.trim().length > 0;
+  const hasSystem = !!selectedSystem;
+  const canSubmit = hasName || hasSystem;
+
+  const handleClose = () => {
+    setGroupName("");
+    setSelectedSystem(undefined);
+    onClose();
+  };
+
+  const handleSubmit = async () => {
+    if (!canSubmit) {
+      return;
+    }
+    const body = {
+      name: hasName ? groupName.trim() : undefined,
+      system_key: hasSystem ? (selectedSystem.value as string) : undefined,
+    };
+
+    if (isEditMode) {
+      const result = await updateGroup({
+        monitor_config_id: monitorId,
+        group_id: group.id,
+        body,
+      });
+      if (isErrorResult(result)) {
+        messageApi.open({
+          type: "error",
+          content: getErrorMessage(result.error, "Failed to update group."),
+        });
+        return;
+      }
+      messageApi.open({ type: "success", content: "Group updated." });
+      handleClose();
+      onSuccess?.(group.id);
+    } else {
+      const result = await createGroup({
+        monitor_config_id: monitorId,
+        body,
+      });
+      if (isErrorResult(result)) {
+        messageApi.open({
+          type: "error",
+          content: getErrorMessage(result.error, "Failed to create group."),
+        });
+        return;
+      }
+      const label =
+        result.data.system_name || result.data.name || "Unnamed group";
+      messageApi.open({
+        type: "success",
+        content: `Group "${label}" created.`,
+      });
+      handleClose();
+      onSuccess?.(result.data.id);
+    }
+  };
+
+  return (
+    <Modal
+      title={isEditMode ? "Edit group" : "Create group"}
+      open={isOpen}
+      onCancel={handleClose}
+      centered
+      destroyOnHidden
+      footer={null}
+      data-testid="create-cloud-infra-group-modal"
+    >
+      <Flex vertical gap={20} className="pb-6 pt-4">
+        <Text>
+          {isEditMode
+            ? "Update the group name or change the system it targets."
+            : "Group resources into a System. Provide a name for a new system, or select an existing one. The system will be created when a resource in this group is promoted."}
+        </Text>
+        <Form layout="vertical">
+          <Form.Item label="Group name" className="mb-4">
+            <Input
+              placeholder="e.g. Payment Processing"
+              value={groupName}
+              onChange={(e) => setGroupName(e.target.value)}
+              onPressEnter={handleSubmit}
+              data-testid="group-name-input"
+            />
+          </Form.Item>
+          <Form.Item label="Existing system" className="mb-0">
+            <SystemSelect
+              placeholder="Search or select a system..."
+              onSelect={(_, option) => setSelectedSystem(option)}
+              value={selectedSystem}
+              allowClear
+              onClear={() => setSelectedSystem(undefined)}
+            />
+          </Form.Item>
+        </Form>
+      </Flex>
+      <Flex justify="space-between">
+        <Button htmlType="reset" onClick={handleClose} data-testid="cancel-btn">
+          Cancel
+        </Button>
+        <Button
+          htmlType="submit"
+          type="primary"
+          disabled={!canSubmit}
+          loading={isLoading}
+          onClick={handleSubmit}
+          data-testid="save-btn"
+        >
+          {isEditMode ? "Save" : "Create"}
+        </Button>
+      </Flex>
+    </Modal>
+  );
+};

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/GroupSelect.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/GroupSelect.tsx
@@ -126,11 +126,20 @@ export const GroupSelect = ({
   };
 
   const handleCreateSuccess = async (groupId: string) => {
-    await assignResources({
+    const result = await assignResources({
       monitor_config_id: monitorId,
       group_id: groupId,
       staged_resource_urns: [resourceUrn],
     });
+    if (isErrorResult(result)) {
+      messageApi.open({
+        type: "error",
+        content: getErrorMessage(
+          result.error,
+          "Group created, but failed to assign to this resource.",
+        ),
+      });
+    }
   };
 
   const tagRender = (props: {

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/GroupSelect.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/fields/GroupSelect.tsx
@@ -1,0 +1,222 @@
+import { Button, Icons, Select, Tag, Text, Tooltip, useMessage } from "fidesui";
+import { useMemo, useState } from "react";
+
+import { getErrorMessage, isErrorResult } from "~/features/common/helpers";
+import { CloudInfraGroupSummary } from "~/types/api";
+
+import {
+  useAssignResourcesToCloudInfraGroupMutation,
+  useGetCloudInfraGroupsQuery,
+  useUnassignResourcesFromCloudInfraGroupMutation,
+} from "../../discovery-detection.slice";
+import { CreateCloudInfraGroupModal } from "../components/CreateCloudInfraGroupModal";
+
+const CREATE_NEW_GROUP_VALUE = "__create_new_group__";
+
+const getGroupLabel = (group: {
+  name?: string | null;
+  system_name?: string | null;
+  system_key?: string | null;
+  id?: string;
+}): string => {
+  const groupName = group.name;
+  const systemName = group.system_name || group.system_key;
+  if (groupName && systemName) {
+    return `${groupName} (${systemName})`;
+  }
+  return groupName || systemName || group.id || "Unnamed group";
+};
+
+interface GroupSelectProps {
+  monitorId: string;
+  resourceUrn: string;
+  groups?: CloudInfraGroupSummary[] | null;
+  disabled?: boolean;
+}
+
+export const GroupSelect = ({
+  monitorId,
+  resourceUrn,
+  groups,
+  disabled,
+}: GroupSelectProps) => {
+  const [open, setOpen] = useState(false);
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const messageApi = useMessage();
+
+  const { data: availableGroups } = useGetCloudInfraGroupsQuery(
+    { monitor_config_id: monitorId, size: 100 },
+    { skip: !monitorId },
+  );
+
+  const [assignResources] = useAssignResourcesToCloudInfraGroupMutation();
+  const [unassignResources] = useUnassignResourcesFromCloudInfraGroupMutation();
+
+  const currentGroupIds = useMemo(
+    () => (groups ?? []).map((g) => g.id),
+    [groups],
+  );
+
+  const options = useMemo(() => {
+    const groupOptions = (availableGroups?.items ?? []).map((group) => {
+      const groupLabel = getGroupLabel(group);
+      return {
+        value: group.id,
+        label: groupLabel,
+        searchLabel: groupLabel,
+      };
+    });
+    return [
+      {
+        value: CREATE_NEW_GROUP_VALUE,
+        label: (
+          <Text type="secondary">
+            <Icons.Add className="mr-1 inline-block size-3" />
+            Create new group...
+          </Text>
+        ),
+        searchLabel: "create new group",
+      },
+      ...groupOptions,
+    ];
+  }, [availableGroups]);
+
+  const handleSelect = async (groupId: string) => {
+    if (groupId === CREATE_NEW_GROUP_VALUE) {
+      setOpen(false);
+      setIsCreateModalOpen(true);
+      return;
+    }
+
+    setOpen(false);
+    const result = await assignResources({
+      monitor_config_id: monitorId,
+      group_id: groupId,
+      staged_resource_urns: [resourceUrn],
+    });
+    if (isErrorResult(result)) {
+      messageApi.open({
+        type: "error",
+        content: getErrorMessage(result.error, "Failed to assign group."),
+      });
+    }
+  };
+
+  const handleDeselect = async (groupId: string) => {
+    const group = (groups ?? []).find((g) => g.id === groupId);
+    if (group?.assignment_promoted) {
+      messageApi.open({
+        type: "warning",
+        content: "Cannot remove a promoted group assignment.",
+      });
+      return;
+    }
+
+    const result = await unassignResources({
+      monitor_config_id: monitorId,
+      group_id: groupId,
+      staged_resource_urns: [resourceUrn],
+    });
+    if (isErrorResult(result)) {
+      messageApi.open({
+        type: "error",
+        content: getErrorMessage(result.error, "Failed to remove group."),
+      });
+    }
+  };
+
+  const handleCreateSuccess = async (groupId: string) => {
+    await assignResources({
+      monitor_config_id: monitorId,
+      group_id: groupId,
+      staged_resource_urns: [resourceUrn],
+    });
+  };
+
+  const tagRender = (props: {
+    value: string;
+    label: React.ReactNode;
+    closable: boolean;
+    onClose: () => void;
+  }) => {
+    const { value, label } = props;
+    const group = (groups ?? []).find((g) => g.id === value);
+    const isPromoted = group?.assignment_promoted ?? false;
+
+    const onPreventMouseDown = (event: React.MouseEvent<HTMLSpanElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+    };
+
+    return (
+      <Tag
+        color="white"
+        bordered
+        onMouseDown={onPreventMouseDown}
+        closable={!isPromoted}
+        onClose={(e) => {
+          e.preventDefault();
+          handleDeselect(value);
+        }}
+        icon={
+          isPromoted ? <Icons.CheckmarkFilled color="#5a9a68" /> : undefined
+        }
+        style={{
+          marginInlineEnd: "calc((var(--fidesui-padding-xs) * 0.5))",
+        }}
+      >
+        <Text size="sm">{label}</Text>
+      </Tag>
+    );
+  };
+
+  return (
+    <>
+      <Select
+        mode="multiple"
+        showSearch={{ optionFilterProp: "searchLabel" }}
+        value={currentGroupIds}
+        options={options}
+        onSelect={handleSelect}
+        onDeselect={handleDeselect}
+        prefix={
+          <Tooltip title="Assign to group">
+            <Button
+              aria-label="Add Group"
+              type="text"
+              size="small"
+              icon={<Icons.Add />}
+              disabled={disabled}
+            />
+          </Tooltip>
+        }
+        placeholder=""
+        suffixIcon={null}
+        classNames={{
+          root: "w-full max-w-full overflow-hidden p-0 cursor-pointer -ml-5",
+        }}
+        style={
+          {
+            "--fidesui-select-multiple-selector-bg-disabled": "transparent",
+          } as React.CSSProperties
+        }
+        variant="borderless"
+        autoFocus={false}
+        maxTagCount="responsive"
+        open={open}
+        onOpenChange={(visible) => setOpen(visible)}
+        tagRender={tagRender}
+        disabled={disabled}
+        popupMatchSelectWidth={400}
+        aria-label="Assign groups"
+        data-testid="group-select"
+      />
+      <CreateCloudInfraGroupModal
+        isOpen={isCreateModalOpen}
+        onClose={() => setIsCreateModalOpen(false)}
+        monitorId={monitorId}
+        onSuccess={handleCreateSuccess}
+      />
+    </>
+  );
+};

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useActionCenterNavigation.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/hooks/useActionCenterNavigation.tsx
@@ -10,6 +10,7 @@ import {
 export enum ActionCenterRoute {
   ATTENTION_REQUIRED = "attention-required",
   ACTIVITY = "activity",
+  GROUPS = "groups",
 }
 
 export const ACTION_CENTER_CONFIG: Record<
@@ -21,6 +22,12 @@ export const ACTION_CENTER_CONFIG: Record<
     type: "item",
     label: "Attention required",
     icon: <Icons.ListBoxes />,
+  },
+  [ActionCenterRoute.GROUPS]: {
+    key: ActionCenterRoute.GROUPS,
+    type: "item",
+    label: "Groups",
+    icon: <Icons.Grid />,
   },
   [ActionCenterRoute.ACTIVITY]: {
     key: ActionCenterRoute.ACTIVITY,
@@ -36,18 +43,29 @@ export const ACTION_CENTER_TAB_ITEMS: NavConfigTab[] = [
   { title: "Activity", path: ACTION_CENTER_ACTIVITY_ROUTE },
 ];
 
-export type ActionCenterRouteConfig = Record<ActionCenterRoute, string>;
+export type ActionCenterRouteConfig = Partial<
+  Record<ActionCenterRoute, string>
+> &
+  Record<
+    ActionCenterRoute.ATTENTION_REQUIRED | ActionCenterRoute.ACTIVITY,
+    string
+  >;
 
 const useActionCenterNavigation = (routeConfig: ActionCenterRouteConfig) => {
   const { activeItem, setActiveItem } = useMenuNavigation({
-    routes: routeConfig,
+    routes: routeConfig as Record<string, string>,
     defaultKey: ActionCenterRoute.ATTENTION_REQUIRED,
   });
+
+  // Only include menu items for routes present in the config
+  const items = Object.fromEntries(
+    Object.entries(ACTION_CENTER_CONFIG).filter(([key]) => key in routeConfig),
+  );
 
   return {
     activeItem,
     setActiveItem,
-    items: ACTION_CENTER_CONFIG,
+    items,
   };
 };
 

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/CloudInfraGroupsTable.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/CloudInfraGroupsTable.tsx
@@ -1,0 +1,190 @@
+import {
+  Button,
+  Empty,
+  Flex,
+  Icons,
+  List,
+  Pagination,
+  Tag,
+  Text,
+  Tooltip,
+  useMessage,
+  useModal,
+} from "fidesui";
+import { useState } from "react";
+
+import { getErrorMessage, isErrorResult } from "~/features/common/helpers";
+import { useAntPagination } from "~/features/common/pagination/useAntPagination";
+import { CloudInfraGroupResponse } from "~/types/api";
+
+import {
+  useDeleteCloudInfraGroupMutation,
+  useGetCloudInfraGroupsQuery,
+} from "../../discovery-detection.slice";
+import { CreateCloudInfraGroupModal } from "../components/CreateCloudInfraGroupModal";
+
+interface CloudInfraGroupsTableProps {
+  monitorId: string;
+}
+
+export const CloudInfraGroupsTable = ({
+  monitorId,
+}: CloudInfraGroupsTableProps) => {
+  const { paginationProps, pageIndex, pageSize } = useAntPagination({
+    defaultPageSize: 25,
+  });
+  const { data, isLoading } = useGetCloudInfraGroupsQuery(
+    {
+      monitor_config_id: monitorId,
+      page: pageIndex,
+      size: pageSize,
+    },
+    { refetchOnMountOrArgChange: true },
+  );
+  const [deleteGroup] = useDeleteCloudInfraGroupMutation();
+  const messageApi = useMessage();
+  const modalApi = useModal();
+
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const [editingGroup, setEditingGroup] = useState<
+    CloudInfraGroupResponse | undefined
+  >();
+
+  const handleDelete = async (group: CloudInfraGroupResponse) => {
+    const groupLabel = group.name || group.system_name || "this group";
+    const confirmed = await modalApi.confirm({
+      title: "Delete group",
+      content: `Are you sure you want to delete "${groupLabel}"? Resource assignments will be lost.`,
+      okText: "Delete",
+      okButtonProps: { danger: true },
+      icon: null,
+    });
+    if (!confirmed) {
+      return;
+    }
+    const result = await deleteGroup({
+      monitor_config_id: monitorId,
+      group_id: group.id,
+    });
+    if (isErrorResult(result)) {
+      messageApi.open({
+        type: "error",
+        content: getErrorMessage(result.error, "Failed to delete group."),
+      });
+      return;
+    }
+    messageApi.open({ type: "success", content: "Group deleted." });
+  };
+
+  return (
+    <Flex vertical gap="middle" className="h-full overflow-hidden">
+      <Flex justify="space-between" align="center">
+        <Text type="secondary">
+          {data?.total ?? 0} group{data?.total !== 1 ? "s" : ""}
+        </Text>
+        <Button
+          type="primary"
+          icon={<Icons.Add />}
+          onClick={() => setIsCreateModalOpen(true)}
+          data-testid="create-group-btn"
+        >
+          Create group
+        </Button>
+      </Flex>
+      <Flex flex={1} style={{ minHeight: 0, overflow: "hidden" }}>
+        <List
+          dataSource={data?.items}
+          loading={isLoading}
+          className="size-full overflow-y-auto overflow-x-clip"
+          locale={{
+            emptyText: (
+              <Empty
+                image={Empty.PRESENTED_IMAGE_SIMPLE}
+                description="No groups yet"
+              />
+            ),
+          }}
+          renderItem={(group) => (
+            <List.Item
+              key={group.id}
+              actions={[
+                <Text key="counts" type="secondary" className="text-xs">
+                  Total resources: {group.resource_count}
+                  {group.promoted_resource_count > 0 &&
+                    `, Promoted: ${group.promoted_resource_count}`}
+                </Text>,
+                <Button
+                  key="edit"
+                  size="small"
+                  icon={<Icons.Edit />}
+                  aria-label="Edit group"
+                  onClick={() => setEditingGroup(group)}
+                />,
+                <Tooltip
+                  key="delete"
+                  title={
+                    group.promoted_resource_count > 0
+                      ? "Cannot delete: group has promoted resources"
+                      : undefined
+                  }
+                >
+                  <Button
+                    size="small"
+                    icon={<Icons.TrashCan />}
+                    aria-label="Delete group"
+                    disabled={group.promoted_resource_count > 0}
+                    onClick={() => handleDelete(group)}
+                  />
+                </Tooltip>,
+              ]}
+            >
+              <List.Item.Meta
+                title={
+                  <Flex gap="small" align="center">
+                    <Text strong>
+                      {group.name || group.system_name || "Unnamed group"}
+                    </Text>
+                    {group.promoted_resource_count === 0 && (
+                      <Tag color="default">Draft</Tag>
+                    )}
+                  </Flex>
+                }
+                description={
+                  <Flex gap="small">
+                    <Text type="secondary">System:</Text>
+                    {group.system_name ? (
+                      <Text>{group.system_name}</Text>
+                    ) : (
+                      <Text type="secondary" italic>
+                        Not assigned
+                      </Text>
+                    )}
+                  </Flex>
+                }
+              />
+            </List.Item>
+          )}
+        />
+      </Flex>
+      <Pagination
+        {...paginationProps}
+        total={data?.total || 0}
+        showSizeChanger={{ suffixIcon: <Icons.ChevronDown /> }}
+        hideOnSinglePage
+      />
+      <CreateCloudInfraGroupModal
+        isOpen={isCreateModalOpen}
+        onClose={() => setIsCreateModalOpen(false)}
+        monitorId={monitorId}
+      />
+      {editingGroup && (
+        <CreateCloudInfraGroupModal
+          isOpen
+          onClose={() => setEditingGroup(undefined)}
+          monitorId={monitorId}
+          group={editingGroup}
+        />
+      )}
+    </Flex>
+  );
+};

--- a/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/CloudInfraResourcesTable.tsx
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/action-center/tables/CloudInfraResourcesTable.tsx
@@ -103,7 +103,9 @@ export const CloudInfraResourcesTable = ({
               />
             ),
           }}
-          renderItem={(item) => <CloudInfraResourceListItem item={item} />}
+          renderItem={(item) => (
+            <CloudInfraResourceListItem item={item} monitorId={monitorId} />
+          )}
         />
       </Flex>
       <Pagination

--- a/clients/admin-ui/src/features/data-discovery-and-detection/discovery-detection.slice.ts
+++ b/clients/admin-ui/src/features/data-discovery-and-detection/discovery-detection.slice.ts
@@ -4,6 +4,9 @@ import queryString from "query-string";
 import type { RootState } from "~/app/store";
 import { baseApi } from "~/features/common/api.slice";
 import {
+  CloudInfraAssignmentActionResponse,
+  CloudInfraGroupRequest,
+  CloudInfraGroupResponse,
   CloudInfraMonitorResourcesDynamicFilters,
   CloudInfraStagedResource,
   DiffStatus,
@@ -80,6 +83,18 @@ interface CloudInfraMonitorResultsQueryParams {
 
 interface CloudInfraMonitorFiltersQueryParams {
   monitor_config_id: string;
+}
+
+interface CloudInfraGroupsQueryParams {
+  monitor_config_id: string;
+  page?: number;
+  size?: number;
+}
+
+interface CloudInfraGroupAssignmentParams {
+  monitor_config_id: string;
+  group_id: string;
+  staged_resource_urns: string[];
 }
 
 // Identity Provider Monitor interfaces (Okta-specific)
@@ -561,6 +576,84 @@ const discoveryDetectionApi = baseApi.injectEndpoints({
       }),
       providesTags: () => ["Cloud Infra Monitor Filters"],
     }),
+    // Cloud Infra Group endpoints
+    getCloudInfraGroups: build.query<
+      {
+        items: CloudInfraGroupResponse[];
+        total: number;
+        page: number;
+        size: number;
+        pages: number;
+      },
+      CloudInfraGroupsQueryParams
+    >({
+      query: ({ monitor_config_id, ...params }) => ({
+        method: "GET",
+        url: `/plus/discovery-monitor/${monitor_config_id}/cloud-infra-groups?${queryString.stringify(
+          params,
+          { arrayFormat: "none" },
+        )}`,
+      }),
+      providesTags: () => ["Cloud Infra Groups"],
+    }),
+    createCloudInfraGroup: build.mutation<
+      CloudInfraGroupResponse,
+      { monitor_config_id: string; body: CloudInfraGroupRequest }
+    >({
+      query: ({ monitor_config_id, body }) => ({
+        method: "POST",
+        url: `/plus/discovery-monitor/${monitor_config_id}/cloud-infra-groups`,
+        body,
+      }),
+      invalidatesTags: ["Cloud Infra Groups"],
+    }),
+    updateCloudInfraGroup: build.mutation<
+      CloudInfraGroupResponse,
+      {
+        monitor_config_id: string;
+        group_id: string;
+        body: CloudInfraGroupRequest;
+      }
+    >({
+      query: ({ monitor_config_id, group_id, body }) => ({
+        method: "PATCH",
+        url: `/plus/discovery-monitor/${monitor_config_id}/cloud-infra-groups/${group_id}`,
+        body,
+      }),
+      invalidatesTags: ["Cloud Infra Groups"],
+    }),
+    deleteCloudInfraGroup: build.mutation<
+      void,
+      { monitor_config_id: string; group_id: string }
+    >({
+      query: ({ monitor_config_id, group_id }) => ({
+        method: "DELETE",
+        url: `/plus/discovery-monitor/${monitor_config_id}/cloud-infra-groups/${group_id}`,
+      }),
+      invalidatesTags: ["Cloud Infra Groups"],
+    }),
+    assignResourcesToCloudInfraGroup: build.mutation<
+      CloudInfraAssignmentActionResponse,
+      CloudInfraGroupAssignmentParams
+    >({
+      query: ({ monitor_config_id, group_id, staged_resource_urns }) => ({
+        method: "PUT",
+        url: `/plus/discovery-monitor/${monitor_config_id}/cloud-infra-groups/${group_id}/assignments`,
+        body: { staged_resource_urns },
+      }),
+      invalidatesTags: ["Cloud Infra Monitor Results", "Cloud Infra Groups"],
+    }),
+    unassignResourcesFromCloudInfraGroup: build.mutation<
+      CloudInfraAssignmentActionResponse,
+      CloudInfraGroupAssignmentParams
+    >({
+      query: ({ monitor_config_id, group_id, staged_resource_urns }) => ({
+        method: "POST",
+        url: `/plus/discovery-monitor/${monitor_config_id}/cloud-infra-groups/${group_id}/assignments/remove`,
+        body: { staged_resource_urns },
+      }),
+      invalidatesTags: ["Cloud Infra Monitor Results", "Cloud Infra Groups"],
+    }),
   }),
 });
 
@@ -596,6 +689,12 @@ export const {
   useUpdateInfrastructureSystemDescriptionMutation,
   useGetCloudInfraMonitorResultsQuery,
   useGetCloudInfraMonitorFiltersQuery,
+  useGetCloudInfraGroupsQuery,
+  useCreateCloudInfraGroupMutation,
+  useUpdateCloudInfraGroupMutation,
+  useDeleteCloudInfraGroupMutation,
+  useAssignResourcesToCloudInfraGroupMutation,
+  useUnassignResourcesFromCloudInfraGroupMutation,
   util: discoveryDetectionUtil,
 } = discoveryDetectionApi;
 

--- a/clients/admin-ui/src/pages/data-discovery/action-center/cloud_infrastructure/[monitorId]/groups/index.tsx
+++ b/clients/admin-ui/src/pages/data-discovery/action-center/cloud_infrastructure/[monitorId]/groups/index.tsx
@@ -1,0 +1,27 @@
+import { NextPage } from "next";
+import { useParams } from "next/navigation";
+
+import ActionCenterLayout from "~/features/data-discovery-and-detection/action-center/ActionCenterLayout";
+import { CloudInfraGroupsTable } from "~/features/data-discovery-and-detection/action-center/tables/CloudInfraGroupsTable";
+
+import { MONITOR_CLOUD_INFRASTRUCTURE_ACTION_CENTER_CONFIG } from "..";
+
+const CloudInfrastructureMonitorGroups: NextPage = () => {
+  const params = useParams<{ monitorId: string }>();
+
+  const monitorId = params?.monitorId
+    ? decodeURIComponent(params.monitorId)
+    : undefined;
+  const loading = !monitorId;
+
+  return (
+    <ActionCenterLayout
+      monitorId={monitorId}
+      routeConfig={MONITOR_CLOUD_INFRASTRUCTURE_ACTION_CENTER_CONFIG}
+    >
+      {loading ? null : <CloudInfraGroupsTable monitorId={monitorId} />}
+    </ActionCenterLayout>
+  );
+};
+
+export default CloudInfrastructureMonitorGroups;

--- a/clients/admin-ui/src/pages/data-discovery/action-center/cloud_infrastructure/[monitorId]/index.tsx
+++ b/clients/admin-ui/src/pages/data-discovery/action-center/cloud_infrastructure/[monitorId]/index.tsx
@@ -6,6 +6,7 @@ import { useDispatch } from "react-redux";
 
 import {
   ACTION_CENTER_CLOUD_INFRASTRUCTURE_MONITOR_ACTIVITY_ROUTE,
+  ACTION_CENTER_CLOUD_INFRASTRUCTURE_MONITOR_GROUPS_ROUTE,
   ACTION_CENTER_CLOUD_INFRASTRUCTURE_MONITOR_ROUTE,
 } from "~/features/common/nav/routes";
 import ActionCenterLayout from "~/features/data-discovery-and-detection/action-center/ActionCenterLayout";
@@ -19,6 +20,8 @@ export const MONITOR_CLOUD_INFRASTRUCTURE_ACTION_CENTER_CONFIG = {
     ACTION_CENTER_CLOUD_INFRASTRUCTURE_MONITOR_ACTIVITY_ROUTE,
   [ActionCenterRoute.ATTENTION_REQUIRED]:
     ACTION_CENTER_CLOUD_INFRASTRUCTURE_MONITOR_ROUTE,
+  [ActionCenterRoute.GROUPS]:
+    ACTION_CENTER_CLOUD_INFRASTRUCTURE_MONITOR_GROUPS_ROUTE,
 } as const;
 
 const CloudInfrastructureMonitorResults: NextPage = () => {

--- a/clients/admin-ui/src/types/api/index.ts
+++ b/clients/admin-ui/src/types/api/index.ts
@@ -147,6 +147,7 @@ export type * from "./models/ClientResponse";
 export type * from "./models/ClientSecretRotateResponse";
 export type * from "./models/ClientUpdateRequest";
 export type * from "./models/CloudConfig";
+export type * from "./models/CloudInfraGroup";
 export type * from "./models/CloudInfraMonitorResourcesDynamicFilters";
 export type * from "./models/CloudInfraMonitorUpdates";
 export type * from "./models/CloudInfraStagedResource";

--- a/clients/admin-ui/src/types/api/models/CloudInfraGroup.ts
+++ b/clients/admin-ui/src/types/api/models/CloudInfraGroup.ts
@@ -1,0 +1,29 @@
+export type CloudInfraGroupSummary = {
+  id: string;
+  name?: string | null;
+  system_key?: string | null;
+  system_name?: string | null;
+  assignment_promoted: boolean;
+};
+
+export type CloudInfraGroupResponse = {
+  id: string;
+  monitor_config_id: string;
+  name?: string | null;
+  system_key?: string | null;
+  system_name?: string | null;
+  resource_count: number;
+  promoted_resource_count: number;
+  created_at: string;
+  updated_at: string;
+};
+
+export type CloudInfraGroupRequest = {
+  name?: string | null;
+  system_key?: string | null;
+};
+
+export type CloudInfraAssignmentActionResponse = {
+  processed: number;
+  skipped: number;
+};

--- a/clients/admin-ui/src/types/api/models/CloudInfraStagedResource.ts
+++ b/clients/admin-ui/src/types/api/models/CloudInfraStagedResource.ts
@@ -1,3 +1,4 @@
+import { CloudInfraGroupSummary } from "./CloudInfraGroup";
 import { DiffStatus } from "./DiffStatus";
 import { StagedResourceTypeValue } from "./StagedResourceTypeValue";
 
@@ -22,4 +23,5 @@ export type CloudInfraStagedResource = {
   cloud_account_id: string;
   source_id: string;
   tags?: Record<string, string> | null;
+  groups?: CloudInfraGroupSummary[] | null;
 };


### PR DESCRIPTION
Ticket [ENG-3572]

### Description Of Changes

**Prototype / functional spike** — this is a working frontend for cloud infra resource grouping built to validate the UX flow. It does not follow final designs.

Users can create groups, assign/unassign resources to groups inline, and manage groups via a dedicated "Groups" tab in the cloud infrastructure monitor.

Groups represent logical collections of cloud infra resources that map to a System. A group can target a new system (created on promotion) or an existing one. Resources can belong to multiple groups.

### Code Changes

* Added TypeScript types for `CloudInfraGroupResponse`, `CloudInfraGroupSummary`, `CloudInfraGroupRequest`, `CloudInfraAssignmentActionResponse`
* Added `groups` field to `CloudInfraStagedResource` type
* Added RTK Query endpoints: `getCloudInfraGroups`, `createCloudInfraGroup`, `updateCloudInfraGroup`, `deleteCloudInfraGroup`, `assignResourcesToCloudInfraGroup`, `unassignResourcesFromCloudInfraGroup`
* Added `GroupSelect` inline component on each resource list item (follows `ClassificationSelect` pattern) with search, create new group option, and tooltip
* Added `CreateCloudInfraGroupModal` supporting both create and edit modes, with group name input and existing system select
* Added `CloudInfraGroupsTable` with group listing, create/edit/delete actions, resource/promoted counts, and draft indicator
* Added "Groups" tab to cloud infrastructure monitor via `ActionCenterRoute.GROUPS` (only visible for cloud infra monitors)
* Made `ActionCenterRouteConfig` partial so the Groups tab only appears for monitors that define it
* Promoted group tags show a green `CheckmarkFilled` icon; non-promoted tags are closable
* AWS resource tags use `marble` color to distinguish from group assignment tags
* Error messages use `getErrorMessage`/`isErrorResult` pattern consistent with the rest of the action center

### Steps to Confirm

1. Enable the `awsMonitor` feature flag
2. Seed a cloud infra monitor by calling `POST {{host}}/api/v1/plus/seed` with body `{"tasks":{"discovery_monitors":true},"discovery_monitors":{"aws":{}}}`
3. Navigate to a cloud infrastructure monitor in Action Center
2. Verify the "Groups" tab appears between "Attention required" and "Activity"
3. On the resources tab, click the `+` icon on a resource to open the group dropdown
4. Select "Create new group..." — verify the modal opens with name and system fields
5. Create a group with a name — verify it appears in the dropdown and as a tag on the resource
6. Create a group linked to an existing system — verify the tag shows `Name (System)`
7. Remove a group tag from a resource — verify it disappears
8. Navigate to the "Groups" tab — verify groups list with resource counts
9. Edit a group — verify the modal pre-fills with current values
10. Delete a group — verify confirmation modal and removal
11. Verify that MUTED and REMOVAL resources have the group select disabled
12. Verify that other monitor types (datastore, website, IDP) do NOT show the Groups tab

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-3572]: https://ethyca.atlassian.net/browse/ENG-3572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ