### PR TITLE
ENG-3971: clean up jest console error noise in admin-ui

### DIFF
--- a/changelog/8277-clean-up-jest-console-noise.yaml
+++ b/changelog/8277-clean-up-jest-console-noise.yaml
@@ -1,4 +1,4 @@
 type: Developer Experience
-description: Cleaned up jest console error noise in admin-ui by fixing the iso-3166 mock, filtering antd-specific props from fidesui mocks in JiraConfigTab tests, and suppressing jsdom-specific warnings that don't indicate real bugs.
+description: Cleaned up jest console error noise in admin-ui.
 pr: 8277
 labels: []

--- a/changelog/8277-clean-up-jest-console-noise.yaml
+++ b/changelog/8277-clean-up-jest-console-noise.yaml
@@ -1,0 +1,4 @@
+type: Developer Experience
+description: Cleaned up jest console error noise in admin-ui by fixing the iso-3166 mock, filtering antd-specific props from fidesui mocks in JiraConfigTab tests, and suppressing jsdom-specific warnings that don't indicate real bugs.
+pr: 8277
+labels: []

--- a/clients/admin-ui/__tests__/jest.setup.ts
+++ b/clients/admin-ui/__tests__/jest.setup.ts
@@ -20,21 +20,23 @@ if (
   NodeList.prototype.includes = Array.prototype.includes;
 }
 
-// nwsapi 2.2.18 + jsdom: when antd v6 stylesheets contain `:has()` selectors,
-// the resolver crashes inside `getComputedStyle` (called by Chakra's
-// color-mode-provider on mount). Wrap `getComputedStyle` so a thrown selector
-// returns an empty CSSStyleDeclaration instead of breaking the render.
+// Wrap `getComputedStyle` for two jsdom limitations:
+//   1. jsdom doesn't implement pseudo-element styles, so any `pseudoElt`
+//      argument triggers a "Not implemented: window.computedStyle(elt,
+//      pseudoElt)" log via its VirtualConsole. @rc-component's scrollbar
+//      measurement passes one, so we drop it (pseudo-element styles aren't
+//      available in jsdom anyway).
+//   2. nwsapi 2.2.18 crashes resolving antd v6's `:has()` selectors, so fall
+//      back to an empty CSSStyleDeclaration when the underlying call throws.
 if (typeof window !== "undefined") {
   const originalGetComputedStyle = window.getComputedStyle.bind(window);
-  window.getComputedStyle = ((
-    elt: Element,
-    pseudoElt?: string | null,
-  ): CSSStyleDeclaration => {
+  window.getComputedStyle = ((elt: Element): CSSStyleDeclaration => {
     try {
-      return originalGetComputedStyle(elt, pseudoElt ?? undefined);
+      return originalGetComputedStyle(elt);
     } catch {
       return {
         getPropertyValue: () => "",
+        length: 0,
       } as unknown as CSSStyleDeclaration;
     }
   }) as typeof window.getComputedStyle;
@@ -60,3 +62,30 @@ if (typeof window !== "undefined") {
 }
 
 installMessageChannelMock();
+
+// Filter console.error output for known noise that doesn't indicate a real bug.
+// React passes its warnings as a format string + substitutions (e.g.
+// `console.error("An update to %s inside a test...", "BaseSelect")`), so we
+// match against the unformatted first argument.
+//   - antd List deprecation warning (no drop-in replacement exists yet)
+//   - rc-trigger's "same shadow root" warning (jsdom doesn't implement shadow DOM)
+//   - `NaN` height from antd-x Sender/Bubble.List measuring DOM that jsdom can't lay out
+//   - React `act()` warnings from async updates in antd Select / next/dynamic /
+//     rc-trigger that fire after the test assertion and can't be reasonably awaited
+const SUPPRESSED_CONSOLE_ERRORS = [
+  "[antd: List] The `List` component is deprecated",
+  "trigger element and popup element should in same shadow root",
+  "`NaN` is an invalid value for the `%s` css style property",
+  "An update to %s inside a test was not wrapped in act",
+];
+
+/* eslint-disable no-console */
+const originalConsoleError = console.error;
+console.error = (...args: unknown[]) => {
+  const message = String(args[0] ?? "");
+  if (SUPPRESSED_CONSOLE_ERRORS.some((pattern) => message.includes(pattern))) {
+    return;
+  }
+  originalConsoleError(...args);
+};
+/* eslint-enable no-console */

--- a/clients/admin-ui/__tests__/utils/iso-3166-mock.ts
+++ b/clients/admin-ui/__tests__/utils/iso-3166-mock.ts
@@ -1,3 +1,5 @@
-export const iso3166 = {
-  esModule: true,
+export const iso3166Mock = {
+  __esModule: true,
+  iso31661: [],
+  iso31662: [],
 };

--- a/clients/admin-ui/package.json
+++ b/clients/admin-ui/package.json
@@ -69,7 +69,7 @@
     "motion": "^12.23.26",
     "narrow-minded": "^1.2.1",
     "next": "^16.2.0",
-    "nuqs": "^2.8.8",
+    "nuqs": "^2.8.9",
     "papaparse": "^5.5.3",
     "query-string": "^9.0.0",
     "react": "^19.2.0",

--- a/clients/admin-ui/src/features/integrations/configure-jira/__tests__/JiraConfigTab.test.tsx
+++ b/clients/admin-ui/src/features/integrations/configure-jira/__tests__/JiraConfigTab.test.tsx
@@ -40,6 +40,8 @@ jest.mock("fidesui", () => ({
     message,
     description,
     action,
+    showIcon: _showIcon,
+    type: _type,
     ...props
   }: Record<string, unknown>) => (
     <div data-testid="alert" {...props}>
@@ -48,8 +50,17 @@ jest.mock("fidesui", () => ({
       {action as React.ReactNode}
     </div>
   ),
-  Button: ({ children, ...props }: Record<string, unknown>) => (
-    <button type="button" {...props}>
+  Button: ({
+    children,
+    htmlType,
+    loading: _loading,
+    ...props
+  }: Record<string, unknown>) => (
+    <button
+      // eslint-disable-next-line react/button-has-type
+      type={(htmlType as "button" | "submit" | "reset" | undefined) ?? "button"}
+      {...props}
+    >
       {children as React.ReactNode}
     </button>
   ),

--- a/clients/admin-ui/tsconfig.json
+++ b/clients/admin-ui/tsconfig.json
@@ -37,8 +37,11 @@
   "include": [
     "next-env.d.ts",
     "app-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
+    "*.ts",
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "__tests__/**/*.ts",
+    "__tests__/**/*.tsx",
     "**/*.d.ts",
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"

--- a/clients/package-lock.json
+++ b/clients/package-lock.json
@@ -58,7 +58,7 @@
         "motion": "^12.23.26",
         "narrow-minded": "^1.2.1",
         "next": "^16.2.0",
-        "nuqs": "^2.8.8",
+        "nuqs": "^2.8.9",
         "papaparse": "^5.5.3",
         "query-string": "^9.0.0",
         "react": "^19.2.0",
@@ -673,6 +673,43 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "admin-ui/node_modules/nuqs": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/nuqs/-/nuqs-2.8.9.tgz",
+      "integrity": "sha512-8ou6AEwsxMWSYo2qkfZtYFVzngwbKmg4c00HVxC1fF6CEJv3Fwm6eoZmfVPALB+vw8Udo7KL5uy96PFcYe1BIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/franky47"
+      },
+      "peerDependencies": {
+        "@remix-run/react": ">=2",
+        "@tanstack/react-router": "^1",
+        "next": ">=14.2.0",
+        "react": ">=18.2.0 || ^19.0.0-0",
+        "react-router": "^5 || ^6 || ^7",
+        "react-router-dom": "^5 || ^6 || ^7"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@tanstack/react-router": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react-router": {
+          "optional": true
+        },
+        "react-router-dom": {
+          "optional": true
+        }
       }
     },
     "admin-ui/node_modules/postcss": {
@@ -6614,7 +6651,6 @@
       "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
       "hasInstallScript": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "detect-libc": "^1.0.3",
         "is-glob": "^4.0.3",
@@ -6655,7 +6691,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -6675,7 +6710,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -6695,7 +6729,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -6715,7 +6748,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -6735,7 +6767,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -6755,7 +6786,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -6775,7 +6805,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -6795,7 +6824,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -6815,7 +6843,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -6835,7 +6862,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -6855,7 +6881,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -6875,7 +6900,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -6895,7 +6919,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -7896,7 +7919,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7910,7 +7932,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7924,7 +7945,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7938,7 +7958,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7952,7 +7971,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7966,7 +7984,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7980,7 +7997,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7994,7 +8010,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8008,7 +8023,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8022,7 +8036,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8036,7 +8049,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8050,7 +8062,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -8063,7 +8074,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8077,7 +8087,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -8090,7 +8099,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8104,7 +8112,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8118,7 +8125,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8132,7 +8138,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8146,7 +8151,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8160,7 +8164,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
@@ -8173,7 +8176,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8187,7 +8189,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8201,7 +8202,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8215,7 +8215,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8229,7 +8228,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14424,7 +14422,6 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
       "optional": true,
-      "peer": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
       },
@@ -14795,7 +14792,6 @@
       "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "prr": "~1.0.1"
       },
@@ -16923,7 +16919,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -17975,7 +17970,6 @@
       "integrity": "sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "bin": {
         "image-size": "bin/image-size.js"
       },
@@ -20415,7 +20409,6 @@
       "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "pify": "^4.0.1",
         "semver": "^5.6.0"
@@ -20430,7 +20423,6 @@
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -20441,7 +20433,6 @@
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "bin": {
         "semver": "bin/semver"
       }
@@ -20452,7 +20443,6 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -22173,7 +22163,6 @@
       "integrity": "sha512-6k0YULvhpw+RoLNiQCRKOl09Rv1dPLr8hHnVjHqdolKwDrdNyk+Hmrthi4lIGPPz3r39dLx0hsF5s40sZ3Us4Q==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "iconv-lite": "^0.6.3",
         "sax": "^1.2.4"
@@ -22191,7 +22180,6 @@
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -22306,8 +22294,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
@@ -22692,43 +22679,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
-      }
-    },
-    "node_modules/nuqs": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/nuqs/-/nuqs-2.8.8.tgz",
-      "integrity": "sha512-LF5sw9nWpHyPWzMMu9oho3r9C5DvkpmBIg4LQN78sexIzGaeRx8DWr0uy3YiFx5i2QGZN1Qqcb+OAtEVRa2bnA==",
-      "license": "MIT",
-      "dependencies": {
-        "@standard-schema/spec": "1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/franky47"
-      },
-      "peerDependencies": {
-        "@remix-run/react": ">=2",
-        "@tanstack/react-router": "^1",
-        "next": ">=14.2.0",
-        "react": ">=18.2.0 || ^19.0.0-0",
-        "react-router": "^5 || ^6 || ^7",
-        "react-router-dom": "^5 || ^6 || ^7"
-      },
-      "peerDependenciesMeta": {
-        "@remix-run/react": {
-          "optional": true
-        },
-        "@tanstack/react-router": {
-          "optional": true
-        },
-        "next": {
-          "optional": true
-        },
-        "react-router": {
-          "optional": true
-        },
-        "react-router-dom": {
-          "optional": true
-        }
       }
     },
     "node_modules/nwsapi": {
@@ -24550,8 +24500,7 @@
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
       "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/psl": {
       "version": "1.15.0",
@@ -26084,8 +26033,7 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
       "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/saxes": {
       "version": "6.0.0",


### PR DESCRIPTION
Ticket [ENG-3971]

### Description Of Changes

The admin-ui jest suite was passing but flooding the console with errors and warnings, making it hard to spot real failures. This PR fixes the real bugs causing some of that noise and suppresses the rest (all jsdom/test-environment limitations that don't indicate product bugs).

After this PR: **1022 passing tests, 0 console errors/warnings**.

### Code Changes

**Real bugs fixed:**
* `clients/admin-ui/__tests__/utils/iso-3166-mock.ts`: the file exported `iso3166` but `jest.setup.ts` imported `iso3166Mock`, so the mock silently resolved to `undefined`. `LocationSelect` then crashed with `Cannot read properties of undefined (reading 'iso31661')`. Fixed the export name and added `iso31661`/`iso31662` array stubs.
* `clients/admin-ui/src/features/integrations/configure-jira/__tests__/JiraConfigTab.test.tsx`: the local `fidesui` mocks were spreading antd-specific props (`showIcon`, `htmlType`, `loading`) onto raw DOM elements, triggering React unknown-prop warnings. Filtered those props out of the mocks.
* `clients/admin-ui/__tests__/jest.setup.ts`: `getComputedStyle` wrapper now drops the unsupported `pseudoElt` argument before calling jsdom (jsdom doesn't implement pseudo-element styles and logs "Not implemented" via VirtualConsole when one is passed; `@rc-component`'s scrollbar measurement was triggering it on every antd Table render).

**Test-environment noise suppressed in `jest.setup.ts`:**
* `[antd: List] The List component is deprecated` — no drop-in replacement exists yet.
* `trigger element and popup element should in same shadow root` — jsdom doesn't implement shadow DOM.
* `` `NaN` is an invalid value for the `height` css style property `` — antd-x Sender/Bubble.List measures DOM that jsdom can't lay out.
* `An update to %s inside a test was not wrapped in act` — async updates from antd `Select`, `next/dynamic`, and `rc-trigger` that fire after the test assertion and can't be reasonably awaited.

### Steps to Confirm

1. `cd clients/admin-ui && npm run test`
2. Output should show `Tests: 6 skipped, 1022 passed, 1028 total` with no `console.error`, `Warning:`, or "Not implemented" lines in the output.

### Pre-Merge Checklist

* [x] Issue requirements met
* [x] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required


[ENG-3971]: https://ethyca.atlassian.net/browse/ENG-3971
