### PR TITLE
ENG-3896: Fix System Information form not disabling for viewers and GVL

### DIFF
--- a/changelog/8263-system-info-form-disable.yaml
+++ b/changelog/8263-system-info-form-disable.yaml
@@ -1,0 +1,3 @@
+type: Fixed
+description: Fixed the System Information form so all fields (including custom fields and antd Selects) lock for viewer users and assigned system managers, matching what the backend actually authorizes.
+pr: 8263

--- a/clients/admin-ui/cypress/e2e/systems/plus/viewer-assigned-system.cy.ts
+++ b/clients/admin-ui/cypress/e2e/systems/plus/viewer-assigned-system.cy.ts
@@ -12,70 +12,76 @@ import { RoleRegistryEnum } from "~/types/api";
 
 const ASSIGNED_SYSTEM_KEY = "demo_analytics_system";
 
-describe("Viewer with assigned system on the System Information form", () => {
-  beforeEach(() => {
-    cy.login();
-    stubSystemCrud();
-    stubTaxonomyEntities();
-    stubPlus(true, {
-      core_fides_version: "2.2.0",
-      fidesplus_server: "healthy",
-      fidesplus_version: "2.2.0",
-      dictionary: { enabled: true, service_health: null, service_error: null },
-      fides_cloud: { enabled: true },
-      rbac: { enabled: true },
-      tcf: { enabled: true },
+[true, false].forEach((rbacEnabled) => {
+  describe(`Viewer with assigned system on the System Information form (RBAC ${rbacEnabled ? "enabled" : "disabled"})`, () => {
+    beforeEach(() => {
+      cy.login();
+      stubSystemCrud();
+      stubTaxonomyEntities();
+      stubPlus(true, {
+        core_fides_version: "2.2.0",
+        fidesplus_server: "healthy",
+        fidesplus_version: "2.2.0",
+        dictionary: {
+          enabled: true,
+          service_health: null,
+          service_error: null,
+        },
+        fides_cloud: { enabled: true },
+        rbac: { enabled: rbacEnabled },
+        tcf: { enabled: true },
+      });
+      cy.intercept("GET", "/api/v1/system", {
+        fixture: "systems/systems.json",
+      }).as("getSystems");
+      cy.intercept({ method: "POST", url: "/api/v1/system*" }).as(
+        "postDictSystem",
+      );
+      cy.intercept("/api/v1/config?api_set=false", {});
+      stubDatasetCrud();
+      stubSystemIntegrations();
+      stubSystemVendors();
     });
-    cy.intercept("GET", "/api/v1/system", {
-      fixture: "systems/systems.json",
-    }).as("getSystems");
-    cy.intercept({ method: "POST", url: "/api/v1/system*" }).as(
-      "postDictSystem",
-    );
-    cy.intercept("/api/v1/config?api_set=false", {});
-    stubDatasetCrud();
-    stubSystemIntegrations();
-    stubSystemVendors();
-  });
 
-  it("viewer assigned to this system can edit it", () => {
-    cy.assumeRole(RoleRegistryEnum.VIEWER);
+    it("viewer assigned to this system can edit it", () => {
+      cy.assumeRole(RoleRegistryEnum.VIEWER);
 
-    cy.fixture("login.json").then((body) => {
-      const { id: userId } = body.user_data;
-      cy.fixture("systems/systems.json").then((systems) => {
-        const assignedSystem = systems.find(
-          (s: { fides_key: string }) => s.fides_key === ASSIGNED_SYSTEM_KEY,
-        );
+      cy.fixture("login.json").then((body) => {
+        const { id: userId } = body.user_data;
+        cy.fixture("systems/systems.json").then((systems) => {
+          const assignedSystem = systems.find(
+            (s: { fides_key: string }) => s.fides_key === ASSIGNED_SYSTEM_KEY,
+          );
+          cy.intercept(`/api/v1/user/${userId}/system-manager`, {
+            body: [assignedSystem],
+          }).as("getManagedSystems");
+        });
+      });
+
+      cy.visit(`${SYSTEM_ROUTE}/configure/${ASSIGNED_SYSTEM_KEY}`);
+      cy.wait("@getManagedSystems");
+
+      cy.getByTestId("input-name").should("exist");
+      cy.contains("Read-only access").should("not.exist");
+      cy.get("fieldset[disabled]").should("not.exist");
+    });
+
+    it("viewer NOT assigned to this system sees read-only form", () => {
+      cy.assumeRole(RoleRegistryEnum.VIEWER);
+
+      cy.fixture("login.json").then((body) => {
+        const { id: userId } = body.user_data;
         cy.intercept(`/api/v1/user/${userId}/system-manager`, {
-          body: [assignedSystem],
+          body: [],
         }).as("getManagedSystems");
       });
+
+      cy.visit(`${SYSTEM_ROUTE}/configure/${ASSIGNED_SYSTEM_KEY}`);
+      cy.wait("@getManagedSystems");
+
+      cy.getByTestId("input-name").should("exist");
+      cy.contains("Read-only access").should("exist");
+      cy.get("fieldset[disabled]").should("exist");
     });
-
-    cy.visit(`${SYSTEM_ROUTE}/configure/${ASSIGNED_SYSTEM_KEY}`);
-    cy.wait("@getManagedSystems");
-
-    cy.getByTestId("input-name").should("exist");
-    cy.contains("Read-only access").should("not.exist");
-    cy.get("fieldset[disabled]").should("not.exist");
-  });
-
-  it("viewer NOT assigned to this system sees read-only form", () => {
-    cy.assumeRole(RoleRegistryEnum.VIEWER);
-
-    cy.fixture("login.json").then((body) => {
-      const { id: userId } = body.user_data;
-      cy.intercept(`/api/v1/user/${userId}/system-manager`, {
-        body: [],
-      }).as("getManagedSystems");
-    });
-
-    cy.visit(`${SYSTEM_ROUTE}/configure/${ASSIGNED_SYSTEM_KEY}`);
-    cy.wait("@getManagedSystems");
-
-    cy.getByTestId("input-name").should("exist");
-    cy.contains("Read-only access").should("exist");
-    cy.get("fieldset[disabled]").should("exist");
   });
 });

--- a/clients/admin-ui/cypress/e2e/systems/plus/viewer-assigned-system.cy.ts
+++ b/clients/admin-ui/cypress/e2e/systems/plus/viewer-assigned-system.cy.ts
@@ -1,11 +1,3 @@
-/**
- * Regression test for ENG-3137: Viewer user can't edit a system assigned to them
- *
- * A viewer user with an assigned system should be able to edit that system.
- * The RBAC commit (8e9788e) introduced a read-only check that only looks at
- * the global SYSTEM_UPDATE scope, ignoring SYSTEM_MANAGER_UPDATE which
- * allows per-system editing for assigned systems.
- */
 import {
   stubDatasetCrud,
   stubPlus,
@@ -16,9 +8,11 @@ import {
 } from "cypress/support/stubs";
 
 import { SYSTEM_ROUTE } from "~/features/common/nav/routes";
-import { RoleRegistryEnum, ScopeRegistryEnum } from "~/types/api";
+import { RoleRegistryEnum } from "~/types/api";
 
-describe("ENG-3137: Viewer with assigned system should be able to edit", () => {
+const ASSIGNED_SYSTEM_KEY = "demo_analytics_system";
+
+describe("Viewer with assigned system on the System Information form", () => {
   beforeEach(() => {
     cy.login();
     stubSystemCrud();
@@ -44,50 +38,43 @@ describe("ENG-3137: Viewer with assigned system should be able to edit", () => {
     stubSystemVendors();
   });
 
-  it("viewer with system_manager:update can edit assigned system", () => {
-    // Simulate a viewer who also has system_manager:update for their assigned system
+  it("viewer assigned to this system can edit it", () => {
+    cy.assumeRole(RoleRegistryEnum.VIEWER);
+
     cy.fixture("login.json").then((body) => {
       const { id: userId } = body.user_data;
-      cy.intercept(`/api/v1/user/${userId}/permission`, {
-        body: {
-          id: userId,
-          user_id: userId,
-          roles: [RoleRegistryEnum.VIEWER],
-          total_scopes: [
-            // Standard viewer scopes
-            ScopeRegistryEnum.SYSTEM_READ,
-            ScopeRegistryEnum.SYSTEM_MANAGER_READ,
-            ScopeRegistryEnum.SYSTEM_MANAGER_UPDATE,
-            // Other viewer scopes
-            ScopeRegistryEnum.USER_READ,
-            ScopeRegistryEnum.ORGANIZATION_READ,
-          ],
-        },
-      }).as("getUserPermission");
+      cy.fixture("systems/systems.json").then((systems) => {
+        const assignedSystem = systems.find(
+          (s: { fides_key: string }) => s.fides_key === ASSIGNED_SYSTEM_KEY,
+        );
+        cy.intercept(`/api/v1/user/${userId}/system-manager`, {
+          body: [assignedSystem],
+        }).as("getManagedSystems");
+      });
     });
 
-    cy.visit(`${SYSTEM_ROUTE}/configure/demo_analytics_system`);
-    cy.wait("@getUserPermission");
+    cy.visit(`${SYSTEM_ROUTE}/configure/${ASSIGNED_SYSTEM_KEY}`);
+    cy.wait("@getManagedSystems");
 
-    // The form should NOT be read-only for a viewer with system_manager:update
     cy.getByTestId("input-name").should("exist");
-
-    // Regression guard (ENG-3137): read-only alert should NOT appear
     cy.contains("Read-only access").should("not.exist");
-
-    // Regression guard (ENG-3137): form fields should be editable, not disabled
     cy.get("fieldset[disabled]").should("not.exist");
   });
 
-  it("viewer WITHOUT system_manager:update sees read-only form", () => {
-    // Standard viewer without system_manager:update
+  it("viewer NOT assigned to this system sees read-only form", () => {
     cy.assumeRole(RoleRegistryEnum.VIEWER);
 
-    cy.visit(`${SYSTEM_ROUTE}/configure/demo_analytics_system`);
+    cy.fixture("login.json").then((body) => {
+      const { id: userId } = body.user_data;
+      cy.intercept(`/api/v1/user/${userId}/system-manager`, {
+        body: [],
+      }).as("getManagedSystems");
+    });
+
+    cy.visit(`${SYSTEM_ROUTE}/configure/${ASSIGNED_SYSTEM_KEY}`);
+    cy.wait("@getManagedSystems");
 
     cy.getByTestId("input-name").should("exist");
-
-    // This viewer SHOULD see read-only since they have no update permissions
     cy.contains("Read-only access").should("exist");
     cy.get("fieldset[disabled]").should("exist");
   });

--- a/clients/admin-ui/src/features/common/custom-fields/CustomFieldsList.tsx
+++ b/clients/admin-ui/src/features/common/custom-fields/CustomFieldsList.tsx
@@ -11,11 +11,13 @@ import { useCustomFields } from "./hooks";
 type CustomFieldsListProps = {
   resourceFidesKey?: string;
   resourceType: LegacyResourceTypes;
+  disabled?: boolean;
 };
 
 export const CustomFieldsList = ({
   resourceFidesKey,
   resourceType,
+  disabled,
 }: CustomFieldsListProps) => {
   const {
     idToAllowListWithOptions,
@@ -59,6 +61,7 @@ export const CustomFieldsList = ({
               >
                 <Input
                   aria-label={definition.name}
+                  disabled={disabled}
                   data-testid={`input-${testNameSegment}`}
                 />
               </Form.Item>
@@ -87,6 +90,7 @@ export const CustomFieldsList = ({
                 mode={isMulti ? "multiple" : undefined}
                 options={allowList.options}
                 className="w-full"
+                disabled={disabled}
                 data-testid={`controlled-select-${testNameSegment}`}
               />
             </Form.Item>

--- a/clients/admin-ui/src/features/system/SystemInformationForm.tsx
+++ b/clients/admin-ui/src/features/system/SystemInformationForm.tsx
@@ -3,6 +3,7 @@ import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 import {
   Alert,
   Button,
+  ConfigProvider,
   Flex,
   Form,
   FormRule,
@@ -477,7 +478,7 @@ const SystemInformationForm = ({
           className="mb-4"
         />
       )}
-      <fieldset disabled={isReadOnly} className="border-0 p-0">
+      <ConfigProvider componentDisabled={isReadOnly}>
         <Flex vertical className="w-full lg:max-w-[70%]">
           <Text>
             Adding appropriate detail and context to each system helps everyone
@@ -540,6 +541,7 @@ const SystemInformationForm = ({
                     ? initialValues.tags.map((s) => ({ value: s, label: s }))
                     : []
                 }
+                disabled={lockedForGVL}
                 data-testid="controlled-select-tags"
               />
             </Form.Item>
@@ -553,6 +555,7 @@ const SystemInformationForm = ({
                   mode="multiple"
                   aria-label="System groups"
                   options={systemGroupOptions}
+                  disabled={lockedForGVL}
                   data-testid="controlled-select-system_groups"
                 />
               </Form.Item>
@@ -570,6 +573,7 @@ const SystemInformationForm = ({
                 aria-label="Dataset references"
                 options={datasetSelectOptions}
                 optionRender={DatasetSelectOption}
+                disabled={lockedForGVL}
                 data-testid="controlled-select-dataset_references"
               />
             </Form.Item>
@@ -850,7 +854,7 @@ const SystemInformationForm = ({
             </>
           )}
         </Flex>
-      </fieldset>
+      </ConfigProvider>
       {!isReadOnly && (
         <div className="mt-6">
           <Form.Item shouldUpdate noStyle>

--- a/clients/admin-ui/src/features/system/SystemInformationForm.tsx
+++ b/clients/admin-ui/src/features/system/SystemInformationForm.tsx
@@ -865,6 +865,7 @@ const SystemInformationForm = ({
                 <CustomFieldsList
                   resourceType={LegacyResourceTypes.SYSTEM}
                   resourceFidesKey={fidesKey}
+                  disabled={isReadOnly}
                 />
               ) : null}
             </>

--- a/clients/admin-ui/src/features/system/SystemInformationForm.tsx
+++ b/clients/admin-ui/src/features/system/SystemInformationForm.tsx
@@ -95,13 +95,13 @@ const SystemInformationForm = ({
   const [form] = Form.useForm<FormValues>();
   const { data: systems = [] } = useGetAllSystemsQuery();
   const features = useFeatures();
-  const { plus: systemGroupsEnabled, rbac: isRbacEnabled } = features;
+  const { plus: systemGroupsEnabled } = features;
 
   const canUpdateSystems = useHasPermission([
     ScopeRegistryEnum.SYSTEM_UPDATE,
     ScopeRegistryEnum.SYSTEM_MANAGER_UPDATE,
   ]);
-  const isReadOnly = isRbacEnabled && passedInSystem && !canUpdateSystems;
+  const isReadOnly = !!passedInSystem && !canUpdateSystems;
 
   const dispatch = useAppDispatch();
 

--- a/clients/admin-ui/src/features/system/SystemInformationForm.tsx
+++ b/clients/admin-ui/src/features/system/SystemInformationForm.tsx
@@ -199,7 +199,6 @@ const SystemInformationForm = ({
 
   const dictionaryOptions = useAppSelector(selectAllDictEntries);
   const lockedForGVL = useAppSelector(selectLockedForGVL);
-  const formDisabled = isReadOnly || lockedForGVL;
 
   const isEditing = useMemo(
     () =>
@@ -492,7 +491,7 @@ const SystemInformationForm = ({
                 options={dictionaryOptions}
                 onVendorSelected={handleVendorSelected}
                 isCreate={!passedInSystem}
-                lockedForGVL={formDisabled}
+                lockedForGVL={isReadOnly || lockedForGVL}
                 nameRules={[
                   { required: true, message: "System name is required" },
                   nameUniquenessRule,
@@ -511,7 +510,7 @@ const SystemInformationForm = ({
               >
                 <Input
                   id="name"
-                  disabled={formDisabled}
+                  disabled={isReadOnly}
                   data-testid="input-name"
                 />
               </Form.Item>
@@ -530,7 +529,7 @@ const SystemInformationForm = ({
               name="description"
               label="Description"
               tooltip="What services does this system perform?"
-              disabled={formDisabled}
+              disabled={isReadOnly}
             />
             <Form.Item
               name="tags"
@@ -546,7 +545,7 @@ const SystemInformationForm = ({
                     ? initialValues.tags.map((s) => ({ value: s, label: s }))
                     : []
                 }
-                disabled={formDisabled}
+                disabled={isReadOnly}
                 data-testid="controlled-select-tags"
               />
             </Form.Item>
@@ -560,7 +559,7 @@ const SystemInformationForm = ({
                   mode="multiple"
                   aria-label="System groups"
                   options={systemGroupOptions}
-                  disabled={formDisabled}
+                  disabled={isReadOnly}
                   data-testid="controlled-select-system_groups"
                 />
               </Form.Item>
@@ -578,7 +577,7 @@ const SystemInformationForm = ({
                 aria-label="Dataset references"
                 options={datasetSelectOptions}
                 optionRender={DatasetSelectOption}
-                disabled={formDisabled}
+                disabled={isReadOnly}
                 data-testid="controlled-select-dataset_references"
               />
             </Form.Item>
@@ -591,7 +590,7 @@ const SystemInformationForm = ({
                   name="processes_personal_data"
                   label="This system processes personal data"
                   tooltip="Does this system process personal data?"
-                  disabled={formDisabled}
+                  disabled={isReadOnly || lockedForGVL}
                 />
               </div>
               <div className="rounded bg-gray-50 p-4">
@@ -600,7 +599,9 @@ const SystemInformationForm = ({
                     name="exempt_from_privacy_regulations"
                     label="This system is exempt from privacy regulations"
                     tooltip="Is this system exempt from privacy regulations?"
-                    disabled={!processesPersonalData || formDisabled}
+                    disabled={
+                      isReadOnly || !processesPersonalData || lockedForGVL
+                    }
                   />
                   {exemptFromPrivacyRegulations && (
                     <div className="mt-4">
@@ -611,7 +612,7 @@ const SystemInformationForm = ({
                         required={exemptFromPrivacyRegulations}
                       >
                         <Input
-                          disabled={formDisabled}
+                          disabled={isReadOnly || lockedForGVL}
                           data-testid="input-reason_for_exemption"
                         />
                       </Form.Item>
@@ -626,7 +627,7 @@ const SystemInformationForm = ({
                       name="uses_profiling"
                       label="This system performs profiling"
                       tooltip="Does this system perform profiling that could have a legal effect?"
-                      disabled={formDisabled}
+                      disabled={isReadOnly || lockedForGVL}
                     />
                     {usesProfiling && (
                       <div className="mt-4">
@@ -640,7 +641,7 @@ const SystemInformationForm = ({
                             mode="multiple"
                             aria-label="Legal basis for profiling"
                             options={legalBasisForProfilingOptions}
-                            disabled={formDisabled}
+                            disabled={isReadOnly || lockedForGVL}
                             data-testid="controlled-select-legal_basis_for_profiling"
                           />
                         </Form.Item>
@@ -652,7 +653,7 @@ const SystemInformationForm = ({
                       name="does_international_transfers"
                       label="This system transfers data"
                       tooltip="Does this system transfer data to other countries or international organizations?"
-                      disabled={formDisabled}
+                      disabled={isReadOnly || lockedForGVL}
                     />
                     {doesInternationalTransfers && (
                       <div className="mt-4">
@@ -666,7 +667,7 @@ const SystemInformationForm = ({
                             mode="multiple"
                             aria-label="Legal basis for transfer"
                             options={legalBasisForTransferOptions}
-                            disabled={formDisabled}
+                            disabled={isReadOnly || lockedForGVL}
                             data-testid="controlled-select-legal_basis_for_transfers"
                           />
                         </Form.Item>
@@ -685,7 +686,7 @@ const SystemInformationForm = ({
                     >
                       <Switch
                         size="small"
-                        disabled={formDisabled}
+                        disabled={isReadOnly || lockedForGVL}
                         data-testid="input-requires_data_protection_assessments"
                       />
                     </Form.Item>
@@ -698,7 +699,7 @@ const SystemInformationForm = ({
                           required={requiresDpas}
                         >
                           <Input
-                            disabled={formDisabled}
+                            disabled={isReadOnly || lockedForGVL}
                             data-testid="input-dpa_location"
                           />
                         </Form.Item>
@@ -717,25 +718,25 @@ const SystemInformationForm = ({
                   name="uses_cookies"
                   label="This system uses cookies"
                   tooltip="Does this system use cookies?"
-                  disabled={formDisabled}
+                  disabled={isReadOnly || lockedForGVL}
                 />
                 <DictSuggestionSwitch
                   name="cookie_refresh"
                   label="This system refreshes cookies"
                   tooltip="Does this system automatically refresh cookies?"
-                  disabled={formDisabled}
+                  disabled={isReadOnly || lockedForGVL}
                 />
                 <DictSuggestionSwitch
                   name="uses_non_cookie_access"
                   label="This system uses non-cookie trackers"
                   tooltip="Does this system use other types of trackers?"
-                  disabled={formDisabled}
+                  disabled={isReadOnly || lockedForGVL}
                 />
                 <DictSuggestionNumberInput
                   name="cookie_max_age_seconds"
                   label="Maximum duration (seconds)"
                   tooltip="What is the maximum amount of time a cookie will live?"
-                  disabled={formDisabled}
+                  disabled={isReadOnly || lockedForGVL}
                 />
               </SystemFormInputGroup>
 
@@ -756,7 +757,7 @@ const SystemInformationForm = ({
                         .includes(input.toLowerCase())
                     }
                     placeholder="Select data stewards"
-                    disabled={formDisabled}
+                    disabled={isReadOnly}
                     data-testid="controlled-select-data_stewards"
                   />
                 </Form.Item>
@@ -765,7 +766,7 @@ const SystemInformationForm = ({
                   name="privacy_policy"
                   label="Privacy policy URL"
                   tooltip="Where can the privacy policy be located?"
-                  disabled={formDisabled}
+                  disabled={isReadOnly || lockedForGVL}
                   rules={[
                     {
                       type: "url",
@@ -778,14 +779,14 @@ const SystemInformationForm = ({
                   name="legal_name"
                   label="Legal name"
                   tooltip="What is the legal name of the business?"
-                  disabled={formDisabled}
+                  disabled={isReadOnly}
                 />
                 <DictSuggestionTextArea
                   id="legal_address"
                   name="legal_address"
                   label="Legal address"
                   tooltip="What is the legal address for the business?"
-                  disabled={formDisabled}
+                  disabled={isReadOnly}
                 />
                 <Form.Item
                   name="administrating_department"
@@ -794,9 +795,9 @@ const SystemInformationForm = ({
                 >
                   <Input
                     disabled={
+                      isReadOnly ||
                       !processesPersonalData ||
-                      exemptFromPrivacyRegulations ||
-                      formDisabled
+                      exemptFromPrivacyRegulations
                     }
                     data-testid="input-administrating_department"
                   />
@@ -811,9 +812,9 @@ const SystemInformationForm = ({
                     aria-label="Responsibility"
                     options={responsibilityOptions}
                     disabled={
+                      isReadOnly ||
                       !processesPersonalData ||
-                      exemptFromPrivacyRegulations ||
-                      formDisabled
+                      exemptFromPrivacyRegulations
                     }
                     data-testid="controlled-select-responsibility"
                   />
@@ -823,7 +824,7 @@ const SystemInformationForm = ({
                   id="dpo"
                   label="Legal contact (DPO)"
                   tooltip="What is the official privacy contact information?"
-                  disabled={formDisabled}
+                  disabled={isReadOnly || lockedForGVL}
                 />
                 <Form.Item
                   name="joint_controller_info"
@@ -832,9 +833,9 @@ const SystemInformationForm = ({
                 >
                   <Input
                     disabled={
+                      isReadOnly ||
                       !processesPersonalData ||
-                      exemptFromPrivacyRegulations ||
-                      formDisabled
+                      exemptFromPrivacyRegulations
                     }
                     data-testid="input-joint_controller_info"
                   />
@@ -844,13 +845,13 @@ const SystemInformationForm = ({
                   name="data_security_practices"
                   id="data_security_practices"
                   tooltip="Which data security practices are employed to keep the data safe?"
-                  disabled={formDisabled}
+                  disabled={isReadOnly}
                 />
                 <DictSuggestionTextInput
                   label="Legitimate interest disclosure URL"
                   name="legitimate_interest_disclosure_url"
                   id="legitimate_interest_disclosure_url"
-                  disabled={formDisabled}
+                  disabled={isReadOnly || lockedForGVL}
                 />
                 <DictSuggestionTextInput
                   label="Vendor deleted date"

--- a/clients/admin-ui/src/features/system/SystemInformationForm.tsx
+++ b/clients/admin-ui/src/features/system/SystemInformationForm.tsx
@@ -16,6 +16,7 @@ import { isEqual } from "lodash";
 import { useEffect, useMemo } from "react";
 
 import { useAppDispatch, useAppSelector } from "~/app/hooks";
+import { selectUser } from "~/features/auth";
 import {
   CustomFieldsList,
   useCustomFields,
@@ -75,6 +76,7 @@ import {
 import VendorSelector from "~/features/system/VendorSelector";
 import {
   useGetAllUsersQuery,
+  useGetUserManagedSystemsQuery,
   useRemoveUserManagedSystemMutation,
 } from "~/features/user-management";
 import { ScopeRegistryEnum, SystemResponse } from "~/types/api";
@@ -97,10 +99,21 @@ const SystemInformationForm = ({
   const features = useFeatures();
   const { plus: systemGroupsEnabled } = features;
 
-  const canUpdateSystems = useHasPermission([
+  const currentUser = useAppSelector(selectUser);
+  const hasSystemUpdateScope = useHasPermission([
     ScopeRegistryEnum.SYSTEM_UPDATE,
-    ScopeRegistryEnum.SYSTEM_MANAGER_UPDATE,
   ]);
+  const { data: currentUserManagedSystems } = useGetUserManagedSystemsQuery(
+    currentUser?.id ?? "",
+    { skip: !currentUser?.id || hasSystemUpdateScope || !passedInSystem },
+  );
+  const isAssignedSystemManager = !!(
+    passedInSystem &&
+    currentUserManagedSystems?.some(
+      (s) => s.fides_key === passedInSystem.fides_key,
+    )
+  );
+  const canUpdateSystems = hasSystemUpdateScope || isAssignedSystemManager;
   const isReadOnly = !!passedInSystem && !canUpdateSystems;
 
   const dispatch = useAppDispatch();

--- a/clients/admin-ui/src/features/system/SystemInformationForm.tsx
+++ b/clients/admin-ui/src/features/system/SystemInformationForm.tsx
@@ -3,7 +3,6 @@ import { FetchBaseQueryError } from "@reduxjs/toolkit/query";
 import {
   Alert,
   Button,
-  ConfigProvider,
   Flex,
   Form,
   FormRule,
@@ -200,6 +199,7 @@ const SystemInformationForm = ({
 
   const dictionaryOptions = useAppSelector(selectAllDictEntries);
   const lockedForGVL = useAppSelector(selectLockedForGVL);
+  const formDisabled = isReadOnly || lockedForGVL;
 
   const isEditing = useMemo(
     () =>
@@ -478,7 +478,7 @@ const SystemInformationForm = ({
           className="mb-4"
         />
       )}
-      <ConfigProvider componentDisabled={isReadOnly}>
+      <fieldset disabled={isReadOnly} className="border-0 p-0">
         <Flex vertical className="w-full lg:max-w-[70%]">
           <Text>
             Adding appropriate detail and context to each system helps everyone
@@ -492,7 +492,7 @@ const SystemInformationForm = ({
                 options={dictionaryOptions}
                 onVendorSelected={handleVendorSelected}
                 isCreate={!passedInSystem}
-                lockedForGVL={lockedForGVL}
+                lockedForGVL={formDisabled}
                 nameRules={[
                   { required: true, message: "System name is required" },
                   nameUniquenessRule,
@@ -509,7 +509,11 @@ const SystemInformationForm = ({
                   nameUniquenessRule,
                 ]}
               >
-                <Input id="name" data-testid="input-name" />
+                <Input
+                  id="name"
+                  disabled={formDisabled}
+                  data-testid="input-name"
+                />
               </Form.Item>
             )}
             {passedInSystem?.fides_key && (
@@ -526,6 +530,7 @@ const SystemInformationForm = ({
               name="description"
               label="Description"
               tooltip="What services does this system perform?"
+              disabled={formDisabled}
             />
             <Form.Item
               name="tags"
@@ -541,7 +546,7 @@ const SystemInformationForm = ({
                     ? initialValues.tags.map((s) => ({ value: s, label: s }))
                     : []
                 }
-                disabled={lockedForGVL}
+                disabled={formDisabled}
                 data-testid="controlled-select-tags"
               />
             </Form.Item>
@@ -555,7 +560,7 @@ const SystemInformationForm = ({
                   mode="multiple"
                   aria-label="System groups"
                   options={systemGroupOptions}
-                  disabled={lockedForGVL}
+                  disabled={formDisabled}
                   data-testid="controlled-select-system_groups"
                 />
               </Form.Item>
@@ -573,7 +578,7 @@ const SystemInformationForm = ({
                 aria-label="Dataset references"
                 options={datasetSelectOptions}
                 optionRender={DatasetSelectOption}
-                disabled={lockedForGVL}
+                disabled={formDisabled}
                 data-testid="controlled-select-dataset_references"
               />
             </Form.Item>
@@ -586,7 +591,7 @@ const SystemInformationForm = ({
                   name="processes_personal_data"
                   label="This system processes personal data"
                   tooltip="Does this system process personal data?"
-                  disabled={lockedForGVL}
+                  disabled={formDisabled}
                 />
               </div>
               <div className="rounded bg-gray-50 p-4">
@@ -595,7 +600,7 @@ const SystemInformationForm = ({
                     name="exempt_from_privacy_regulations"
                     label="This system is exempt from privacy regulations"
                     tooltip="Is this system exempt from privacy regulations?"
-                    disabled={!processesPersonalData || lockedForGVL}
+                    disabled={!processesPersonalData || formDisabled}
                   />
                   {exemptFromPrivacyRegulations && (
                     <div className="mt-4">
@@ -606,7 +611,7 @@ const SystemInformationForm = ({
                         required={exemptFromPrivacyRegulations}
                       >
                         <Input
-                          disabled={lockedForGVL}
+                          disabled={formDisabled}
                           data-testid="input-reason_for_exemption"
                         />
                       </Form.Item>
@@ -621,7 +626,7 @@ const SystemInformationForm = ({
                       name="uses_profiling"
                       label="This system performs profiling"
                       tooltip="Does this system perform profiling that could have a legal effect?"
-                      disabled={lockedForGVL}
+                      disabled={formDisabled}
                     />
                     {usesProfiling && (
                       <div className="mt-4">
@@ -635,7 +640,7 @@ const SystemInformationForm = ({
                             mode="multiple"
                             aria-label="Legal basis for profiling"
                             options={legalBasisForProfilingOptions}
-                            disabled={lockedForGVL}
+                            disabled={formDisabled}
                             data-testid="controlled-select-legal_basis_for_profiling"
                           />
                         </Form.Item>
@@ -647,7 +652,7 @@ const SystemInformationForm = ({
                       name="does_international_transfers"
                       label="This system transfers data"
                       tooltip="Does this system transfer data to other countries or international organizations?"
-                      disabled={lockedForGVL}
+                      disabled={formDisabled}
                     />
                     {doesInternationalTransfers && (
                       <div className="mt-4">
@@ -661,7 +666,7 @@ const SystemInformationForm = ({
                             mode="multiple"
                             aria-label="Legal basis for transfer"
                             options={legalBasisForTransferOptions}
-                            disabled={lockedForGVL}
+                            disabled={formDisabled}
                             data-testid="controlled-select-legal_basis_for_transfers"
                           />
                         </Form.Item>
@@ -680,7 +685,7 @@ const SystemInformationForm = ({
                     >
                       <Switch
                         size="small"
-                        disabled={lockedForGVL}
+                        disabled={formDisabled}
                         data-testid="input-requires_data_protection_assessments"
                       />
                     </Form.Item>
@@ -693,7 +698,7 @@ const SystemInformationForm = ({
                           required={requiresDpas}
                         >
                           <Input
-                            disabled={lockedForGVL}
+                            disabled={formDisabled}
                             data-testid="input-dpa_location"
                           />
                         </Form.Item>
@@ -712,25 +717,25 @@ const SystemInformationForm = ({
                   name="uses_cookies"
                   label="This system uses cookies"
                   tooltip="Does this system use cookies?"
-                  disabled={lockedForGVL}
+                  disabled={formDisabled}
                 />
                 <DictSuggestionSwitch
                   name="cookie_refresh"
                   label="This system refreshes cookies"
                   tooltip="Does this system automatically refresh cookies?"
-                  disabled={lockedForGVL}
+                  disabled={formDisabled}
                 />
                 <DictSuggestionSwitch
                   name="uses_non_cookie_access"
                   label="This system uses non-cookie trackers"
                   tooltip="Does this system use other types of trackers?"
-                  disabled={lockedForGVL}
+                  disabled={formDisabled}
                 />
                 <DictSuggestionNumberInput
                   name="cookie_max_age_seconds"
                   label="Maximum duration (seconds)"
                   tooltip="What is the maximum amount of time a cookie will live?"
-                  disabled={lockedForGVL}
+                  disabled={formDisabled}
                 />
               </SystemFormInputGroup>
 
@@ -751,6 +756,7 @@ const SystemInformationForm = ({
                         .includes(input.toLowerCase())
                     }
                     placeholder="Select data stewards"
+                    disabled={formDisabled}
                     data-testid="controlled-select-data_stewards"
                   />
                 </Form.Item>
@@ -759,7 +765,7 @@ const SystemInformationForm = ({
                   name="privacy_policy"
                   label="Privacy policy URL"
                   tooltip="Where can the privacy policy be located?"
-                  disabled={lockedForGVL}
+                  disabled={formDisabled}
                   rules={[
                     {
                       type: "url",
@@ -772,12 +778,14 @@ const SystemInformationForm = ({
                   name="legal_name"
                   label="Legal name"
                   tooltip="What is the legal name of the business?"
+                  disabled={formDisabled}
                 />
                 <DictSuggestionTextArea
                   id="legal_address"
                   name="legal_address"
                   label="Legal address"
                   tooltip="What is the legal address for the business?"
+                  disabled={formDisabled}
                 />
                 <Form.Item
                   name="administrating_department"
@@ -786,7 +794,9 @@ const SystemInformationForm = ({
                 >
                   <Input
                     disabled={
-                      !processesPersonalData || exemptFromPrivacyRegulations
+                      !processesPersonalData ||
+                      exemptFromPrivacyRegulations ||
+                      formDisabled
                     }
                     data-testid="input-administrating_department"
                   />
@@ -801,7 +811,9 @@ const SystemInformationForm = ({
                     aria-label="Responsibility"
                     options={responsibilityOptions}
                     disabled={
-                      !processesPersonalData || exemptFromPrivacyRegulations
+                      !processesPersonalData ||
+                      exemptFromPrivacyRegulations ||
+                      formDisabled
                     }
                     data-testid="controlled-select-responsibility"
                   />
@@ -811,7 +823,7 @@ const SystemInformationForm = ({
                   id="dpo"
                   label="Legal contact (DPO)"
                   tooltip="What is the official privacy contact information?"
-                  disabled={lockedForGVL}
+                  disabled={formDisabled}
                 />
                 <Form.Item
                   name="joint_controller_info"
@@ -820,7 +832,9 @@ const SystemInformationForm = ({
                 >
                   <Input
                     disabled={
-                      !processesPersonalData || exemptFromPrivacyRegulations
+                      !processesPersonalData ||
+                      exemptFromPrivacyRegulations ||
+                      formDisabled
                     }
                     data-testid="input-joint_controller_info"
                   />
@@ -830,12 +844,13 @@ const SystemInformationForm = ({
                   name="data_security_practices"
                   id="data_security_practices"
                   tooltip="Which data security practices are employed to keep the data safe?"
+                  disabled={formDisabled}
                 />
                 <DictSuggestionTextInput
                   label="Legitimate interest disclosure URL"
                   name="legitimate_interest_disclosure_url"
                   id="legitimate_interest_disclosure_url"
-                  disabled={lockedForGVL}
+                  disabled={formDisabled}
                 />
                 <DictSuggestionTextInput
                   label="Vendor deleted date"
@@ -854,7 +869,7 @@ const SystemInformationForm = ({
             </>
           )}
         </Flex>
-      </ConfigProvider>
+      </fieldset>
       {!isReadOnly && (
         <div className="mt-6">
           <Form.Item shouldUpdate noStyle>


### PR DESCRIPTION
Ticket [ENG-3896]

### Description Of Changes

The System Information form was supposed to lock down when the user couldn't actually save (viewer-only RBAC, or a GVL-managed vendor selected), but several states were broken:

1. **Viewer users could still edit most fields.** The form's only viewer-mode guard was `<fieldset disabled={isReadOnly}>`. The HTML `fieldset[disabled]` cascade only disables native form controls — antd's `Select`, `Switch`, `Input`, `InputNumber`, etc. render custom DOM and ignore it. So in viewer mode the UI looked editable even though the backend rejected the save.
2. **The viewer gate required the `rbac` plus-config flag.** `isReadOnly` was gated on `isRbacEnabled && passedInSystem && !canUpdateSystems`. In any tenant where `plus-health.rbac.enabled` wasn't true, `isReadOnly` was always false, even for users who genuinely lacked `system:update`. The backend still rejected the save (scope check is unconditional), but the UI silently looked editable. Dropped the flag — scope is the source of truth.
3. **Assigned system managers were locked out.** `useHasPermission([SYSTEM_UPDATE, SYSTEM_MANAGER_UPDATE])` checks the user's role-level scopes. `SYSTEM_MANAGER_UPDATE` is granted per-system at token-issue time (see `_has_scope_as_system_manager` in `system_manager_oauth_util.py`) and never appears in role scopes. So a Viewer assigned as a manager for a specific system had the form stuck read-only even though the backend would accept their save. Now the form fetches the current user's managed-systems list (`GET /user/{id}/system-manager`) and treats membership as equivalent to having `system:update` for the open system.
4. **Several Select fields were never wired up to `lockedForGVL`.** `tags`, `system_groups`, `dataset_references`, and the `description` / `legal_name` / `legal_address` / `data_security_practices` DictSuggestion fields had no `disabled` prop at all — they relied solely on the broken fieldset cascade. Wired `isReadOnly` (only — these are admin metadata, not GVL data) into each one.
5. **CustomFieldsList was completely uncontrolled.** It rendered antd Input/Select with no `disabled` prop. Added an optional `disabled` prop and pass `isReadOnly` from the parent form.

### Code Changes

* `SystemInformationForm.tsx`:
  * Drop `isRbacEnabled` from the `isReadOnly` computation.
  * Look up the current user's managed systems via `useGetUserManagedSystemsQuery` (skipped when the user already has `SYSTEM_UPDATE`, when there's no current user, or when creating). Treat the open system being on that list as `canUpdateSystems = true`.
  * Thread `isReadOnly` into every per-field `disabled` prop, OR'd with the existing `lockedForGVL` for GVL-managed fields and with the compound `!processesPersonalData || exemptFromPrivacyRegulations` for the conditional admin fields. Preserves the GVL semantics — only the originally-GVL-locked fields are GVL-locked.
  * Add `disabled={isReadOnly}` to the `tags`, `system_groups`, `dataset_references`, `data_stewards` Selects, the no-dict `name` Input, and the `description` / `legal_name` / `legal_address` / `data_security_practices` DictSuggestion fields (which previously had no `disabled`).
  * Pass `lockedForGVL={isReadOnly || lockedForGVL}` to `VendorSelector` so the system name input also locks in viewer mode.
* `CustomFieldsList.tsx`: Add optional `disabled?: boolean` prop and forward it to the Input/Select children.

### Tests

A new Cypress spec (`viewer-assigned-system.cy.ts`) covers the viewer/assigned-system path. Because the central insight of this fix is that the form should behave consistently regardless of the `rbac` plus-config flag, the spec is parameterized to run twice — once with `rbac.enabled: true` and once with `rbac.enabled: false` — verifying for each:

* A Viewer assigned to the open system can edit it (no read-only banner, no disabled fieldset).
* A Viewer not assigned to the open system sees the read-only form.

### Steps to Confirm

1. As a viewer user (no `system:update` scope, no `system_manager:update` assignment for the system) on any tenant — regardless of whether plus RBAC config is enabled — open an existing system. Confirm every field on the System Information tab is non-interactive, including the Description, Tags, System Groups, Dataset References, Data Stewards, all DictSuggestion text/switches, the VendorSelector name, and any Custom Fields.
2. As a Viewer who *is* assigned as a System Manager for the open system, confirm the form is fully editable and save succeeds. Repeat on a tenant with `plus-health.rbac.enabled: false` to confirm the assigned-manager path works whether or not the RBAC plus-config flag is on (this was the original bug).
3. As an editor on a non-GVL system, confirm all fields stay editable.
4. As an editor on a GVL-vendor system (`lockedForGVL` is true), confirm only the GVL-managed fields lock (legal basis, cookies, privacy policy, DPO, etc.). Admin metadata fields (tags, system groups, dataset references, data stewards, description, legal name/address, data security practices) remain editable. This preserves pre-PR GVL behavior.

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a db-migration label to the entry if your change includes a DB migration
  * [ ] Add a high-risk label to the entry if your change includes a high-risk change
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, PR opened in fidesdocs
  * [ ] Documentation issue created in fidesdocs
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ENG-3896]: https://ethyca.atlassian.net/browse/ENG-3896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ