### PR TITLE
ENG-3888: up list cap on experiences property select dropdown

### DIFF
--- a/changelog/8276-fix-properties-picker-cap.yaml
+++ b/changelog/8276-fix-properties-picker-cap.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Fixed the Properties picker in the Privacy Experience editor only showing the first 50 properties
+pr: 8276
+labels: []

--- a/clients/admin-ui/src/features/properties/property.slice.ts
+++ b/clients/admin-ui/src/features/properties/property.slice.ts
@@ -11,7 +11,7 @@ export interface State {
 
 const initialState: State = {
   page: 1,
-  pageSize: 50,
+  pageSize: 300,
 };
 
 interface PropertyParams {


### PR DESCRIPTION
Ticket [ENG-3888] <!-- simply paste the ticket number between the brackets and it will auto-convert to a link -->

### Description Of Changes

Fetches up to 300 properties in the Experience editor (instead of just up to 50)

Companion PR: https://github.com/ethyca/fidesplus/pull/3644
Merging this before that other one would break things because right now the properties GET endpoint caps the `size` query param to 100.


### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [ ] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


[ENG-3888]: https://ethyca.atlassian.net/browse/ENG-3888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ