### PR TITLE
fix(privacy-center): avoid blank consent page when privacy experience is unavailable

### DIFF
--- a/changelog/fix-consent-page-blank-when-experience-unavailable.yaml
+++ b/changelog/fix-consent-page-blank-when-experience-unavailable.yaml
@@ -1,4 +1,4 @@
 type: Fixed
 description: Fixed the Privacy Center consent page rendering a blank screen in notice-driven mode when a privacy experience could not be resolved; it now shows a loading state while resolving and a message when the experience is unavailable
-pr: 0 # TODO: replace with the PR number once opened
+pr: 8288
 labels: []

--- a/changelog/fix-consent-page-blank-when-experience-unavailable.yaml
+++ b/changelog/fix-consent-page-blank-when-experience-unavailable.yaml
@@ -1,0 +1,4 @@
+type: Fixed
+description: Fixed the Privacy Center consent page rendering a blank screen in notice-driven mode when a privacy experience could not be resolved; it now shows a loading state while resolving and a message when the experience is unavailable
+pr: 0 # TODO: replace with the PR number once opened
+labels: []

--- a/clients/privacy-center/components/ConsentPage.tsx
+++ b/clients/privacy-center/components/ConsentPage.tsx
@@ -11,7 +11,12 @@ import {
   saveFidesCookie,
   setupI18n,
 } from "fides-js";
-import { ChakraStack as Stack, useChakraToast as useToast } from "fidesui";
+import {
+  ChakraSpinner as Spinner,
+  ChakraStack as Stack,
+  ChakraText as Text,
+  useChakraToast as useToast,
+} from "fidesui";
 import type { NextPage } from "next";
 import { useRouter } from "next/navigation";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
@@ -62,7 +67,8 @@ const ConsentPage: NextPage = () => {
     [config],
   );
   const { setI18nInstance } = useI18n();
-  useSubscribeToPrivacyExperienceQuery();
+  const { isLoading: isExperienceLoading } =
+    useSubscribeToPrivacyExperienceQuery();
 
   const getIdVerificationConfigQueryResult = useGetIdVerificationConfigQuery();
   const [
@@ -269,18 +275,10 @@ const ConsentPage: NextPage = () => {
     setIsI18nInitialized(true);
   }, [experience, setI18nInstance, isConfigDrivenConsent]);
 
-  return (
-    <Stack
-      as="main"
-      align="center"
-      data-testid="consent"
-      className="pc-page pc-page--consent pc-consent"
-    >
-      <ClientMetadata title="Privacy Center" icon={config.favicon_path} />
-
-      {/* Wait until i18n is initalized so we can diplay the correct language and
-       also we can use the correct history ids */}
-      {isI18nInitialized && (
+  const renderConsentBody = () => {
+    // i18n ready: render the consent UI.
+    if (isI18nInitialized) {
+      return (
         <Stack
           align="center"
           py={["6", "16"]}
@@ -295,7 +293,50 @@ const ConsentPage: NextPage = () => {
           {consentContext.globalPrivacyControl ? <GpcBanner /> : null}
           <ConsentToggles storePreferences={storeConsentPreferences} />
         </Stack>
-      )}
+      );
+    }
+    // Still resolving geolocation / privacy experience: show a loading state.
+    if (isExperienceLoading) {
+      return (
+        <Stack align="center" py={["6", "16"]} data-testid="consent-loading">
+          <Spinner />
+        </Stack>
+      );
+    }
+    // Notice-driven consent could not resolve a privacy experience (e.g. no
+    // region available). Surface a message instead of rendering a blank page.
+    if (!isConfigDrivenConsent && !experience) {
+      return (
+        <Stack
+          align="center"
+          py={["6", "16"]}
+          maxWidth="720px"
+          px={[4, 6, 0]}
+          data-testid="consent-unavailable"
+        >
+          <Text textAlign="center">
+            We&apos;re unable to load your consent settings right now. Please
+            refresh the page or try again later.
+          </Text>
+        </Stack>
+      );
+    }
+    return null;
+  };
+
+  return (
+    <Stack
+      as="main"
+      align="center"
+      data-testid="consent"
+      className="pc-page pc-page--consent pc-consent"
+    >
+      <ClientMetadata title="Privacy Center" icon={config.favicon_path} />
+
+      {/* Wait until i18n is initialized so we display the correct language and
+       use the correct history ids; otherwise show a loading or unavailable
+       state so the page is never silently blank. */}
+      {renderConsentBody()}
     </Stack>
   );
 };

--- a/clients/privacy-center/features/consent/hooks.ts
+++ b/clients/privacy-center/features/consent/hooks.ts
@@ -35,7 +35,7 @@ export const useSubscribeToPrivacyExperienceQuery = () => {
     !GEOLOCATION_API_URL ||
     !!region;
 
-  useGetUserGeolocationQuery(GEOLOCATION_API_URL, {
+  const geolocationQuery = useGetUserGeolocationQuery(GEOLOCATION_API_URL, {
     skip: skipFetchGeolocation,
   });
 
@@ -45,7 +45,19 @@ export const useSubscribeToPrivacyExperienceQuery = () => {
     region: region as PrivacyNoticeRegion,
     property_id: propertyId,
   };
-  useGetPrivacyExperienceQuery(params, {
+  const experienceQuery = useGetPrivacyExperienceQuery(params, {
     skip: !region || skipFetchExperience,
   });
+
+  // True while geolocation or the privacy experience is still being resolved.
+  // Lets consumers render a loading state instead of a blank page until the
+  // experience is known (or known to be unavailable).
+  const isLoading =
+    (!skipFetchGeolocation &&
+      (geolocationQuery.isLoading || geolocationQuery.isFetching)) ||
+    (!!region &&
+      !skipFetchExperience &&
+      (experienceQuery.isLoading || experienceQuery.isFetching));
+
+  return { isLoading };
 };


### PR DESCRIPTION
### Description Of Changes

In the Privacy Center, notice-driven consent (`IS_OVERLAY_ENABLED=true`) gates the entire `ConsentPage` body on `isI18nInitialized`, which is only set once a privacy experience resolves (`components/ConsentPage.tsx`). When an experience can't be resolved, the page renders a **permanently blank `<main>`** — no spinner, no error.

This is reachable with default settings: `IS_GEOLOCATION_ENABLED` defaults to `false`, and `selectUserRegion` returns `undefined` when geolocation is off (`features/consent/consent.slice.ts`), so the experience query is skipped (`features/consent/hooks.ts`) and `experience` stays `undefined` forever. It also covers the case where the experience request fails. (Config-driven consent initializes i18n synchronously and is unaffected.)

This PR is defensive and changes no working behavior: it surfaces a loading state while resolving, and a clear message when notice-driven consent cannot resolve an experience.

### Code Changes

- `features/consent/hooks.ts`: `useSubscribeToPrivacyExperienceQuery` now returns `{ isLoading }`, derived from the geolocation and privacy-experience query states (additive; existing callers are unaffected).
- `components/ConsentPage.tsx`: render a spinner while the experience is resolving and a fallback message when notice-driven consent has no experience, instead of an empty page. Config-driven path unchanged.

### Steps to Confirm

1. Privacy Center with `IS_OVERLAY_ENABLED=true` and `IS_GEOLOCATION_ENABLED=false`.
2. Navigate to the consent page.
3. Before: blank page (empty `<main>`, no spinner/error). After: a loading spinner, then a message that consent settings can't be loaded.
4. Config-driven consent (`IS_OVERLAY_ENABLED=false`) renders the consent UI exactly as before.

### Pre-Merge Checklist

- [x] Changelog fragment added
- [x] No migrations
- [x] No documentation updates required
- [ ] CI pipelines succeeded
- [ ] CLA signed