### PR TITLE
ENG-3944: Populate Template select when editing taxonomy-backed custom field

### DIFF
--- a/changelog/8261-fix-custom-field-template-populate.yaml
+++ b/changelog/8261-fix-custom-field-template-populate.yaml
@@ -1,0 +1,3 @@
+type: Fixed
+description: Fixed the Custom Fields edit form not populating the Template select when editing a taxonomy-backed custom field.
+pr: 8261

--- a/clients/admin-ui/src/features/custom-fields/CustomFieldForm.tsx
+++ b/clients/admin-ui/src/features/custom-fields/CustomFieldForm.tsx
@@ -185,12 +185,13 @@ const CustomFieldForm = ({
       return undefined;
     }
     const fieldType = getCustomFieldType(field);
-    const template =
+    const isCustomFieldType =
       fieldType === FieldTypes.OPEN_TEXT ||
       fieldType === FieldTypes.SINGLE_SELECT ||
-      fieldType === FieldTypes.MULTIPLE_SELECT
-        ? CUSTOM_TEMPLATE_VALUE
-        : undefined;
+      fieldType === FieldTypes.MULTIPLE_SELECT;
+    const template = isCustomFieldType
+      ? CUSTOM_TEMPLATE_VALUE
+      : field.field_type;
     return {
       ...field,
       value_type: field.field_type,


### PR DESCRIPTION
Ticket [ENG-3944]

### Description Of Changes

When editing an existing custom field whose type is a taxonomy (e.g. `data_category`), the required Template select was rendering empty (`Select…`) instead of pre-populating with the field's current taxonomy template. Saving without re-selecting the template would fail validation.

`parseFieldToFormValues` in `CustomFieldForm.tsx` only assigned `template` when the field type was one of the "custom" types (open text, single select, multi select), leaving it `undefined` for taxonomy-backed fields. The Template select's option values correspond to `value_type` strings, so the form value for `template` should be the field's `field_type` when it isn't a custom type.

### Code Changes

* `clients/admin-ui/src/features/custom-fields/CustomFieldForm.tsx` — when the field isn't a custom type, default `template` to `field.field_type` instead of `undefined` so the Template select pre-populates with the matching taxonomy option.

### Steps to Confirm

1. Go to **Settings → Custom fields** and create a new custom field with Template = "Data categories" (or any taxonomy template), then save.
2. Click the new field to edit it — the Template select should pre-populate with "Data categories" (previously showed empty "Select…").
3. Click Save without changing anything — should succeed (previously failed with "Select a template" validation error).
4. Edit an existing "Custom" type field (open text / single / multi select) — Template still shows "Custom" and Field type/options remain populated. ✅ Regression check.

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required

[ENG-3944]: https://ethyca.atlassian.net/browse/ENG-3944
