### PR TITLE
Add body_path to cursor pagination for GraphQL support

### DIFF
--- a/src/fides/api/schemas/saas/strategy_configuration.py
+++ b/src/fides/api/schemas/saas/strategy_configuration.py
@@ -90,12 +90,18 @@ class LinkPaginationConfiguration(StrategyConfiguration):
 
 class CursorPaginationConfiguration(StrategyConfiguration):
     """
-    Extracts the cursor value from the 'field' of the last object in the array specified by 'data_path'
+    Extracts the cursor value from the 'field' of the last object in the array specified by 'data_path'.
+
+    By default the cursor is injected as a query parameter named ``cursor_param``.
+    If ``body_path`` is provided (dot-notation, e.g. ``variables.after``), the cursor
+    is injected into the JSON request body at that path instead — useful for GraphQL
+    Relay-style pagination.
     """
 
     cursor_param: str
     field: str
     has_next: Optional[str] = None
+    body_path: Optional[str] = None
 
 
 class ApiKeyAuthenticationConfiguration(StrategyConfiguration):

--- a/src/fides/api/service/pagination/pagination_strategy_cursor.py
+++ b/src/fides/api/service/pagination/pagination_strategy_cursor.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any, Dict, Optional
 
 import pydash
@@ -17,6 +18,7 @@ class CursorPaginationStrategy(PaginationStrategy):
         self.cursor_param = configuration.cursor_param
         self.field = configuration.field
         self.has_next = configuration.has_next
+        self.body_path = configuration.body_path
 
     def get_next_request(
         self,
@@ -55,13 +57,19 @@ class CursorPaginationStrategy(PaginationStrategy):
             if str(has_next).lower() != "true":
                 return None
 
-        # add or replace cursor_param with new cursor value
-        request_params.query_params[self.cursor_param] = cursor
+        # inject cursor into body (for GraphQL) or query params (default)
+        body = request_params.body
+        if self.body_path:
+            body_dict = json.loads(body) if body else {}
+            pydash.set_(body_dict, self.body_path, cursor)
+            body = json.dumps(body_dict)
+        else:
+            request_params.query_params[self.cursor_param] = cursor
 
         return SaaSRequestParams(
             method=request_params.method,
             headers=request_params.headers,
             path=request_params.path,
             query_params=request_params.query_params,
-            body=request_params.body,
+            body=body,
         )

--- a/tests/fides/ops/service/pagination/test_pagination_strategy_cursor.py
+++ b/tests/fides/ops/service/pagination/test_pagination_strategy_cursor.py
@@ -294,3 +294,158 @@ def test_cursor_object_and_has_next_in_metadata(
         path="/items",
         query_params={"after": 2},
     )
+
+
+# --- body_path tests (GraphQL Relay-style cursor injection into request body) ---
+
+
+@pytest.fixture(scope="function")
+def graphql_relay_response():
+    """Simulates a GraphQL Relay response with pageInfo alongside edges."""
+    response = Response()
+    response._content = bytes(
+        json.dumps(
+            {
+                "data": {
+                    "orders": {
+                        "pageInfo": {
+                            "hasNextPage": True,
+                            "endCursor": "YXJyYXljb25uZWN0aW9uOjk=",
+                        },
+                        "edges": [
+                            {"node": {"id": "1"}},
+                            {"node": {"id": "2"}},
+                        ],
+                    }
+                }
+            }
+        ),
+        "utf-8",
+    )
+    return response
+
+
+@pytest.fixture(scope="function")
+def graphql_relay_response_last_page():
+    """Simulates a final page GraphQL Relay response."""
+    response = Response()
+    response._content = bytes(
+        json.dumps(
+            {
+                "data": {
+                    "orders": {
+                        "pageInfo": {
+                            "hasNextPage": False,
+                            "endCursor": "YXJyYXljb25uZWN0aW9uOjE5",
+                        },
+                        "edges": [
+                            {"node": {"id": "10"}},
+                        ],
+                    }
+                }
+            }
+        ),
+        "utf-8",
+    )
+    return response
+
+
+def test_body_path_injects_cursor_into_body(graphql_relay_response):
+    """Cursor is injected into the JSON body at body_path instead of query params."""
+    config = CursorPaginationConfiguration(
+        cursor_param="after",
+        field="data.orders.pageInfo.endCursor",
+        has_next="data.orders.pageInfo.hasNextPage",
+        body_path="variables.after",
+    )
+    original_body = json.dumps(
+        {
+            "query": "{ orders(first: 10, after: $after) { edges { node { id } } pageInfo { hasNextPage endCursor } } }",
+            "variables": {"first": 10, "after": None},
+        }
+    )
+    request_params = SaaSRequestParams(
+        method=HTTPMethod.POST,
+        path="/graphql",
+        body=original_body,
+    )
+    paginator = CursorPaginationStrategy(config)
+    next_request = paginator.get_next_request(
+        request_params, {}, graphql_relay_response, "data.orders.edges"
+    )
+
+    assert next_request is not None
+    assert next_request.query_params == {}
+    body = json.loads(next_request.body)
+    assert body["variables"]["after"] == "YXJyYXljb25uZWN0aW9uOjk="
+    assert body["variables"]["first"] == 10
+    assert body["query"] == json.loads(original_body)["query"]
+
+
+def test_body_path_stops_on_last_page(graphql_relay_response_last_page):
+    """Pagination stops when hasNextPage is false, even with body_path."""
+    config = CursorPaginationConfiguration(
+        cursor_param="after",
+        field="data.orders.pageInfo.endCursor",
+        has_next="data.orders.pageInfo.hasNextPage",
+        body_path="variables.after",
+    )
+    request_params = SaaSRequestParams(
+        method=HTTPMethod.POST,
+        path="/graphql",
+        body=json.dumps({"query": "...", "variables": {"after": "prev_cursor"}}),
+    )
+    paginator = CursorPaginationStrategy(config)
+    next_request = paginator.get_next_request(
+        request_params, {}, graphql_relay_response_last_page, "data.orders.edges"
+    )
+
+    assert next_request is None
+
+
+def test_body_path_overwrites_previous_cursor(graphql_relay_response):
+    """On page 3+, body_path overwrites the previous cursor value."""
+    config = CursorPaginationConfiguration(
+        cursor_param="after",
+        field="data.orders.pageInfo.endCursor",
+        has_next="data.orders.pageInfo.hasNextPage",
+        body_path="variables.after",
+    )
+    request_params = SaaSRequestParams(
+        method=HTTPMethod.POST,
+        path="/graphql",
+        body=json.dumps(
+            {"query": "...", "variables": {"after": "old_cursor_from_page_1"}}
+        ),
+    )
+    paginator = CursorPaginationStrategy(config)
+    next_request = paginator.get_next_request(
+        request_params, {}, graphql_relay_response, "data.orders.edges"
+    )
+
+    assert next_request is not None
+    body = json.loads(next_request.body)
+    assert body["variables"]["after"] == "YXJyYXljb25uZWN0aW9uOjk="
+
+
+def test_body_path_preserves_headers(graphql_relay_response):
+    """Headers are preserved when using body_path pagination."""
+    config = CursorPaginationConfiguration(
+        cursor_param="after",
+        field="data.orders.pageInfo.endCursor",
+        has_next="data.orders.pageInfo.hasNextPage",
+        body_path="variables.after",
+    )
+    request_params = SaaSRequestParams(
+        method=HTTPMethod.POST,
+        path="/graphql",
+        headers={"Authorization": "Bearer token123"},
+        body=json.dumps({"query": "...", "variables": {"after": None}}),
+    )
+    paginator = CursorPaginationStrategy(config)
+    next_request = paginator.get_next_request(
+        request_params, {}, graphql_relay_response, "data.orders.edges"
+    )
+
+    assert next_request is not None
+    assert next_request.headers == {"Authorization": "Bearer token123"}


### PR DESCRIPTION
Ticket [N/A] <!-- framework enhancement, no ticket -->

### Description Of Changes

Adds an optional `body_path` field to the cursor pagination strategy that injects the pagination cursor into the JSON request body instead of URL query params. This enables declarative YAML-based cursor pagination for GraphQL APIs using Relay-style pagination (`hasNextPage`/`endCursor` passed as variables in the POST body).

Fully backward compatible — when `body_path` is omitted, existing query-param behavior is unchanged.

Example YAML usage:
```yaml
pagination:
  strategy: cursor
  configuration:
    cursor_param: after
    field: data.orders.pageInfo.endCursor
    has_next: data.orders.pageInfo.hasNextPage
    body_path: variables.after
```

**Motivation:** Currently, all GraphQL connectors with Relay pagination (Saleor, Shopify, Medallia) require Python request overrides just for cursor pagination because the framework can only inject cursors as URL query params. This change allows those paginated reads to be expressed declaratively in YAML. The ShipHero integration (ethyca/fidesplus#3641) is the first connector to use this feature.

### Code Changes

* Added optional `body_path` field to `CursorPaginationConfiguration` in `strategy_configuration.py`
* Updated `CursorPaginationStrategy.get_next_request()` to JSON-parse the body, set cursor at `body_path`, and re-serialize when `body_path` is provided
* Added 4 new tests for body injection, last-page stop, cursor overwrite on subsequent pages, and header preservation

### Steps to Confirm

1. Verify all 15 cursor pagination tests pass (11 existing + 4 new): `pytest tests/fides/ops/service/pagination/test_pagination_strategy_cursor.py -v --noconftest`
2. Verify no regressions in existing SaaS connector tests that use cursor pagination

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [x] No UX review needed
* Followup issues:
  * [x] No followup issues
* Database migrations:
  * [x] No migrations
* Documentation:
  * [ ] No documentation updates required