### PR TITLE
ENG-3965: Add aws_iam authentication strategy for SaaS connectors

### DIFF
--- a/changelog/8272-aws-iam-authentication-strategy.yaml
+++ b/changelog/8272-aws-iam-authentication-strategy.yaml
@@ -1,0 +1,4 @@
+type: Added
+description: Added aws_iam authentication strategy for SaaS connectors, supporting AWS Signature V4 signing with static credentials and STS AssumeRole with automatic credential caching
+pr: 8272
+labels: []

--- a/src/fides/api/schemas/connection_configuration/connection_secrets_saas.py
+++ b/src/fides/api/schemas/connection_configuration/connection_secrets_saas.py
@@ -162,7 +162,7 @@ class SaaSSchemaFactory:
                         json_schema_extra=extra,
                     ),
                 )
-                if connector_param.default_value
+                if connector_param.default_value or connector_param.optional
                 else (
                     param_type,
                     FieldInfo(

--- a/src/fides/api/schemas/saas/saas_config.py
+++ b/src/fides/api/schemas/saas/saas_config.py
@@ -334,6 +334,7 @@ class ConnectorParam(BaseModel):
     multiselect: Optional[bool] = False
     description: Optional[str] = None
     sensitive: Optional[bool] = False
+    optional: bool = False
     type: Optional[str] = None
     allowed_values: Optional[List[str]] = None
     # type="endpoint" marks this param as a URL endpoint/domain param.

--- a/src/fides/api/schemas/saas/strategy_configuration.py
+++ b/src/fides/api/schemas/saas/strategy_configuration.py
@@ -198,3 +198,29 @@ class GoogleCloudServiceAccountConfiguration(StrategyConfiguration):
             "'https://www.googleapis.com/auth/devstorage.read_write' for Cloud Storage, "
         ),
     )
+
+
+class AWSIAMAuthenticationConfiguration(StrategyConfiguration):
+    """
+    Configuration for AWS IAM (Signature V4) authentication.
+
+    Signs HTTP requests using AWS credentials so they can be sent to
+    IAM-protected endpoints such as API Gateway with IAM authorization.
+    Supports both static credentials and STS AssumeRole.
+    """
+
+    region: Optional[str] = Field(
+        default=None,
+        description=(
+            "AWS region for signing requests (e.g. 'us-east-1'). "
+            "If not specified, the region is resolved from the connector secrets "
+            "('aws_region') or inferred from the API Gateway endpoint hostname."
+        ),
+    )
+    service: str = Field(
+        default="execute-api",
+        description=(
+            "The AWS service name used for Signature V4 signing. "
+            "Defaults to 'execute-api' for API Gateway."
+        ),
+    )

--- a/src/fides/api/service/authentication/__init__.py
+++ b/src/fides/api/service/authentication/__init__.py
@@ -1,5 +1,6 @@
 from fides.api.service.authentication import (
     authentication_strategy_api_key,
+    authentication_strategy_aws_iam,
     authentication_strategy_basic,
     authentication_strategy_bearer,
     authentication_strategy_google_cloud_service_account,

--- a/src/fides/api/service/authentication/authentication_strategy_aws_iam.py
+++ b/src/fides/api/service/authentication/authentication_strategy_aws_iam.py
@@ -1,0 +1,250 @@
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, NoReturn, Optional
+from urllib.parse import urlparse
+
+from botocore.auth import SigV4Auth
+from botocore.awsrequest import AWSRequest
+from botocore.credentials import Credentials
+from botocore.exceptions import ClientError, NoCredentialsError
+from loguru import logger
+from requests import PreparedRequest
+from sqlalchemy.orm import Session
+
+from fides.api.common_exceptions import FidesopsException
+from fides.api.models.connectionconfig import ConnectionConfig
+from fides.api.schemas.saas.strategy_configuration import (
+    AWSIAMAuthenticationConfiguration,
+    StrategyConfiguration,
+)
+from fides.api.service.authentication.authentication_strategy import (
+    AuthenticationStrategy,
+)
+from fides.api.util.logger import Pii
+
+TOKEN_REFRESH_BUFFER_SECONDS = 300
+
+
+class AWSIAMAuthenticationStrategy(AuthenticationStrategy):
+    """
+    Authenticates HTTP requests using AWS IAM (Signature V4).
+
+    Supports two modes:
+    - AssumeRole: Customer provides an IAM Role ARN. Fides assumes the role
+      via STS to get temporary credentials, then signs requests with SigV4.
+    - Static keys: Customer provides AWS access key ID and secret access key
+      directly.
+
+    Designed for authenticating against AWS API Gateway endpoints protected
+    by IAM authorization.
+    """
+
+    name = "aws_iam"
+    configuration_model = AWSIAMAuthenticationConfiguration
+
+    def __init__(self, configuration: AWSIAMAuthenticationConfiguration):
+        self.aws_region = configuration.region
+        self.service = configuration.service
+
+    def add_authentication(
+        self, request: PreparedRequest, connection_config: ConnectionConfig
+    ) -> PreparedRequest:
+        credentials = self._get_credentials(connection_config)
+        region = self._resolve_region(request.url, connection_config)
+
+        aws_request = AWSRequest(
+            method=request.method,
+            url=request.url,
+            headers=dict(request.headers) if request.headers else {},
+            data=request.body or "",
+        )
+
+        SigV4Auth(credentials, self.service, region).add_auth(aws_request)
+
+        request.headers.update(dict(aws_request.headers))
+        return request
+
+    def _get_credentials(self, connection_config: ConnectionConfig) -> Credentials:
+        secrets = connection_config.secrets
+        if not secrets:
+            raise FidesopsException(
+                "Secrets are not configured for this connector. "
+                "AWS IAM authentication requires either an assume_role_arn "
+                "or aws_access_key_id and aws_secret_access_key."
+            )
+
+        assume_role_arn = secrets.get("aws_assume_role_arn")
+        if assume_role_arn:
+            return self._get_assumed_role_credentials(secrets, connection_config)
+
+        access_key_id = secrets.get("aws_access_key_id")
+        secret_access_key = secrets.get("aws_secret_access_key")
+        if not access_key_id or not secret_access_key:
+            raise FidesopsException(
+                "AWS IAM authentication requires either 'aws_assume_role_arn' "
+                "or both 'aws_access_key_id' and 'aws_secret_access_key'."
+            )
+        session_token = secrets.get("aws_session_token")
+        return Credentials(access_key_id, secret_access_key, session_token)
+
+    def _get_assumed_role_credentials(
+        self,
+        secrets: Dict[str, Any],
+        connection_config: ConnectionConfig,
+    ) -> Credentials:
+        cached_key = secrets.get("aws_iam_access_key_id")
+        cached_secret = secrets.get("aws_iam_secret_access_key")
+        cached_token = secrets.get("aws_iam_session_token")
+        cached_expiry = secrets.get("aws_iam_credentials_expire_at")
+
+        if cached_key and cached_secret and cached_token and cached_expiry:
+            if not self._is_close_to_expiration(cached_expiry):
+                return Credentials(cached_key, cached_secret, cached_token)
+
+        return self._refresh_assumed_role_credentials(secrets, connection_config)
+
+    def _refresh_assumed_role_credentials(
+        self,
+        secrets: Dict[str, Any],
+        connection_config: ConnectionConfig,
+    ) -> Credentials:
+        import boto3
+
+        assume_role_arn = secrets["aws_assume_role_arn"]
+
+        logger.info(
+            "Assuming AWS IAM role for {}",
+            connection_config.key,
+        )
+
+        try:
+            access_key_id = secrets.get("aws_access_key_id")
+            secret_access_key = secrets.get("aws_secret_access_key")
+
+            if access_key_id and secret_access_key:
+                session = boto3.Session(
+                    aws_access_key_id=access_key_id,
+                    aws_secret_access_key=secret_access_key,
+                    aws_session_token=secrets.get("aws_session_token"),
+                )
+            else:
+                session = boto3.Session()
+
+            sts_client = session.client("sts")
+            response = sts_client.assume_role(
+                RoleArn=assume_role_arn,
+                RoleSessionName="FidesSaaSConnectorSession",
+            )
+
+            temp_creds = response["Credentials"]
+            access_key = temp_creds["AccessKeyId"]
+            secret_key = temp_creds["SecretAccessKey"]
+            session_token = temp_creds["SessionToken"]
+            expiration = temp_creds["Expiration"]
+
+            expires_at = int(expiration.timestamp())
+            self._store_credentials(
+                connection_config, access_key, secret_key, session_token, expires_at
+            )
+
+            logger.info(
+                "Successfully assumed AWS IAM role for {}",
+                connection_config.key,
+            )
+
+            return Credentials(access_key, secret_key, session_token)
+
+        except (ClientError, NoCredentialsError) as exc:
+            self._handle_credential_error(exc, connection_config)
+
+    def _resolve_region(
+        self, url: Optional[str], connection_config: ConnectionConfig
+    ) -> str:
+        if self.aws_region:
+            return self.aws_region
+
+        secrets = connection_config.secrets or {}
+        region_from_secrets = secrets.get("aws_region")
+        if region_from_secrets:
+            return region_from_secrets
+
+        if url:
+            parsed = urlparse(url)
+            hostname = parsed.hostname or ""
+            parts = hostname.split(".")
+            if len(parts) >= 4 and parts[-2] == "amazonaws" and parts[-1] == "com":
+                return parts[-3]
+
+        return "us-east-1"
+
+    def _is_close_to_expiration(self, expires_at: int) -> bool:
+        buffer_time = datetime.now(timezone.utc) + timedelta(
+            seconds=TOKEN_REFRESH_BUFFER_SECONDS
+        )
+        return expires_at < buffer_time.timestamp()
+
+    def _store_credentials(
+        self,
+        connection_config: ConnectionConfig,
+        access_key_id: str,
+        secret_access_key: str,
+        session_token: str,
+        expires_at: int,
+    ) -> None:
+        db: Optional[Session] = Session.object_session(connection_config)
+        if db is None:
+            logger.warning(
+                "Unable to cache AWS IAM credentials for {} - no database session available",
+                connection_config.key,
+            )
+            return
+
+        updated_secrets = {
+            **(connection_config.secrets or {}),
+            "aws_iam_access_key_id": access_key_id,
+            "aws_iam_secret_access_key": secret_access_key,
+            "aws_iam_session_token": session_token,
+            "aws_iam_credentials_expire_at": expires_at,
+        }
+        connection_config.update(db, data={"secrets": updated_secrets})
+        logger.debug(
+            "Cached AWS IAM credentials for {} (expires at {})",
+            connection_config.key,
+            datetime.fromtimestamp(expires_at, tz=timezone.utc).isoformat(),
+        )
+
+    def _handle_credential_error(
+        self, exc: Exception, connection_config: ConnectionConfig
+    ) -> NoReturn:
+        error_msg = str(exc)
+        logger.error(
+            "Error assuming AWS IAM role for {}: {}",
+            connection_config.key,
+            Pii(error_msg),
+        )
+
+        if isinstance(exc, NoCredentialsError):
+            user_message = (
+                "No AWS credentials found. Provide either aws_access_key_id "
+                "and aws_secret_access_key, or ensure the Fides environment "
+                "has AWS credentials configured (e.g. via instance profile)."
+            )
+        elif isinstance(exc, ClientError):
+            error_code = exc.response.get("Error", {}).get("Code", "")
+            if error_code == "AccessDenied":
+                user_message = (
+                    "Access denied when assuming the IAM role. Verify that "
+                    "the role's trust policy allows Fides to assume it and "
+                    "that the provided credentials have sts:AssumeRole permission."
+                )
+            elif error_code in ("MalformedPolicyDocument", "PackedPolicyTooLarge"):
+                user_message = f"IAM role configuration error: {error_code}. Check the role ARN and trust policy."
+            else:
+                user_message = f"AWS STS error ({error_code}): {error_msg}"
+        else:
+            user_message = f"Failed to assume AWS IAM role: {error_msg}"
+
+        raise FidesopsException(user_message) from exc
+
+    @staticmethod
+    def get_configuration_model() -> StrategyConfiguration:
+        return AWSIAMAuthenticationConfiguration  # type: ignore

--- a/src/fides/api/service/authentication/authentication_strategy_aws_iam.py
+++ b/src/fides/api/service/authentication/authentication_strategy_aws_iam.py
@@ -99,6 +99,11 @@ class AWSIAMAuthenticationStrategy(AuthenticationStrategy):
         if cached_key and cached_secret and cached_token and cached_expiry:
             if not self._is_close_to_expiration(cached_expiry):
                 return Credentials(cached_key, cached_secret, cached_token)
+        elif any([cached_key, cached_secret, cached_token, cached_expiry]):
+            logger.debug(
+                "Partial cached credentials found for {}; refreshing.",
+                connection_config.key,
+            )
 
         return self._refresh_assumed_role_credentials(secrets, connection_config)
 
@@ -107,6 +112,7 @@ class AWSIAMAuthenticationStrategy(AuthenticationStrategy):
         secrets: Dict[str, Any],
         connection_config: ConnectionConfig,
     ) -> Credentials:
+        # Imported lazily to avoid a hard dependency on boto3 at module load time.
         import boto3
 
         assume_role_arn = secrets["aws_assume_role_arn"]
@@ -155,6 +161,7 @@ class AWSIAMAuthenticationStrategy(AuthenticationStrategy):
 
         except (ClientError, NoCredentialsError) as exc:
             self._handle_credential_error(exc, connection_config)
+            raise  # unreachable; _handle_credential_error is NoReturn
 
     def _resolve_region(
         self, url: Optional[str], connection_config: ConnectionConfig
@@ -174,6 +181,12 @@ class AWSIAMAuthenticationStrategy(AuthenticationStrategy):
             if len(parts) >= 4 and parts[-2] == "amazonaws" and parts[-1] == "com":
                 return parts[-3]
 
+        logger.warning(
+            "Could not infer AWS region from URL or secrets for connector {}; "
+            "defaulting to us-east-1. Set aws_region in the connector secrets or "
+            "authentication configuration to avoid this.",
+            connection_config.key,
+        )
         return "us-east-1"
 
     def _is_close_to_expiration(self, expires_at: int) -> bool:
@@ -224,9 +237,12 @@ class AWSIAMAuthenticationStrategy(AuthenticationStrategy):
 
         if isinstance(exc, NoCredentialsError):
             user_message = (
-                "No AWS credentials found. Provide either aws_access_key_id "
-                "and aws_secret_access_key, or ensure the Fides environment "
-                "has AWS credentials configured (e.g. via instance profile)."
+                "No base AWS credentials found to authenticate the STS AssumeRole call. "
+                "Providing an IAM Role ARN alone is not sufficient. AWS requires credentials "
+                "to call sts:AssumeRole. Either provide aws_access_key_id and "
+                "aws_secret_access_key alongside the ARN, or ensure the Fides environment "
+                "has ambient AWS credentials configured (e.g. instance profile, environment "
+                "variables, or ~/.aws/credentials)."
             )
         elif isinstance(exc, ClientError):
             error_code = exc.response.get("Error", {}).get("Code", "")

--- a/src/fides/api/service/authentication/authentication_strategy_factory.py
+++ b/src/fides/api/service/authentication/authentication_strategy_factory.py
@@ -24,6 +24,9 @@ from fides.api.service.authentication.authentication_strategy_oauth2_authorizati
 from fides.api.service.authentication.authentication_strategy_oauth2_client_credentials import (
     OAuth2ClientCredentialsAuthenticationStrategy,
 )
+from fides.api.service.authentication.authentication_strategy_aws_iam import (
+    AWSIAMAuthenticationStrategy,
+)
 from fides.api.service.authentication.authentication_strategy_query_param import (
     QueryParamAuthenticationStrategy,
 )
@@ -40,6 +43,7 @@ class SupportedAuthenticationStrategies(Enum):
     oauth2_authorization_code = OAuth2AuthorizationCodeAuthenticationStrategy
     oauth2_client_credentials = OAuth2ClientCredentialsAuthenticationStrategy
     google_cloud_service_account = GoogleCloudServiceAccountAuthenticationStrategy
+    aws_iam = AWSIAMAuthenticationStrategy
 
     @classmethod
     def __contains__(cls, item: str) -> bool:

--- a/tests/fides/ops/schemas/connection_configuration/test_connection_secrets_saas.py
+++ b/tests/fides/ops/schemas/connection_configuration/test_connection_secrets_saas.py
@@ -10,7 +10,6 @@ from fides.api.schemas.connection_configuration.connection_secrets_saas import (
 )
 from fides.api.schemas.saas.saas_config import (
     ConnectorParam,
-    ExternalDatasetReference,
     SaaSConfig,
 )
 from fides.config.security_settings import DomainValidationMode
@@ -44,22 +43,23 @@ class TestSaaSConnectionSecrets:
         with pytest.raises(ValidationError) as exc:
             schema.model_validate(config)
 
-        required_fields = [
-            connector_param.name
-            for connector_param in (
-                saas_config.connector_params + saas_config.external_references
-            )
-            if isinstance(
-                connector_param, ExternalDatasetReference
-            )  # external refs are required
-            or not connector_param.default_value
-        ]
-
         errors = exc._excinfo[1].errors()
         assert (
             errors[0]["msg"]
             == "Value error, custom_schema must be supplied all of: [username, api_key, api_version, page_size, account_types, customer_id]."
         )
+
+    def test_optional_param_not_required(self, saas_config: SaaSConfig):
+        saas_config.connector_params = [
+            ConnectorParam(name="required_key"),
+            ConnectorParam(name="optional_key", optional=True),
+        ]
+        saas_config.external_references = []
+        schema = SaaSSchemaFactory(saas_config).get_saas_schema()
+        # optional_key absent — should not raise
+        schema.model_validate({"required_key": "value"})
+        # optional_key present — should also work
+        schema.model_validate({"required_key": "value", "optional_key": "val"})
 
     def test_extra_fields(
         self, saas_config: SaaSConfig, saas_example_secrets: Dict[str, Any]

--- a/tests/fides/ops/service/authentication/test_authentication_strategy_aws_iam.py
+++ b/tests/fides/ops/service/authentication/test_authentication_strategy_aws_iam.py
@@ -59,9 +59,7 @@ class TestStrategyConfiguration:
         assert strategy.service == "execute-api"
 
     def test_custom_service(self):
-        strategy = AuthenticationStrategy.get_strategy(
-            "aws_iam", {"service": "lambda"}
-        )
+        strategy = AuthenticationStrategy.get_strategy("aws_iam", {"service": "lambda"})
         assert strategy.service == "lambda"
 
     def test_custom_region(self):
@@ -142,9 +140,7 @@ class TestCredentialResolution:
 
 class TestAssumeRole:
     @patch("fides.api.service.authentication.authentication_strategy_aws_iam.boto3")
-    def test_assume_role_signs_request(
-        self, mock_boto3, assume_role_connection_config
-    ):
+    def test_assume_role_signs_request(self, mock_boto3, assume_role_connection_config):
         future_expiry = datetime.now(timezone.utc) + timedelta(hours=1)
         mock_sts = MagicMock()
         mock_sts.assume_role.return_value = {
@@ -253,7 +249,7 @@ class TestAssumeRole:
 
         with pytest.raises(FidesopsException) as exc:
             strategy.add_authentication(req, assume_role_connection_config)
-        assert "No AWS credentials found" in str(exc.value)
+        assert "No base AWS credentials found" in str(exc.value)
 
 
 class TestCredentialCaching:
@@ -291,9 +287,7 @@ class TestCredentialCaching:
     ):
         from botocore.credentials import Credentials
 
-        mock_refresh.return_value = Credentials(
-            "ASIA_NEW", "new_secret", "new_token"
-        )
+        mock_refresh.return_value = Credentials("ASIA_NEW", "new_secret", "new_token")
 
         close_expiry = int(
             (
@@ -325,9 +319,7 @@ class TestCredentialCaching:
 
 class TestRegionResolution:
     def test_region_from_configuration(self, static_key_secrets):
-        connection_config = ConnectionConfig(
-            key="test", secrets=static_key_secrets
-        )
+        connection_config = ConnectionConfig(key="test", secrets=static_key_secrets)
         req = Request(
             method="GET",
             url="https://abc123.execute-api.us-east-1.amazonaws.com/prod/users",
@@ -342,9 +334,7 @@ class TestRegionResolution:
         assert "ap-southeast-1" in auth_header
 
     def test_region_from_secrets(self, static_key_secrets):
-        connection_config = ConnectionConfig(
-            key="test", secrets=static_key_secrets
-        )
+        connection_config = ConnectionConfig(key="test", secrets=static_key_secrets)
         req = Request(
             method="GET",
             url="https://custom-domain.example.com/users",
@@ -447,9 +437,7 @@ class TestRequestSigning:
             url="https://abc123.execute-api.us-west-2.amazonaws.com/prod/users",
         ).prepare()
 
-        strategy = AuthenticationStrategy.get_strategy(
-            "aws_iam", {"service": "lambda"}
-        )
+        strategy = AuthenticationStrategy.get_strategy("aws_iam", {"service": "lambda"})
         authenticated_request = strategy.add_authentication(
             req, static_key_connection_config
         )

--- a/tests/fides/ops/service/authentication/test_authentication_strategy_aws_iam.py
+++ b/tests/fides/ops/service/authentication/test_authentication_strategy_aws_iam.py
@@ -1,0 +1,458 @@
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from botocore.exceptions import ClientError, NoCredentialsError
+from requests import Request
+
+from fides.api.common_exceptions import FidesopsException
+from fides.api.models.connectionconfig import ConnectionConfig
+from fides.api.service.authentication.authentication_strategy import (
+    AuthenticationStrategy,
+)
+from fides.api.service.authentication.authentication_strategy_aws_iam import (
+    TOKEN_REFRESH_BUFFER_SECONDS,
+    AWSIAMAuthenticationStrategy,
+)
+
+
+@pytest.fixture
+def static_key_secrets():
+    return {
+        "aws_access_key_id": "AKIAIOSFODNN7EXAMPLE",
+        "aws_secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        "aws_region": "us-west-2",
+    }
+
+
+@pytest.fixture
+def assume_role_secrets():
+    return {
+        "aws_assume_role_arn": "arn:aws:iam::123456789012:role/CustomerFidesRole",
+        "aws_region": "us-east-1",
+    }
+
+
+@pytest.fixture
+def static_key_connection_config(static_key_secrets):
+    return ConnectionConfig(
+        key="aws_iam_test_connector",
+        secrets=static_key_secrets,
+    )
+
+
+@pytest.fixture
+def assume_role_connection_config(assume_role_secrets):
+    return ConnectionConfig(
+        key="aws_iam_assume_role_connector",
+        secrets=assume_role_secrets,
+    )
+
+
+class TestStrategyConfiguration:
+    def test_strategy_registered(self):
+        strategy = AuthenticationStrategy.get_strategy("aws_iam", {})
+        assert isinstance(strategy, AWSIAMAuthenticationStrategy)
+
+    def test_default_service(self):
+        strategy = AuthenticationStrategy.get_strategy("aws_iam", {})
+        assert strategy.service == "execute-api"
+
+    def test_custom_service(self):
+        strategy = AuthenticationStrategy.get_strategy(
+            "aws_iam", {"service": "lambda"}
+        )
+        assert strategy.service == "lambda"
+
+    def test_custom_region(self):
+        strategy = AuthenticationStrategy.get_strategy(
+            "aws_iam", {"region": "eu-west-1"}
+        )
+        assert strategy.aws_region == "eu-west-1"
+
+    def test_default_region_is_none(self):
+        strategy = AuthenticationStrategy.get_strategy("aws_iam", {})
+        assert strategy.aws_region is None
+
+
+class TestCredentialResolution:
+    def test_missing_secrets(self):
+        connection_config = ConnectionConfig(key="test", secrets=None)
+        req = Request(
+            method="GET",
+            url="https://abc123.execute-api.us-east-1.amazonaws.com/prod/resource",
+        ).prepare()
+
+        strategy = AuthenticationStrategy.get_strategy("aws_iam", {})
+
+        with pytest.raises(FidesopsException) as exc:
+            strategy.add_authentication(req, connection_config)
+        assert "Secrets are not configured" in str(exc.value)
+
+    def test_missing_both_role_and_keys(self):
+        connection_config = ConnectionConfig(
+            key="test", secrets={"aws_region": "us-east-1"}
+        )
+        req = Request(
+            method="GET",
+            url="https://abc123.execute-api.us-east-1.amazonaws.com/prod/resource",
+        ).prepare()
+
+        strategy = AuthenticationStrategy.get_strategy("aws_iam", {})
+
+        with pytest.raises(FidesopsException) as exc:
+            strategy.add_authentication(req, connection_config)
+        assert "aws_assume_role_arn" in str(exc.value)
+
+    def test_static_keys_sign_request(self, static_key_connection_config):
+        req = Request(
+            method="GET",
+            url="https://abc123.execute-api.us-west-2.amazonaws.com/prod/users",
+        ).prepare()
+
+        strategy = AuthenticationStrategy.get_strategy("aws_iam", {})
+        authenticated_request = strategy.add_authentication(
+            req, static_key_connection_config
+        )
+
+        assert "Authorization" in authenticated_request.headers
+        assert "AWS4-HMAC-SHA256" in authenticated_request.headers["Authorization"]
+        assert "X-Amz-Date" in authenticated_request.headers
+
+    def test_static_keys_with_session_token(self):
+        connection_config = ConnectionConfig(
+            key="test",
+            secrets={
+                "aws_access_key_id": "AKIAIOSFODNN7EXAMPLE",
+                "aws_secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                "aws_session_token": "FwoGZXIvYXdzEBYaDH...",
+                "aws_region": "us-east-1",
+            },
+        )
+        req = Request(
+            method="GET",
+            url="https://abc123.execute-api.us-east-1.amazonaws.com/prod/users",
+        ).prepare()
+
+        strategy = AuthenticationStrategy.get_strategy("aws_iam", {})
+        authenticated_request = strategy.add_authentication(req, connection_config)
+
+        assert "X-Amz-Security-Token" in authenticated_request.headers
+
+
+class TestAssumeRole:
+    @patch("fides.api.service.authentication.authentication_strategy_aws_iam.boto3")
+    def test_assume_role_signs_request(
+        self, mock_boto3, assume_role_connection_config
+    ):
+        future_expiry = datetime.now(timezone.utc) + timedelta(hours=1)
+        mock_sts = MagicMock()
+        mock_sts.assume_role.return_value = {
+            "Credentials": {
+                "AccessKeyId": "ASIA_TEMP_KEY",
+                "SecretAccessKey": "temp_secret",
+                "SessionToken": "temp_session_token",
+                "Expiration": future_expiry,
+            }
+        }
+        mock_session = MagicMock()
+        mock_session.client.return_value = mock_sts
+        mock_boto3.Session.return_value = mock_session
+
+        req = Request(
+            method="GET",
+            url="https://abc123.execute-api.us-east-1.amazonaws.com/prod/users",
+        ).prepare()
+
+        strategy = AuthenticationStrategy.get_strategy("aws_iam", {})
+        authenticated_request = strategy.add_authentication(
+            req, assume_role_connection_config
+        )
+
+        assert "Authorization" in authenticated_request.headers
+        assert "AWS4-HMAC-SHA256" in authenticated_request.headers["Authorization"]
+        mock_sts.assume_role.assert_called_once_with(
+            RoleArn="arn:aws:iam::123456789012:role/CustomerFidesRole",
+            RoleSessionName="FidesSaaSConnectorSession",
+        )
+
+    @patch("fides.api.service.authentication.authentication_strategy_aws_iam.boto3")
+    def test_assume_role_with_base_credentials(self, mock_boto3):
+        connection_config = ConnectionConfig(
+            key="test",
+            secrets={
+                "aws_assume_role_arn": "arn:aws:iam::123456789012:role/SomeRole",
+                "aws_access_key_id": "AKIAIOSFODNN7EXAMPLE",
+                "aws_secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                "aws_region": "us-east-1",
+            },
+        )
+
+        future_expiry = datetime.now(timezone.utc) + timedelta(hours=1)
+        mock_sts = MagicMock()
+        mock_sts.assume_role.return_value = {
+            "Credentials": {
+                "AccessKeyId": "ASIA_TEMP",
+                "SecretAccessKey": "temp_secret",
+                "SessionToken": "temp_token",
+                "Expiration": future_expiry,
+            }
+        }
+        mock_session = MagicMock()
+        mock_session.client.return_value = mock_sts
+        mock_boto3.Session.return_value = mock_session
+
+        req = Request(
+            method="GET",
+            url="https://abc123.execute-api.us-east-1.amazonaws.com/prod/users",
+        ).prepare()
+
+        strategy = AuthenticationStrategy.get_strategy("aws_iam", {})
+        strategy.add_authentication(req, connection_config)
+
+        mock_boto3.Session.assert_called_once_with(
+            aws_access_key_id="AKIAIOSFODNN7EXAMPLE",
+            aws_secret_access_key="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            aws_session_token=None,
+        )
+
+    @patch("fides.api.service.authentication.authentication_strategy_aws_iam.boto3")
+    def test_assume_role_access_denied(self, mock_boto3, assume_role_connection_config):
+        mock_sts = MagicMock()
+        mock_sts.assume_role.side_effect = ClientError(
+            {"Error": {"Code": "AccessDenied", "Message": "Not authorized"}},
+            "AssumeRole",
+        )
+        mock_session = MagicMock()
+        mock_session.client.return_value = mock_sts
+        mock_boto3.Session.return_value = mock_session
+
+        req = Request(
+            method="GET",
+            url="https://abc123.execute-api.us-east-1.amazonaws.com/prod/users",
+        ).prepare()
+
+        strategy = AuthenticationStrategy.get_strategy("aws_iam", {})
+
+        with pytest.raises(FidesopsException) as exc:
+            strategy.add_authentication(req, assume_role_connection_config)
+        assert "Access denied" in str(exc.value)
+
+    @patch("fides.api.service.authentication.authentication_strategy_aws_iam.boto3")
+    def test_assume_role_no_credentials(
+        self, mock_boto3, assume_role_connection_config
+    ):
+        mock_boto3.Session.side_effect = NoCredentialsError()
+
+        req = Request(
+            method="GET",
+            url="https://abc123.execute-api.us-east-1.amazonaws.com/prod/users",
+        ).prepare()
+
+        strategy = AuthenticationStrategy.get_strategy("aws_iam", {})
+
+        with pytest.raises(FidesopsException) as exc:
+            strategy.add_authentication(req, assume_role_connection_config)
+        assert "No AWS credentials found" in str(exc.value)
+
+
+class TestCredentialCaching:
+    def test_uses_cached_credentials_when_valid(self, assume_role_secrets):
+        future_expiry = int(
+            (datetime.now(timezone.utc) + timedelta(hours=1)).timestamp()
+        )
+        connection_config = ConnectionConfig(
+            key="test",
+            secrets={
+                **assume_role_secrets,
+                "aws_iam_access_key_id": "ASIA_CACHED",
+                "aws_iam_secret_access_key": "cached_secret",
+                "aws_iam_session_token": "cached_token",
+                "aws_iam_credentials_expire_at": future_expiry,
+            },
+        )
+
+        req = Request(
+            method="GET",
+            url="https://abc123.execute-api.us-east-1.amazonaws.com/prod/users",
+        ).prepare()
+
+        strategy = AuthenticationStrategy.get_strategy("aws_iam", {})
+        authenticated_request = strategy.add_authentication(req, connection_config)
+
+        assert "Authorization" in authenticated_request.headers
+        assert "AWS4-HMAC-SHA256" in authenticated_request.headers["Authorization"]
+
+    @patch(
+        "fides.api.service.authentication.authentication_strategy_aws_iam.AWSIAMAuthenticationStrategy._refresh_assumed_role_credentials"
+    )
+    def test_refreshes_credentials_when_close_to_expiration(
+        self, mock_refresh, assume_role_secrets
+    ):
+        from botocore.credentials import Credentials
+
+        mock_refresh.return_value = Credentials(
+            "ASIA_NEW", "new_secret", "new_token"
+        )
+
+        close_expiry = int(
+            (
+                datetime.now(timezone.utc)
+                + timedelta(seconds=TOKEN_REFRESH_BUFFER_SECONDS - 60)
+            ).timestamp()
+        )
+        connection_config = ConnectionConfig(
+            key="test",
+            secrets={
+                **assume_role_secrets,
+                "aws_iam_access_key_id": "ASIA_OLD",
+                "aws_iam_secret_access_key": "old_secret",
+                "aws_iam_session_token": "old_token",
+                "aws_iam_credentials_expire_at": close_expiry,
+            },
+        )
+
+        req = Request(
+            method="GET",
+            url="https://abc123.execute-api.us-east-1.amazonaws.com/prod/users",
+        ).prepare()
+
+        strategy = AuthenticationStrategy.get_strategy("aws_iam", {})
+        strategy.add_authentication(req, connection_config)
+
+        mock_refresh.assert_called_once()
+
+
+class TestRegionResolution:
+    def test_region_from_configuration(self, static_key_secrets):
+        connection_config = ConnectionConfig(
+            key="test", secrets=static_key_secrets
+        )
+        req = Request(
+            method="GET",
+            url="https://abc123.execute-api.us-east-1.amazonaws.com/prod/users",
+        ).prepare()
+
+        strategy = AuthenticationStrategy.get_strategy(
+            "aws_iam", {"region": "ap-southeast-1"}
+        )
+        authenticated_request = strategy.add_authentication(req, connection_config)
+
+        auth_header = authenticated_request.headers["Authorization"]
+        assert "ap-southeast-1" in auth_header
+
+    def test_region_from_secrets(self, static_key_secrets):
+        connection_config = ConnectionConfig(
+            key="test", secrets=static_key_secrets
+        )
+        req = Request(
+            method="GET",
+            url="https://custom-domain.example.com/users",
+        ).prepare()
+
+        strategy = AuthenticationStrategy.get_strategy("aws_iam", {})
+        authenticated_request = strategy.add_authentication(req, connection_config)
+
+        auth_header = authenticated_request.headers["Authorization"]
+        assert "us-west-2" in auth_header
+
+    def test_region_inferred_from_url(self):
+        connection_config = ConnectionConfig(
+            key="test",
+            secrets={
+                "aws_access_key_id": "AKIAIOSFODNN7EXAMPLE",
+                "aws_secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            },
+        )
+        req = Request(
+            method="GET",
+            url="https://abc123.execute-api.eu-central-1.amazonaws.com/prod/users",
+        ).prepare()
+
+        strategy = AuthenticationStrategy.get_strategy("aws_iam", {})
+        authenticated_request = strategy.add_authentication(req, connection_config)
+
+        auth_header = authenticated_request.headers["Authorization"]
+        assert "eu-central-1" in auth_header
+
+    def test_region_falls_back_to_us_east_1(self):
+        connection_config = ConnectionConfig(
+            key="test",
+            secrets={
+                "aws_access_key_id": "AKIAIOSFODNN7EXAMPLE",
+                "aws_secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            },
+        )
+        req = Request(
+            method="GET",
+            url="https://custom-domain.example.com/users",
+        ).prepare()
+
+        strategy = AuthenticationStrategy.get_strategy("aws_iam", {})
+        authenticated_request = strategy.add_authentication(req, connection_config)
+
+        auth_header = authenticated_request.headers["Authorization"]
+        assert "us-east-1" in auth_header
+
+
+class TestRequestSigning:
+    def test_preserves_existing_headers(self, static_key_connection_config):
+        req = Request(
+            method="GET",
+            url="https://abc123.execute-api.us-west-2.amazonaws.com/prod/users",
+            headers={"Content-Type": "application/json", "X-Custom": "value"},
+        ).prepare()
+
+        strategy = AuthenticationStrategy.get_strategy("aws_iam", {})
+        authenticated_request = strategy.add_authentication(
+            req, static_key_connection_config
+        )
+
+        assert authenticated_request.headers["Content-Type"] == "application/json"
+        assert authenticated_request.headers["X-Custom"] == "value"
+        assert "Authorization" in authenticated_request.headers
+
+    def test_signs_post_with_body(self, static_key_connection_config):
+        req = Request(
+            method="POST",
+            url="https://abc123.execute-api.us-west-2.amazonaws.com/prod/users",
+            json={"email": "test@example.com"},
+        ).prepare()
+
+        strategy = AuthenticationStrategy.get_strategy("aws_iam", {})
+        authenticated_request = strategy.add_authentication(
+            req, static_key_connection_config
+        )
+
+        assert "Authorization" in authenticated_request.headers
+        assert "AWS4-HMAC-SHA256" in authenticated_request.headers["Authorization"]
+
+    def test_service_name_in_signature(self, static_key_connection_config):
+        req = Request(
+            method="GET",
+            url="https://abc123.execute-api.us-west-2.amazonaws.com/prod/users",
+        ).prepare()
+
+        strategy = AuthenticationStrategy.get_strategy("aws_iam", {})
+        authenticated_request = strategy.add_authentication(
+            req, static_key_connection_config
+        )
+
+        auth_header = authenticated_request.headers["Authorization"]
+        assert "execute-api" in auth_header
+
+    def test_custom_service_name(self, static_key_connection_config):
+        req = Request(
+            method="GET",
+            url="https://abc123.execute-api.us-west-2.amazonaws.com/prod/users",
+        ).prepare()
+
+        strategy = AuthenticationStrategy.get_strategy(
+            "aws_iam", {"service": "lambda"}
+        )
+        authenticated_request = strategy.add_authentication(
+            req, static_key_connection_config
+        )
+
+        auth_header = authenticated_request.headers["Authorization"]
+        assert "lambda" in auth_header


### PR DESCRIPTION
Ticket [ENG-3965]

### Description Of Changes

Adds a reusable `aws_iam` authentication strategy so any SaaS connector can sign outbound HTTP requests with AWS Signature V4. This standardizes IAM-based authentication across connectors rather than each integration reimplementing signing logic.

Designed primarily for AWS API Gateway endpoints protected by IAM authorization, but the `service` field is configurable so it can be used with other AWS services.

### Code Changes

* `authentication_strategy_aws_iam.py` — new `AWSIAMAuthenticationStrategy` class that:
  * Signs requests via `botocore.auth.SigV4Auth`
  * Supports **static credentials** (`aws_access_key_id` / `aws_secret_access_key` / optional `aws_session_token`) and **STS AssumeRole** (`aws_assume_role_arn`)
  * Caches assumed-role temporary credentials in `connection_config.secrets` and refreshes them 5 minutes before expiry
  * Infers the AWS region from strategy config → connector secrets → API Gateway hostname → defaults to `us-east-1`
* `strategy_configuration.py` — `AWSIAMAuthenticationConfiguration` schema with `region` and `service` fields
* `authentication_strategy_factory.py` — registers `aws_iam` in `SupportedAuthenticationStrategies`
* `authentication/__init__.py` — imports new module so it is picked up at startup
* `tests/ops/service/authentication/test_authentication_strategy_aws_iam.py` — unit tests covering both auth modes, region resolution, credential caching, and error handling

### Steps to Confirm

1. Create a SaaS connector config with `authentication: {strategy: aws_iam}` and static AWS credentials; confirm outbound requests include `Authorization`, `X-Amz-Date`, and `X-Amz-Security-Token` headers signed with SigV4
2. Configure `aws_assume_role_arn` instead of static keys; confirm Fides calls STS `AssumeRole` and caches the temporary credentials in the connector secrets
3. Confirm cached credentials are reused on subsequent requests and refreshed when within 5 minutes of expiry
4. Run `pytest tests/ops/service/authentication/test_authentication_strategy_aws_iam.py -v`

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required

[ENG-3965]: https://ethyca.atlassian.net/browse/ENG-3965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ