### PR TITLE
fix(admin-ui): surface custom report delete failures instead of reporting success

### DIFF
--- a/changelog/fix-custom-report-delete-error-handling.yaml
+++ b/changelog/fix-custom-report-delete-error-handling.yaml
@@ -1,4 +1,4 @@
 type: Fixed
 description: Fixed custom report deletion silently reporting success when the delete request failed, and clearing the applied report before the delete completed
-pr: 0 # TODO: replace with the PR number once opened
+pr: 8287
 labels: []

--- a/changelog/fix-custom-report-delete-error-handling.yaml
+++ b/changelog/fix-custom-report-delete-error-handling.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Fixed custom report deletion silently reporting success when the delete request failed, and clearing the applied report before the delete completed
+pr: 0 # TODO: replace with the PR number once opened
+labels: []

--- a/clients/admin-ui/cypress/e2e/datamap-report.cy.ts
+++ b/clients/admin-ui/cypress/e2e/datamap-report.cy.ts
@@ -638,6 +638,26 @@ describe("Data map report table", () => {
         .its("request.url")
         .should("include", "1234");
     });
+    it("should surface an error and keep the report when deletion fails", () => {
+      cy.intercept("DELETE", "/api/v1/plus/custom-report/*", {
+        statusCode: 500,
+        body: "Internal Server Error",
+      }).as("deleteCustomReportError");
+      cy.getByTestId("custom-reports-trigger").click();
+      cy.wait("@getCustomReportsMinimal");
+      cy.getByTestId("custom-reports-popover").within(() => {
+        cy.getByTestId("delete-report-button").first().click();
+      });
+      cy.getAntModalConfirmButtons().should("be.visible");
+      cy.getAntModalConfirmButtons().find(".ant-btn-dangerous").click();
+      cy.wait("@deleteCustomReportError");
+      // The failure is surfaced and nothing is silently cleared.
+      cy.shouldShowMessage("error");
+      cy.get(".ant-message-success").should("not.exist");
+      cy.getByTestId("custom-reports-popover").within(() => {
+        cy.getByTestId("custom-report-item").should("have.length", 2);
+      });
+    });
   });
 
   describe("Exporting", () => {

--- a/clients/admin-ui/src/features/common/custom-reports/CustomReportTemplates.tsx
+++ b/clients/admin-ui/src/features/common/custom-reports/CustomReportTemplates.tsx
@@ -16,7 +16,7 @@ import {
 } from "fidesui";
 import { useEffect, useMemo, useState } from "react";
 
-import { getErrorMessage } from "~/features/common/helpers";
+import { getErrorMessage, isErrorResult } from "~/features/common/helpers";
 import { useHasPermission } from "~/features/common/Restrict";
 import {
   CustomReportResponse,
@@ -144,11 +144,22 @@ export const CustomReportTemplates = ({
   };
 
   const handleDeleteReport = async (id: string) => {
+    const result = await deleteCustomReportMutationTrigger(id);
+    if (isErrorResult(result)) {
+      message.error(
+        getErrorMessage(
+          result.error,
+          `A problem occurred while deleting the ${CUSTOM_REPORT_TITLE.toLowerCase()}.`,
+        ),
+      );
+      return;
+    }
+    // Only clear the applied report once the delete has actually succeeded.
     if (id === fetchedReport?.id) {
       handleReset();
       onSavedReportDeleted();
     }
-    deleteCustomReportMutationTrigger(id);
+    message.success(`${CUSTOM_REPORT_TITLE} deleted successfully.`);
   };
 
   const onDelete = (report: CustomReportResponseMinimal) => {


### PR DESCRIPTION
### Description Of Changes

In the Data Map report's **Custom Reports** popover, deleting a report calls the delete mutation without awaiting or checking its result, and clears the currently-applied report *before* the request resolves (`CustomReportTemplates.tsx` `handleDeleteReport`).

If the `DELETE` fails, the UI shows no error, the applied report/view is wiped, and a success-looking outcome is presented — yet the report still exists on the server (the list and trigger label only refresh on a successful, tag-invalidating mutation), so it silently reappears on reload.

This PR awaits the mutation, surfaces an error on failure (matching the sibling `handleSelection`), and only clears the applied report once the delete actually succeeds.

### Code Changes

- `clients/admin-ui/src/features/common/custom-reports/CustomReportTemplates.tsx`: `handleDeleteReport` now awaits `deleteCustomReportMutationTrigger`, shows `message.error` (via `getErrorMessage`) on failure and returns early, clears the applied report only after a successful delete, and shows a success message.
- `clients/admin-ui/cypress/e2e/datamap-report.cy.ts`: added a test asserting that a failed delete surfaces an error and keeps the report (the failure path was previously untested).
- `changelog/fix-custom-report-delete-error-handling.yaml`: added.

### Steps to Confirm

1. Data Map report → **Custom Reports** popover; apply a saved report.
2. Force the delete to fail (e.g. block/500 `*/api/v1/plus/custom-report/*`).
3. Delete the applied report → an error message is shown; the applied view is preserved; the report remains listed.
4. Without the block, delete succeeds → success message and the report is removed.

### Pre-Merge Checklist

- [x] Changelog fragment added
- [x] No migrations
- [x] No documentation updates required
- [ ] CI pipelines succeeded
- [ ] CLA signed