### PR TITLE
ENG-3524: Display checkbox custom fields in request details

### DIFF
--- a/changelog/8278-display-checkbox-custom-fields-in-request-details.yaml
+++ b/changelog/8278-display-checkbox-custom-fields-in-request-details.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Fixed display of checkbox and boolean custom fields in privacy request details, which were previously filtered out or not formatted correctly
+pr: 8278
+labels: []

--- a/clients/admin-ui/src/features/privacy-requests/RequestCustomFields.tsx
+++ b/clients/admin-ui/src/features/privacy-requests/RequestCustomFields.tsx
@@ -9,6 +9,26 @@ type RequestCustomFieldsProps = {
   subjectRequest: PrivacyRequestEntity;
 };
 
+const formatFieldValue = (value: unknown): string => {
+  if (typeof value === "boolean") {
+    return value ? "Yes" : "No";
+  }
+  if (Array.isArray(value)) {
+    return value.join(", ");
+  }
+  return formatIsoDate(value);
+};
+
+const hasValue = (value: unknown): boolean => {
+  if (typeof value === "boolean") {
+    return true;
+  }
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+  return value !== null && value !== undefined && value !== "" && value !== 0;
+};
+
 const RequestCustomFields = ({ subjectRequest }: RequestCustomFieldsProps) => {
   const { custom_privacy_request_fields: customPrivacyRequestFields } =
     subjectRequest;
@@ -18,14 +38,10 @@ const RequestCustomFields = ({ subjectRequest }: RequestCustomFieldsProps) => {
       {customPrivacyRequestFields &&
         Object.keys(customPrivacyRequestFields).length > 0 &&
         Object.entries(customPrivacyRequestFields)
-          .filter(([, item]) => item.value)
+          .filter(([, item]) => hasValue(item.value))
           .map(([key, item]) => (
             <RequestDetailsRow label={item.label} key={key}>
-              <Typography.Text>
-                {Array.isArray(item.value)
-                  ? item.value.join(", ")
-                  : formatIsoDate(item.value)}
-              </Typography.Text>
+              <Typography.Text>{formatFieldValue(item.value)}</Typography.Text>
             </RequestDetailsRow>
           ))}
     </div>


### PR DESCRIPTION
Ticket [ENG-3524]

### Description Of Changes

Boolean and checkbox custom fields from privacy center forms were not displaying correctly in the privacy request details view. Boolean `false` values and empty arrays were being filtered out entirely, and boolean values were not formatted in a human-readable way.

This PR adds proper handling for these field types by:
- Introducing a `hasValue` helper that correctly treats boolean `false` as a valid value (rather than filtering it out)
- Introducing a `formatFieldValue` helper that renders booleans as "Yes"/"No" and joins array values with commas
- Replacing the inline formatting logic with these dedicated helpers

### Code Changes

* Added `formatFieldValue` utility function to handle boolean, array, and date value formatting in `RequestCustomFields.tsx`
* Added `hasValue` utility function that correctly identifies valid values including boolean `false` and non-empty arrays
* Updated the filter and display logic in `RequestCustomFields` to use the new helpers

### Steps to Confirm

1. Configure a privacy center form with checkbox and boolean custom fields
2. Submit a privacy request filling in those fields (including setting some to `false`)
3. View the privacy request details in the admin UI
4. Confirm that boolean fields display as "Yes" or "No"
5. Confirm that checkbox (array) fields display as comma-separated values
6. Confirm that fields with `false` values are not filtered out

### Pre-Merge Checklist

* [x] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [x] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [x] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [x] No documentation updates required

[ENG-3524]: https://ethyca.atlassian.net/browse/ENG-3524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ