### PR TITLE
Initial support for IAB TCF Policy v5.0.b / GVL spec v4 (feature standard texts) [DRAFT]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Changes can also be flagged with a GitHub label for tracking purposes. The URL o
 
 ## [Unreleased](https://github.com/ethyca/fides/compare/2.86.2..main)
 
+### Added
+- Initial support for IAB TCF Policy v5.0.b / GVL specification version 4 (feature standard explanation texts)
+
 ## [2.86.2](https://github.com/ethyca/fides/compare/2.86.1..2.86.2)
 
 ### Changed

--- a/clients/fides-js/__tests__/__fixtures__/mock_gvl_translations.json
+++ b/clients/fides-js/__tests__/__fixtures__/mock_gvl_translations.json
@@ -139,7 +139,10 @@
         "id": 3,
         "name": "Identify devices based on information transmitted automatically",
         "description": "Your device might be distinguished from other devices based on information it automatically sends when accessing the Internet (for instance, the IP address of your Internet connection or the type of browser you are using) in support of the purposes exposed in this notice.",
-        "illustrations": []
+        "illustrations": [
+          "Example illustration: your browser's IP address and user-agent string are read to distinguish your device."
+        ],
+        "standardTexts": "We and our technology partners may identify your device based on information it transmits automatically in support of the purposes explained in this notice."
       }
     },
     "specialFeatures": {

--- a/clients/fides-js/__tests__/lib/i18n/i18n-utils.test.ts
+++ b/clients/fides-js/__tests__/lib/i18n/i18n-utils.test.ts
@@ -370,6 +370,10 @@ describe("i18n-utils", () => {
           // Example feature
           "exp.tcf.features.3.name": /^Identify devices based on information/,
           "exp.tcf.features.3.description": /^Your device might be /,
+          // Feature illustrations & standard-explanation text (GVL spec v4)
+          "exp.tcf.features.3.illustrations.0": /^Example illustration/,
+          "exp.tcf.features.3.standard_texts":
+            /^We and our technology partners/,
           // Example special feature
           "exp.tcf.specialFeatures.1.name": /^Use precise geolocation data/,
           "exp.tcf.specialFeatures.1.description": /^With your acceptance/,

--- a/clients/fides-js/src/components/tcf/TcfFeatures.tsx
+++ b/clients/fides-js/src/components/tcf/TcfFeatures.tsx
@@ -1,5 +1,6 @@
 import { PrivacyExperience } from "../../lib/consent-types";
 import { FidesEventDetailsPreference } from "../../lib/events";
+import { messageExists } from "../../lib/i18n";
 import { useI18n } from "../../lib/i18n/i18n-context";
 import {
   EnabledIds,
@@ -15,15 +16,31 @@ const FeatureChildren = ({
   feature,
 }: {
   type: RecordListType;
-  feature: TCFFeatureRecord;
+  feature: TCFFeatureRecord | TCFSpecialFeatureRecord;
 }) => {
   const { i18n } = useI18n();
   const vendors = [...(feature.vendors || []), ...(feature.systems || [])];
+  // The standard feature-explanation text and illustrations were introduced
+  // with IAB TCF Policy v5.0.b / GVL specification version 4. They are rendered
+  // only when present, mirroring how purpose illustrations are handled, so
+  // older GVL specification versions render exactly as before.
+  const standardTextKey = `exp.tcf.${type}.${feature.id}.standard_texts`;
   return (
     <div>
       <p className="fides-tcf-toggle-content">
         {i18n.t(`exp.tcf.${type}.${feature.id}.description`)}
       </p>
+      {(feature.illustrations || []).map((illustration, i) => (
+        <p
+          key={illustration}
+          className="fides-tcf-illustration fides-background-dark"
+        >
+          {i18n.t(`exp.tcf.${type}.${feature.id}.illustrations.${i}`)}
+        </p>
+      ))}
+      {messageExists(i18n, standardTextKey) && (
+        <p className="fides-tcf-toggle-content">{i18n.t(standardTextKey)}</p>
+      )}
       <EmbeddedVendorList vendors={vendors} />
     </div>
   );

--- a/clients/fides-js/src/lib/i18n/i18n-utils.ts
+++ b/clients/fides-js/src/lib/i18n/i18n-utils.ts
@@ -205,6 +205,13 @@ function extractMessagesFromGVLTranslations(
               messages[`${prefix}.illustrations.${i}`] = illustration;
             });
           }
+          // Introduced with IAB TCF Policy v5.0.b / GVL specification version 4:
+          // Features (and special features) may carry a standard
+          // feature-explanation text. Guarded so absent fields are a no-op for
+          // older GVL specification versions.
+          if (record.standardTexts) {
+            messages[`${prefix}.standard_texts`] = record.standardTexts;
+          }
         });
       });
 

--- a/clients/fides-js/src/lib/tcf/types.ts
+++ b/clients/fides-js/src/lib/tcf/types.ts
@@ -98,6 +98,12 @@ export type TCFFeatureRecord = {
   id: number;
   name: string;
   description: string;
+  // Optional, introduced with IAB TCF Policy v5.0.b / GVL specification version
+  // 4. Features can now carry "illustrations" (mirroring purposes) and a
+  // standard feature-explanation text. These are optional and render-if-present
+  // so older GVL specification versions (which omit them) remain unaffected.
+  illustrations?: Array<string>;
+  standard_texts?: string;
   vendors?: Array<EmbeddedVendor>;
   systems?: Array<EmbeddedVendor>;
 };
@@ -112,6 +118,11 @@ export type TCFSpecialFeatureRecord = {
   id: number;
   name: string;
   description: string;
+  // Optional, introduced with IAB TCF Policy v5.0.b / GVL specification version
+  // 4. See TCFFeatureRecord above for details. Render-if-present and safe to
+  // omit for older GVL specification versions.
+  illustrations?: Array<string>;
+  standard_texts?: string;
   default_preference?: UserConsentPreference;
   current_preference?: UserConsentPreference; // NOTE: added on the client-side
   vendors?: Array<EmbeddedVendor>;


### PR DESCRIPTION
Ticket [ ]

### Description Of Changes

Draft to begin supporting the IAB Europe / IAB Tech Lab **TCF Policy v5.0.b**, which bumps the Global Vendor List to **`gvlSpecificationVersion` 4**. That update adds a `standardTexts` object and feature "illustrations" to the GVL and its translations, and requires CMPs to display a **standard feature-explanation text** for each Feature in the consent UI (web-environment compliance deadline ~mid-October 2026). This is *not* a TC-string binary-format change, so TC-string encoding/decoding is untouched.

Opening as a **draft** so the team can review scope and the follow-up decisions below before this is finalized.

All changes are additive, backward-compatible, and render-if-present.

Requested via Slack: https://ethyca.slack.com/archives/C0A77N4PSKW/p1784297786610569?thread_ts=1784211321.982189&cid=C0A77N4PSKW

### Code Changes

* `clients/fides-js/src/lib/tcf/types.ts` — added optional `illustrations?` and `standard_texts?` to `TCFFeatureRecord` and `TCFSpecialFeatureRecord`.
* `clients/fides-js/src/lib/i18n/i18n-utils.ts` — flatten a feature translation's `standardTexts` into an `exp.tcf.<type>.<id>.standard_texts` i18n message (guarded); feature illustrations already flow through the existing illustrations handling.
* `clients/fides-js/src/components/tcf/TcfFeatures.tsx` — `FeatureChildren` now renders feature illustrations and the standard explanation text when present (mirrors how `TcfPurposes.tsx` renders purpose illustrations); renders nothing new when the fields/messages are absent.
* Fixture + test: added `illustrations`/`standardTexts` to a feature in `mock_gvl_translations.json` and assertions in `i18n-utils.test.ts`.
* `CHANGELOG.md` — entry under Unreleased → Added.

### Steps to Confirm

1. `npm run typecheck` (tsc --noEmit) in `clients/fides-js` → clean
2. `npx jest __tests__/lib/i18n/i18n-utils.test.ts` → 60/60 pass; `__tests__/lib/tcf` → 9/9 pass
3. eslint on changed files → clean

**Needs human review / follow-ups (NOT resolved in this draft):**

* **Confirm the exact deadline.** Public IAB sources state "mid-October 2026, exact date TBC"; the internally-cited "Oct 23" should be verified against IAB Europe's official CMP & Vendor notifications before it's treated as fixed.
* **`@iabtechlabtcf/*` fork (pinned 1.5.20/1.5.21).** Its `GVL` type is still on the older spec, so the `GVLJson`/`GVLTranslationJson` `Pick` types were intentionally left unchanged and the standard text is read per-record via the existing cast. Accepting `gvlSpecificationVersion: 4` and typing a top-level `standardTexts` object properly needs a fork bump or type augmentation.
* **GVL ingestion path is out of this repo.** The GVL reaches `fides-js` via `PrivacyExperience.gvl` (opaque dict) populated by the Compass/dictionary service. That source must emit spec-4 GVL (with `standardTexts`) and not strip unknown keys — needs verification.
* **Standard-text shape assumption.** Modeled as a per-feature `standardTexts` string (mirroring purpose illustrations). If the real GVL v4 nests these under a top-level object, the flattening/consumer will need adjusting.

### Pre-Merge Checklist

* [ ] Issue requirements met
* [ ] All CI pipelines succeeded
* [x] `CHANGELOG.md` updated
  * [ ] Add a https://github.com/ethyca/fides/labels/db-migration label to the entry if your change includes a DB migration
  * [ ] Add a https://github.com/ethyca/fides/labels/high-risk label to the entry if your change includes a high-risk change (i.e. potential for performance impact or unexpected regression) that should be flagged
  * [ ] Updates unreleased work already in Changelog, no new entry necessary
* UX feedback:
  * [ ] All UX related changes have been reviewed by a designer
  * [ ] No UX review needed
* Followup issues:
  * [ ] Followup issues created
  * [ ] No followup issues
* Database migrations:
  * [ ] Ensure that your downrev is up to date with the latest revision on `main`
  * [ ] Ensure that your `downgrade()` migration is correct and works
    * [ ] If a downgrade migration is not possible for this change, please call this out in the PR description!
  * [x] No migrations
* Documentation:
  * [ ] Documentation complete, [PR opened in fidesdocs](https://github.com/ethyca/fidesdocs/pulls)
  * [ ] Documentation [issue created in fidesdocs](https://github.com/ethyca/fidesdocs/issues/new/choose)
  * [ ] If there are any new client scopes created as part of the pull request, remember to update public-facing documentation that references our scope registry
  * [ ] No documentation updates required


---
_Generated by [Claude Code](https://claude.ai/code/session_01R1EsnjKbmotT29gvt21cPJ)_