### PR TITLE
ENG-3913: Fix scope assignment error reporting all scopes as missing

### DIFF
--- a/changelog/8256-fix-scope-assignment-error-message.yaml
+++ b/changelog/8256-fix-scope-assignment-error-message.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Fixed OAuth scope assignment error reporting all scopes as missing for role-based users
+pr: 8256
+labels: []

--- a/src/fides/api/oauth/utils.py
+++ b/src/fides/api/oauth/utils.py
@@ -909,7 +909,12 @@ def verify_client_can_assign_scopes(
 
     # If they don't have all scopes via direct assignment or roles, check individual scopes
     if not has_scope_via_role:
-        unauthorized_scopes = set(scopes) - set(token_scopes)
+        # Combine direct token scopes with role-derived scopes to find
+        # which specific scope(s) the user is actually missing
+        assigned_roles = token_data.get(JWE_PAYLOAD_ROLES, [])
+        role_scopes = get_scopes_from_roles(assigned_roles)
+        effective_scopes = set(token_scopes) | set(role_scopes)
+        unauthorized_scopes = set(scopes) - effective_scopes
 
         if unauthorized_scopes:
             raise HTTPException(

--- a/tests/fides/lib/test_oauth_util.py
+++ b/tests/fides/lib/test_oauth_util.py
@@ -4,7 +4,9 @@ import json
 from datetime import datetime
 
 import pytest
+from fastapi import HTTPException
 from fastapi.security import SecurityScopes
+from starlette.requests import Request
 
 from fides.api.common_exceptions import AuthorizationError
 from fides.api.cryptography.schemas.jwt import (
@@ -36,6 +38,7 @@ from fides.api.oauth.utils import (
     has_permissions,
     has_scope_subset,
     is_token_expired,
+    verify_client_can_assign_scopes,
     verify_oauth_client,
     verify_oauth_client_async,
 )
@@ -1034,3 +1037,61 @@ class TestAsyncPermissionChecker:
         assert result is True
         assert len(received_db) == 1
         assert received_db[0] == mock_async_session
+
+
+class TestVerifyClientCanAssignScopes:
+    """Tests for verify_client_can_assign_scopes error reporting."""
+
+    def test_role_based_user_reports_only_missing_scopes(self, db, config, owner_user):
+        """When an owner user (role-based, no direct token scopes) tries to
+        assign scopes that include one invalid scope, the error should only
+        list the actually-missing scope — not every scope.
+
+        Regression: the fallback was computing unauthorized_scopes from the
+        empty direct token scopes, making it report ALL requested scopes as
+        missing instead of just the offending one(s).
+        """
+        fake_scope = "fake:nonexistent_scope"
+        valid_scopes = [
+            USER_READ,
+            USER_DELETE,
+            PRIVACY_REQUEST_READ,
+            PRIVACY_REQUEST_REVIEW,
+            DATASET_CREATE_OR_UPDATE,
+        ]
+        requested_scopes = valid_scopes + [fake_scope]
+
+        payload = {
+            JWE_PAYLOAD_ROLES: [OWNER],
+            JWE_PAYLOAD_CLIENT_ID: owner_user.client.id,
+            JWE_ISSUED_AT: datetime.now().isoformat(),
+        }
+        token = generate_jwe(
+            json.dumps(payload),
+            config.security.app_encryption_key,
+        )
+
+        request = Request(
+            scope={
+                "type": "http",
+                "headers": [
+                    (b"authorization", f"Bearer {token}".encode()),
+                ],
+            },
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            verify_client_can_assign_scopes(
+                request=request,
+                requesting_client=owner_user.client,
+                scopes=requested_scopes,
+                db=db,
+            )
+
+        detail = exc_info.value.detail
+        # The error should mention ONLY the fake scope, not the valid ones
+        assert fake_scope in detail
+        for scope in valid_scopes:
+            assert scope not in detail, (
+                f"Valid scope '{scope}' should not be listed as missing"
+            )


### PR DESCRIPTION
Ticket [ENG-3913]

### Description Of Changes

When a role-based user (e.g. owner) tried to assign scopes to an OAuth client, `verify_client_can_assign_scopes` reported **all** requested scopes as missing instead of just the actually-unauthorized one(s).

The root cause: when `has_permissions()` fails, the fallback computes `unauthorized_scopes = set(scopes) - set(token_scopes)`. For role-based users, `token_scopes` (direct scopes from the JWT) is empty — their scopes come from roles, not direct assignment. So the subtraction yields every requested scope as "missing."

The fix computes the user's effective scopes as the union of direct token scopes and role-derived scopes before diffing, so only the truly missing scope(s) appear in the error message.

### Code Changes

* In `verify_client_can_assign_scopes`, compute `effective_scopes` from both direct token scopes and `get_scopes_from_roles(assigned_roles)` before determining unauthorized scopes
* Add `TestVerifyClientCanAssignScopes` regression test verifying only the actually-missing scope appears in the error

### Steps to Confirm

1. Log into the Admin UI as an owner user
2. Go to `/api-clients`, create a new client
3. Select multiple scopes and submit
4. Verify no false "missing scopes" error appears
5. Try assigning a scope the user genuinely doesn't have and confirm only that scope is reported

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required

[ENG-3913]: https://ethyca.atlassian.net/browse/ENG-3913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ