### PR TITLE
Update CHANGELOG for 2.86.1 patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,16 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 - https://github.com/ethyca/fides/labels/high-risk: to indicate that a change is a "high-risk" change that could potentially lead to unanticipated regressions or degradations
 - https://github.com/ethyca/fides/labels/db-migration: to indicate that a given change includes a DB migration
 
-## [Unreleased](https://github.com/ethyca/fides/compare/2.86.0..main)
+## [Unreleased](https://github.com/ethyca/fides/compare/2.86.1..main)
+
+## [2.86.1](https://github.com/ethyca/fides/compare/2.86.0..2.86.1)
+
+### Fixed
+- Fixed stuck DSRs when async task ConnectionConfig is deleted or disabled [#8211](https://github.com/ethyca/fides/pull/8211)
+- Fixed property form paths not saving and actions not working during property creation [#8271](https://github.com/ethyca/fides/pull/8271)
+- Fixed "Download troubleshooting data" feature to stream diagnostics ZIP directly instead of uploading to storage, eliminating storage configuration dependency and reliability issues [#8254](https://github.com/ethyca/fides/pull/8254)
+- Fixed watchdog incorrectly erroring privacy requests paused for manual webhook or manual task input, and fixed connection config updates incorrectly requeuing manual task DSRs [#8264](https://github.com/ethyca/fides/pull/8264)
+- Fixed permanently stuck privacy requests when erasure task creation fails silently by recreating missing erasure tasks from the current graph on retry [#8268](https://github.com/ethyca/fides/pull/8268)
 
 ## [2.86.0](https://github.com/ethyca/fides/compare/2.85.1..2.86.0)
 

--- a/changelog/8211-fix-stuck-dsrs-orphaned-async-tasks.yaml
+++ b/changelog/8211-fix-stuck-dsrs-orphaned-async-tasks.yaml
@@ -1,4 +1,0 @@
-type: Fixed
-description: Fixed stuck DSRs when async task ConnectionConfig is deleted or disabled
-pr: 8211
-labels: []

--- a/changelog/8254-stream-dsr-diagnostics-zip.yaml
+++ b/changelog/8254-stream-dsr-diagnostics-zip.yaml
@@ -1,3 +1,0 @@
-type: Fixed
-description: Fixed "Download troubleshooting data" feature to stream diagnostics ZIP directly instead of uploading to storage, eliminating storage configuration dependency and reliability issues
-pr: 8254

--- a/changelog/8264-fix-requires-input-watchdog-guard.yaml
+++ b/changelog/8264-fix-requires-input-watchdog-guard.yaml
@@ -1,4 +1,0 @@
-type: Fixed
-description: Fixed watchdog incorrectly erroring privacy requests paused for manual webhook or manual task input, and fixed connection config updates incorrectly requeuing manual task DSRs
-pr: 8264
-labels: []

--- a/changelog/8268-recreate-missing-erasure-tasks.yaml
+++ b/changelog/8268-recreate-missing-erasure-tasks.yaml
@@ -1,4 +1,0 @@
-type: Fixed
-description: Fixed permanently stuck privacy requests when erasure task creation fails silently by recreating missing erasure tasks from the current graph on retry
-pr: 8268
-labels: []


### PR DESCRIPTION
## Summary
- Compiles changelog entries for the 2.86.1 patch release
- Includes PRs: #8211, #8254, #8264, #8268, #8271

## PRs in this release
- ENG-3950: Recreate missing erasure tasks on retry (#8268)
- ENG-3834: Fix stuck DSRs caused by deleted or misconfigured integrations (#8211)
- ENG-3687: Fix Watchdog incorrectly marking privacy requests as error (#8264)
- ENG-3926: Stream diagnostics ZIP directly instead of uploading to storage (#8254)
- ENG-3953: Fix property form paths not saving and actions during create (#8271)