### PR TITLE
Fix identity field validation schema to prevent field conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,6 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.86.1..main)
 
-### Fixed
-- Fixed custom privacy request fields named "phone" or "email" incorrectly receiving E.164/email format validation when those identity inputs were not configured; also improved phone validation error message to specify expected format [#8282](https://github.com/ethyca/fides/pull/8282)
-
 ## [2.86.1](https://github.com/ethyca/fides/compare/2.86.0..2.86.1)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.86.1..main)
 
+### Fixed
+- Fixed custom privacy request fields named "phone" or "email" incorrectly receiving E.164/email format validation when those identity inputs were not configured; also improved phone validation error message to specify expected format [#8282](https://github.com/ethyca/fides/pull/8282)
+
 ## [2.86.1](https://github.com/ethyca/fides/compare/2.86.0..2.86.1)
 
 ### Fixed

--- a/changelog/8282-fix-phone-validation-custom-fields.yaml
+++ b/changelog/8282-fix-phone-validation-custom-fields.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Fixed custom privacy request fields named "phone" or "email" incorrectly receiving E.164/email format validation when those identity inputs were not configured; also improved phone validation error message to specify expected format
+pr: 8282
+labels: []

--- a/clients/admin-ui/src/features/privacy-requests/form/helpers.ts
+++ b/clients/admin-ui/src/features/privacy-requests/form/helpers.ts
@@ -35,7 +35,7 @@ export const generateFormRulesFromAction = (
 
   const phonePattern = /^\+?[1-9]\d{1,14}$/;
   const phoneMessage =
-    "Phone number must be formatted correctly (e.g. 15555555555)";
+    "Phone must be in E.164 format (e.g. +15551234567 or 15551234567)";
 
   if (action.identity_inputs?.phone === "required") {
     rules["identity.phone_number"] = [

--- a/clients/privacy-center/components/modals/consent-request-modal/useConsentRequestForm.ts
+++ b/clients/privacy-center/components/modals/consent-request-modal/useConsentRequestForm.ts
@@ -64,33 +64,42 @@ const useConsentRequestForm = ({
 
   const initialValues = useMemo(() => getInitialValues(), [getInitialValues]);
 
-  // Build the static portion of the validation schema (identity fields)
-  const identityValidationSchema = useMemo(
-    () =>
-      Yup.object().shape({
-        email: emailValidation(identityInputs?.email!).test(
-          "one of email or phone entered",
-          "You must enter an email",
-          (_value, context) => {
-            if (identityInputs?.email === "required") {
-              return Boolean(context.parent.email);
-            }
-            return true;
-          },
-        ),
-        phone: phoneValidation(identityInputs?.phone!).test(
-          "one of email or phone entered",
-          "You must enter a phone number",
-          (_value, context) => {
-            if (identityInputs?.phone === "required") {
-              return Boolean(context.parent.phone);
-            }
-            return true;
-          },
-        ),
-      }),
-    [identityInputs?.email, identityInputs?.phone],
-  );
+  // Build the static portion of the validation schema (identity fields).
+  // Only include validation rules for identity fields that are actually configured,
+  // to avoid conflicts with custom_privacy_request_fields that may use the same keys.
+  const identityValidationSchema = useMemo(() => {
+    const schemaFields: Record<string, Yup.StringSchema> = {};
+
+    // Only add email validation if email is configured in identity_inputs
+    if (identityInputs?.email) {
+      schemaFields.email = emailValidation(identityInputs.email).test(
+        "one of email or phone entered",
+        "You must enter an email",
+        (_value, context) => {
+          if (identityInputs.email === "required") {
+            return Boolean(context.parent.email);
+          }
+          return true;
+        },
+      );
+    }
+
+    // Only add phone validation if phone is configured in identity_inputs
+    if (identityInputs?.phone) {
+      schemaFields.phone = phoneValidation(identityInputs.phone).test(
+        "one of email or phone entered",
+        "You must enter a phone number",
+        (_value, context) => {
+          if (identityInputs.phone === "required") {
+            return Boolean(context.parent.phone);
+          }
+          return true;
+        },
+      );
+    }
+
+    return Yup.object().shape(schemaFields);
+  }, [identityInputs?.email, identityInputs?.phone]);
 
   const { validate, applicableFieldsRef, validationError } =
     useConditionalValidate({

--- a/clients/privacy-center/components/modals/privacy-request-modal/usePrivacyRequestForm.ts
+++ b/clients/privacy-center/components/modals/privacy-request-modal/usePrivacyRequestForm.ts
@@ -108,54 +108,63 @@ const usePrivacyRequestForm = ({
 
   const initialValues = useMemo(() => getInitialValues(), [getInitialValues]);
 
-  // Build the static portion of the validation schema (identity fields)
-  const identityValidationSchema = useMemo(
-    () =>
-      Yup.object().shape({
-        name: nameValidation(nameInput),
-        email: emailValidation(emailInput).test(
-          "one of email or phone entered",
-          "You must enter either email or phone",
-          (_value, context) => {
-            if (emailInput === "optional" && phoneInput === "optional") {
-              return Boolean(context.parent.phone || context.parent.email);
-            }
-            return true;
-          },
-        ),
-        phone: phoneValidation(phoneInput).test(
-          "one of email or phone entered",
-          "You must enter either email or phone",
-          (_value, context) => {
-            if (emailInput === "optional" && phoneInput === "optional") {
-              return Boolean(context.parent.phone || context.parent.email);
-            }
-            return true;
-          },
-        ),
-        ...Object.fromEntries(
-          Object.entries(customIdentityFields).flatMap(([key, value]) => {
-            if (!value) {
-              return [];
-            }
-            if (value.field_type === "date") {
-              return [
-                [
-                  key,
-                  dateFieldValidation(
-                    value,
-                    value.label,
-                    value.required !== false,
-                  ),
-                ],
-              ];
-            }
-            return [[key, Yup.string().required(`${value.label} is required`)]];
-          }),
-        ),
-      }),
-    [emailInput, phoneInput, nameInput, customIdentityFields],
-  );
+  // Build the static portion of the validation schema (identity fields).
+  // Only include validation rules for identity fields that are actually configured,
+  // to avoid conflicts with custom_privacy_request_fields that may use the same keys.
+  const identityValidationSchema = useMemo(() => {
+    const schemaFields: Record<string, Yup.StringSchema> = {};
+
+    // Only add name validation if name is configured in identity_inputs
+    if (nameInput) {
+      schemaFields.name = nameValidation(nameInput);
+    }
+
+    // Only add email validation if email is configured in identity_inputs
+    if (emailInput) {
+      schemaFields.email = emailValidation(emailInput).test(
+        "one of email or phone entered",
+        "You must enter either email or phone",
+        (_value, context) => {
+          if (emailInput === "optional" && phoneInput === "optional") {
+            return Boolean(context.parent.phone || context.parent.email);
+          }
+          return true;
+        },
+      );
+    }
+
+    // Only add phone validation if phone is configured in identity_inputs
+    if (phoneInput) {
+      schemaFields.phone = phoneValidation(phoneInput).test(
+        "one of email or phone entered",
+        "You must enter either email or phone",
+        (_value, context) => {
+          if (emailInput === "optional" && phoneInput === "optional") {
+            return Boolean(context.parent.phone || context.parent.email);
+          }
+          return true;
+        },
+      );
+    }
+
+    // Add custom identity field validations
+    Object.entries(customIdentityFields).forEach(([key, value]) => {
+      if (!value) {
+        return;
+      }
+      if (value.field_type === "date") {
+        schemaFields[key] = dateFieldValidation(
+          value,
+          value.label,
+          value.required !== false,
+        );
+      } else {
+        schemaFields[key] = Yup.string().required(`${value.label} is required`);
+      }
+    });
+
+    return Yup.object().shape(schemaFields);
+  }, [emailInput, phoneInput, nameInput, customIdentityFields]);
 
   const { validate, applicableFieldsRef, validationError } =
     useConditionalValidate({

--- a/clients/privacy-center/components/modals/validation.ts
+++ b/clients/privacy-center/components/modals/validation.ts
@@ -53,7 +53,7 @@ export const emailValidation = (option?: string | null) => {
 export const phoneValidation = (option?: string | null) => {
   // E.164 international standard format
   let validation = Yup.string().matches(/^\+[1-9]\d{1,14}$/, {
-    message: "Phone is invalid",
+    message: "Phone must be in E.164 format (e.g. +15551234567)",
     excludeEmptyString: true,
   });
   if (option === "required") {


### PR DESCRIPTION
Ticket [<issue>]

### Description Of Changes

This PR fixes a validation schema issue where identity fields (name, email, phone) were always included in the Yup validation schema, even when not configured in `identity_inputs`. This caused conflicts when custom privacy request fields used the same field names.

The changes ensure that validation rules are only added for identity fields that are actually configured, preventing validation conflicts with custom fields that may share the same keys.

Additionally, phone number validation error messages have been improved to be more descriptive and consistent across the codebase, clarifying the E.164 format requirement.

### Code Changes

* **Privacy Request Modal** (`usePrivacyRequestForm.ts`): Refactored `identityValidationSchema` to conditionally include validation rules only for configured identity fields (name, email, phone)
* **Consent Request Modal** (`useConsentRequestForm.ts`): Applied the same conditional validation schema pattern for email and phone fields
* **Admin UI Form Helpers** (`helpers.ts`): Updated phone validation error message to clarify E.164 format requirement
* **Privacy Center Validation** (`validation.ts`): Updated phone validation error message to be more descriptive and consistent

### Steps to Confirm

1. Test privacy request forms with custom fields that share names with identity fields (e.g., a custom "email" field)
2. Verify that validation works correctly when identity fields are optional or not configured
3. Confirm phone number validation error messages display the improved format guidance
4. Ensure existing privacy request and consent request flows continue to work as expected

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [ ] `CHANGELOG.md` updated
* [ ] No UX review needed
* [ ] No followup issues
* [ ] No migrations
* [ ] No documentation updates required

https://claude.ai/code/session_017HuVbasMgn5gdt7kUXxLDD