### PR TITLE
Remove duplicate resolveDataCategories from Go pipeline

### DIFF
--- a/policy-engine/pkg/pipeline/pipeline.go
+++ b/policy-engine/pkg/pipeline/pipeline.go
@@ -422,61 +422,6 @@ func resolveDataCategories(
 	return out
 }
 
-// resolveDataCategories looks up data categories for the columns accessed
-// in a specific dataset collection. If no specific columns were extracted
-// (SELECT * or parse failure), returns all categories from all fields in
-// the collection.
-func resolveDataCategories(
-	datasetKey string,
-	collection string,
-	columnsByDataset map[string]map[string][]string,
-	fieldCategories map[string]map[string][]string,
-) []string {
-	if fieldCategories == nil || collection == "" {
-		return nil
-	}
-
-	collFields, ok := fieldCategories[collection]
-	if !ok || len(collFields) == 0 {
-		return nil
-	}
-
-	var columns []string
-	if dsCols, ok := columnsByDataset[datasetKey]; ok {
-		columns = dsCols[collection]
-	}
-
-	catSet := map[string]bool{}
-
-	if len(columns) == 0 {
-		// SELECT * or no columns extracted — use all field categories
-		for _, cats := range collFields {
-			for _, c := range cats {
-				catSet[c] = true
-			}
-		}
-	} else {
-		for _, col := range columns {
-			if cats, ok := collFields[col]; ok {
-				for _, c := range cats {
-					catSet[c] = true
-				}
-			}
-		}
-	}
-
-	if len(catSet) == 0 {
-		return nil
-	}
-
-	out := make([]string, 0, len(catSet))
-	for c := range catSet {
-		out = append(out, c)
-	}
-	sort.Strings(out)
-	return out
-}
-
 func allSuppressed(violations []pbac.PurposeViolation) bool {
 	for _, v := range violations {
 		if v.SuppressedByPolicy == nil {

--- a/policy-engine/pkg/pipeline/pipeline_test.go
+++ b/policy-engine/pkg/pipeline/pipeline_test.go
@@ -418,9 +418,9 @@ func TestTableResolution_SchemaQualifiedDisambiguation(t *testing.T) {
 				"dataset_b": {DatasetKey: "dataset_b", PurposeKeys: []string{"marketing"}},
 			},
 			Tables: map[string]string{
-				"transactions":             "dataset_b", // bare name = last loaded
-				"dataset_a.transactions":   "dataset_a",
-				"dataset_b.transactions":   "dataset_b",
+				"transactions":           "dataset_b", // bare name = last loaded
+				"dataset_a.transactions": "dataset_a",
+				"dataset_b.transactions": "dataset_b",
 			},
 			FieldCategories: map[string]map[string][]string{},
 		},


### PR DESCRIPTION
Ticket [ENG-3945]

### Description Of Changes

PR #8160 added a schema-qualified `resolveDataCategories` function (line 369) to support disambiguating collections that share the same name across datasets. However, the squash-merge of #8267 re-introduced the old unqualified-only copy (line 429), leaving two functions with identical signatures. This breaks `go build` for the policy engine, which in turn breaks the fidesplus Docker build.

### Code Changes

* Removed the duplicate (old, unqualified-only) `resolveDataCategories` function from `policy-engine/pkg/pipeline/pipeline.go`
* The enhanced schema-qualified version (with fallback to unqualified lookup) is retained

### Steps to Confirm

1. Confirm CI Go build passes (currently broken on main due to duplicate function signatures)
2. Confirm existing PBAC/policy-engine tests pass

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [x] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [x] No UX review needed
* Followup issues:
  * [x] No followup issues
* Database migrations:
  * [x] No migrations
* Documentation:
  * [x] No documentation updates required

[ENG-3945]: https://ethyca.atlassian.net/browse/ENG-3945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ