### PR TITLE
ENG-3942: Fix Vendors table source filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.86.0..main)
 
+### Fixed
+
+- Fixed Vendors table source filter (GVL / AC) silently failing due to a column-id mismatch [#8260](https://github.com/ethyca/fides/pull/8260)
+
 ## [2.86.0](https://github.com/ethyca/fides/compare/2.85.1..2.86.0)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,6 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.86.0..main)
 
-### Fixed
-
-- Fixed Vendors table source filter (GVL / AC) silently failing due to a column-id mismatch [#8259](https://github.com/ethyca/fides/pull/8259)
-
 ## [2.86.0](https://github.com/ethyca/fides/compare/2.85.1..2.86.0)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ### Fixed
 
-- Fixed Vendors table source filter (GVL / AC) silently failing due to a column-id mismatch [#8260](https://github.com/ethyca/fides/pull/8260)
+- Fixed Vendors table source filter (GVL / AC) silently failing due to a column-id mismatch [#8259](https://github.com/ethyca/fides/pull/8259)
 
 ## [2.86.0](https://github.com/ethyca/fides/compare/2.85.1..2.86.0)
 

--- a/changelog/8259-fix-vendors-table-filter.yaml
+++ b/changelog/8259-fix-vendors-table-filter.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Fixed source filter on the Vendors table silently doing nothing
+pr: 8259
+labels: []

--- a/clients/admin-ui/src/features/system/add-multiple-systems/AddMultipleSystems.tsx
+++ b/clients/admin-ui/src/features/system/add-multiple-systems/AddMultipleSystems.tsx
@@ -303,7 +303,7 @@ export const AddMultipleSystems = ({ redirectRoute }: Props) => {
 
   const vendorFilter = tableInstance
     .getState()
-    .columnFilters.find((c) => c.id === "vendor_id");
+    .columnFilters.find((c) => c.id === "source");
   const totalFilters =
     vendorFilter && Array.isArray(vendorFilter.value)
       ? vendorFilter.value.length

--- a/clients/admin-ui/src/features/system/add-multiple-systems/MultipleSystemsFilterModal.tsx
+++ b/clients/admin-ui/src/features/system/add-multiple-systems/MultipleSystemsFilterModal.tsx
@@ -74,7 +74,7 @@ const MultipleSystemsFilterModal = <T,>({
       id: string;
       value: string[];
     } = {
-      id: "vendor_id",
+      id: "source",
       value: [],
     };
     if (filters.GVL) {


### PR DESCRIPTION
Ticket [ENG-3942](https://ethyca.atlassian.net/browse/ENG-3942)

### Description Of Changes

On the Choose Vendors page (`/consent/configure/add-vendors`), applying a source filter (GVL / AC) from the Filter modal did nothing. The filter badge would update, but the table rows stayed unfiltered.

Root cause: in [#6348](https://github.com/ethyca/fides/pull/6348) the source column id was renamed from `"vendor_id"` to `"source"` (and a new `"id"` column was introduced for the new ID column). `MultipleSystemsFilterModal` and the count-badge lookup in `AddMultipleSystems` were never updated, so they kept calling `setColumnFilters([{ id: "vendor_id", ... }])`. tanstack-table couldn't match the id to any column and silently dropped the filter.

### Code Changes

* `clients/admin-ui/src/features/system/add-multiple-systems/MultipleSystemsFilterModal.tsx` — set `columnFilters.id` to `"source"`
* `clients/admin-ui/src/features/system/add-multiple-systems/AddMultipleSystems.tsx` — look up the column filter by `"source"` for the badge count

### Steps to Confirm

1. Run a Fides env with TCF enabled (Filter button is TCF-gated).
2. Navigate to `/consent/configure/add-vendors`.
3. Click **Filter**, check **Global Vendor List**, click **Done**.
4. Confirm the table row count drops (~2,392 → ~1,361 on nightly) and every visible Source tag reads `GVL`.
5. Open Filter again, click **Reset Filters**, click **Done**. Confirm the table returns to the full unfiltered set with mixed sources.
6. Repeat with the **Google Additional Consent** checkbox.

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
* UX feedback:
  * [x] No UX review needed
* Followup issues:
  * [x] No followup issues
* Database migrations:
  * [x] No migrations
* Documentation:
  * [x] No documentation updates required

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ENG-3942]: https://ethyca.atlassian.net/browse/ENG-3942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ